### PR TITLE
Add see-also link from "Timing code and collecting statistics" to "Word annotations".

### DIFF
--- a/basis/tools/time/time-docs.factor
+++ b/basis/tools/time/time-docs.factor
@@ -10,7 +10,7 @@ ARTICLE: "timing" "Timing code and collecting statistics"
 "A lower-level word puts timings on the stack, intead of printing:"
 { $subsections benchmark }
 "You can also read the system clock directly; see " { $link "system" } "."
-{ $see-also "profiling" "calendar" } ;
+{ $see-also "profiling" "tools.annotations" "calendar" } ;
 
 ABOUT: "timing"
 


### PR DESCRIPTION
"Word annotations" aka "tools.annotations" describes word timing words including add-timing.  But currently, it is not linked directly from "Timing code and collecting statistics".  A 2 step link path exists, namely see-also to "Profiling code" (tools.profiler), and then see-also from there.  But especially since "Profiling code" is devoted to call counting, not timing, a more direct link seems worthwhile.
