### PR TITLE
Win32 UNC fix

### DIFF
--- a/basis/io/files/windows/windows.factor
+++ b/basis/io/files/windows/windows.factor
@@ -325,9 +325,14 @@ M: winnt root-directory? ( path -- ? )
 TR: normalize-separators "/" "\\" ;
 
 M: winnt normalize-path ( string -- string' )
-    absolute-path
-    normalize-separators
-    prepend-prefix ;
+    dup [ "//" head? ] [ "\\\\" head? ] bi
+    or [
+        normalize-separators
+    ] [
+        absolute-path
+        normalize-separators
+        prepend-prefix
+    ] if ;
 
 M: winnt CreateFile-flags ( DWORD -- DWORD )
     FILE_FLAG_OVERLAPPED bitor ;


### PR DESCRIPTION
prefixes were added incorrectly in front of UNC paths, making them invalid.
