### PR TITLE
Change GTK to not load on macosx.

### DIFF
--- a/basis/images/gtk/platforms.txt
+++ b/basis/images/gtk/platforms.txt
@@ -1,2 +1,4 @@
 linux
-bsd
+freebsd
+netbsd
+openbsd

--- a/basis/ui/backend/gtk/platforms.txt
+++ b/basis/ui/backend/gtk/platforms.txt
@@ -1,1 +1,4 @@
-unix
+linux
+freebsd
+netbsd
+openbsd


### PR DESCRIPTION
Fixes issue #172 and #173.

Downside is that you can't `USE: images.gtk` on `macosx`.
