### PR TITLE
Add scan-identifier and use it in CREATE and CREATE-CLASS

### DIFF
--- a/core/classes/parser/parser.factor
+++ b/core/classes/parser/parser.factor
@@ -13,4 +13,4 @@ IN: classes.parser
     dup create-predicate-word save-location ;
 
 : CREATE-CLASS ( -- word )
-    scan create-class-in ;
+    scan-identifier create-class-in ;

--- a/core/lexer/lexer-docs.factor
+++ b/core/lexer/lexer-docs.factor
@@ -67,6 +67,11 @@ HELP: scan-token
 { $description "Reads the next token from the lexer. Tokens are delimited by whitespace, with the exception that " { $snippet "\"" } " is treated like a single token even when not followed by whitespace. This word throws " { $link unexpected-eof } " on end of input. To output " { $link f } " on end of input, use " { $link scan } " instead." }
 $parsing-note ;
 
+HELP: scan-identifier
+{ $values { "str" string } }
+{ $description "Reads the next token from the lexer. Tokens are delimited by whitespace, with the exception that " { $snippet "\"" } " is treated like a single token even when not followed by whitespace. This word outputs " { $link f } " on end of input. This word also checks that the token it scans cannot be interpreted as a number, and throws an error on scanning a number." }
+$parsing-note ;
+
 HELP: still-parsing?
 { $values { "lexer" lexer } { "?" "a boolean" } }
 { $description "Outputs " { $link f } " if end of input has been reached, " { $link t } " otherwise." } ;

--- a/core/lexer/lexer.factor
+++ b/core/lexer/lexer.factor
@@ -151,6 +151,12 @@ M: lexer-error error-line [ error>> error-line ] [ line>> ] bi or ;
 : with-lexer ( lexer quot -- newquot )
     [ lexer set ] dip [ <lexer-error> rethrow ] recover ; inline
 
+: scan-identifier ( -- str/f )
+    scan
+    dup string>number [
+        "Identifiers cannot be numbers" throw
+    ] when ;
+
 SYMBOL: lexer-factory
 
 [ <lexer> ] lexer-factory set-global

--- a/core/parser/parser-docs.factor
+++ b/core/parser/parser-docs.factor
@@ -15,6 +15,7 @@ ARTICLE: "reading-ahead" "Reading ahead"
 { $subsections
     scan
     scan-word
+    scan-identifier
 }
 "For example, the " { $link POSTPONE: HEX: } " word uses this feature to read hexadecimal literals:"
 { $see POSTPONE: HEX: }

--- a/core/parser/parser-tests.factor
+++ b/core/parser/parser-tests.factor
@@ -624,3 +624,11 @@ EXCLUDE: qualified.tests.bar => x ;
     [ ] [ "vocabs.loader.test.l" unuse-vocab ] unit-test
     [ f ] [ "vocabs.loader.test.l" manifest get search-vocab-names>> key? ] unit-test    
 ] with-file-vocabs
+
+
+! Test cases for #183
+[ "SINGLETON: 33" <string-reader> "class identifier test" parse-stream ]
+[ error>> lexer-error? ] must-fail-with
+
+[ ": 44 ( -- ) ;" <string-reader> "word identifier test" parse-stream ]
+[ error>> lexer-error? ] must-fail-with

--- a/core/parser/parser.factor
+++ b/core/parser/parser.factor
@@ -20,7 +20,7 @@ M: parsing-word stack-effect drop (( parsed -- parsed )) ;
 : create-in ( str -- word )
     current-vocab create dup set-word dup save-location ;
 
-: CREATE ( -- word ) scan create-in ;
+: CREATE ( -- word ) scan-identifier create-in ;
 
 : CREATE-WORD ( -- word ) CREATE dup reset-generic ;
 


### PR DESCRIPTION
Add scan-identifier and use it in CREATE and CREATE-CLASS so the casual user cannot create words/classes with numbers as names. Fixes #183.
