### PR TITLE
Workable fix for load-vocab. Fixes #201.

### DIFF
--- a/core/vocabs/vocabs.factor
+++ b/core/vocabs/vocabs.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2007, 2009 Eduardo Cavazos, Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors assocs strings kernel sorting namespaces
-sequences definitions sets combinators ;
+sequences definitions sets combinators splitting ;
 IN: vocabs
 
 SYMBOL: dictionary
@@ -130,9 +130,32 @@ M: string >vocab-link dup vocab [ ] [ <vocab-link> ] ?if ;
 
 M: vocab-spec forget* forget-vocab ;
 
+! Load foo when we load foo.private unless foo.private already exists.
+! foo.private could already exist because bootstrap defines primitives
+! in that vocabulary or because it has already been loaded elsewhere.
+! Either way, it is safe to not load it.
+: lookup-vocab ( name -- name'/vocab load? )
+    dup ".private" tail? [
+        dup vocab [
+            nip f
+        ] [
+            ".private" ?tail drop t
+        ] if*
+    ] [ t ] if ;
+
 SYMBOL: load-vocab-hook ! ( name -- vocab )
 
-: load-vocab ( name -- vocab ) load-vocab-hook get call( name -- vocab ) ;
+: call-load-vocab-hook ( name -- vocab )
+    load-vocab-hook get call( name -- vocab ) ;
+
+GENERIC: load-vocab ( name -- vocab )
+
+M: string load-vocab ( name -- vocab )
+    lookup-vocab [ call-load-vocab-hook ] when ;
+
+M: vocab load-vocab call-load-vocab-hook ;
+
+M: vocab-link load-vocab call-load-vocab-hook ;
 
 PREDICATE: runnable-vocab < vocab
     vocab-main >boolean ;


### PR DESCRIPTION
If I move require to vocabs, then I have to update lots of usages (fine by me, but assume that I won't do this for now). Thus, I can't make require the primitive since it's in vocabs.parser. vocabs.parser needs to call vocabs:load-vocab, but can call it with a string, vocab, or vocab-link--so it has to be generic.

The logic for lookup-vocab can't be simplified. If the required vocabulary is public, load it every time so that reload works. If the vocabulary is .private and already exists, don't load the public vocabulary. Otherwise (if the .private vocabulary doesn't exist yet), load the public vocabulary.

Summary -- there has to be one word in vocabs that handles the .private/public lookup and calls the load-hook, and both vocabs.parser and vocabs.loader call this word because they depend on vocabs.
