### PR TITLE
Improves overall benchmark performance by 4-5%.

### DIFF
--- a/basis/hints/hints.factor
+++ b/basis/hints/hints.factor
@@ -4,8 +4,8 @@ USING: accessors arrays assocs byte-arrays byte-vectors classes
 combinators definitions effects fry generic generic.single
 generic.standard hashtables io.binary io.encodings
 io.streams.string kernel kernel.private math math.parser
-namespaces parser sbufs sequences splitting splitting.private
-strings vectors words ;
+namespaces parser sbufs sequences sequences.private splitting
+splitting.private strings vectors words ;
 IN: hints
 
 GENERIC: specializer-predicate ( spec -- quot )
@@ -131,3 +131,11 @@ M\ hashtable at* { { fixnum object } { word object } } "specializer" set-word-pr
 M\ hashtable set-at { { object fixnum object } { object word object } } "specializer" set-word-prop
 
 \ encode-string { string object object } "specializer" set-word-prop
+
+\ nth { fixnum object } "specializer" set-word-prop
+
+\ nth-unsafe { fixnum object } "specializer" set-word-prop
+
+\ set-nth { fixnum object } "specializer" set-word-prop
+
+\ set-nth-unsafe { fixnum object } "specializer" set-word-prop

--- a/basis/math/ranges/ranges.factor
+++ b/basis/math/ranges/ranges.factor
@@ -5,9 +5,9 @@ sequences.private accessors classes.tuple arrays ;
 IN: math.ranges
 
 TUPLE: range
-{ from read-only }
-{ length read-only }
-{ step read-only } ;
+{ from number read-only }
+{ length integer read-only }
+{ step number read-only } ;
 
 : <range> ( a b step -- range )
     [ over - ] dip [ /i 1 + 0 max ] keep range boa ; inline

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -201,8 +201,8 @@ INSTANCE: reversed virtual-sequence
 
 ! A slice of another sequence.
 TUPLE: slice
-{ from read-only }
-{ to read-only }
+{ from integer read-only }
+{ to integer read-only }
 { seq read-only } ;
 
 : collapse-slice ( m n slice -- m' n' seq )
@@ -248,7 +248,7 @@ M: slice length [ to>> ] [ from>> ] bi - ; inline
 INSTANCE: slice virtual-sequence
 
 ! One element repeated many times
-TUPLE: repetition { len read-only } { elt read-only } ;
+TUPLE: repetition { len integer read-only } { elt read-only } ;
 
 C: <repetition> repetition
 


### PR DESCRIPTION
Seems to slow down backtrack, fib2, gc0, knucleotide, tuple-arrays, yuv-to-rgb.

Overall benchmarks go from 99 seconds to 93 seconds on my machine.
