### PR TITLE
a fix for "No prompt found!" problem of the FUEL

### DIFF
--- a/misc/fuel/fuel-connection.el
+++ b/misc/fuel/fuel-connection.el
@@ -128,7 +128,7 @@
     (fuel-con--setup-comint)
     (fuel-con--establish-connection conn buffer)))
 
-(defconst fuel-con--prompt-regex "( .+ ) ")
+(defconst fuel-con--prompt-regex "IN: .+")
 (defconst fuel-con--eot-marker "<~FUEL~>")
 (defconst fuel-con--init-stanza "USE: fuel fuel-retort")
 


### PR DESCRIPTION
The REPL prompt was changed.
