### PR TITLE
vm: kill the stdin loop when exiting

### DIFF
--- a/vm/os-unix.cpp
+++ b/vm/os-unix.cpp
@@ -499,4 +499,13 @@ void factor_vm::unlock_console()
 	pthread_mutex_unlock(&stdin_mutex);
 }
 
+// This method is used to kill the stdin_loop before exiting from factor.
+// A Nvidia driver bug on Linux is the reason this has to be done, see:
+// http://www.nvnews.net/vbulletin/showthread.php?t=164619
+void factor_vm::close_console()
+{
+	pthread_mutex_lock(&stdin_mutex);
+	pthread_kill(stdin_thread, SIGTERM);
+}
+
 }

--- a/vm/os-windows.cpp
+++ b/vm/os-windows.cpp
@@ -308,6 +308,10 @@ void factor_vm::unlock_console()
 {
 }
 
+void factor_vm::close_console()
+{
+}
+
 void factor_vm::sampler_thread_loop()
 {
 	LARGE_INTEGER counter, new_counter, units_per_second;

--- a/vm/run.cpp
+++ b/vm/run.cpp
@@ -5,6 +5,7 @@ namespace factor
 
 void factor_vm::primitive_exit()
 {
+	close_console();
 	exit((int)to_fixnum(ctx->pop()));
 }
 

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -730,6 +730,7 @@ struct factor_vm
 	void open_console();
 	void lock_console();
 	void unlock_console();
+	void close_console();
 
 	// os-windows
   #if defined(WINDOWS)


### PR DESCRIPTION
This prevents an endless loop, caused by the nvidia drivers on linux.
See http://www.nvnews.net/vbulletin/showthread.php?t=164619
