### PR TITLE
Don't die if factor-rc has an error

### DIFF
--- a/basis/command-line/command-line.factor
+++ b/basis/command-line/command-line.factor
@@ -1,10 +1,35 @@
 ! Copyright (C) 2003, 2009 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: init continuations hashtables io io.encodings.utf8
-io.files io.pathnames kernel kernel.private namespaces parser
-sequences source-files strings system splitting vocabs.loader
-alien.strings accessors parser.notes ;
+USING: accessors alien.strings assocs continuations fry
+hashtables init io io.encodings.utf8 io.files io.pathnames
+kernel kernel.private namespaces parser parser.notes sequences
+source-files source-files.errors splitting strings system
+tools.errors vocabs.loader ;
 IN: command-line
+
+SYMBOL: user-init-errors
+SYMBOL: +user-init-error+
+
+T{ error-type
+    { type +user-init-error+ }
+    { word ":user-init-errors" }
+    { plural "rc file errors" }
+    { icon "vocab:ui/tools/error-list/icons/help-lint-error.tiff" }
+    { quot [ user-init-errors get-global values ] }
+    { forget-quot [ user-init-errors get-global delete-at ] }
+} define-error-type
+
+: :user-init-errors ( -- )
+    user-init-errors get-global values errors. ;
+
+TUPLE: user-init-error error file line# asset ;
+
+: <user-init-error> ( error -- error' )
+    [ ] [ error-file ] [ error-line ] tri
+    f user-init-error boa ; inline
+M: user-init-error error-file file>> ;
+M: user-init-error error-line line#>> ;
+M: user-init-error error-type drop +user-init-error+ ;
 
 SYMBOL: script
 SYMBOL: command-line
@@ -15,15 +40,20 @@ SYMBOL: command-line
 : rc-path ( name -- path )
     home prepend-path ;
 
-: run-bootstrap-init ( -- )
-    "user-init" get [
-        ".factor-boot-rc" rc-path ?run-file
+: try-user-init ( file -- )
+    "user-init" get swap '[
+        _ [ ?run-file ] [
+            <user-init-error>
+            swap user-init-errors get set-at
+            notify-error-observers
+        ] recover
     ] when ;
 
+: run-bootstrap-init ( -- )
+    ".factor-boot-rc" rc-path try-user-init ;
+
 : run-user-init ( -- )
-    "user-init" get [
-        ".factor-rc" rc-path ?run-file
-    ] when ;
+    ".factor-rc" rc-path try-user-init ;
 
 : load-vocab-roots ( -- )
     "user-init" get [
@@ -68,4 +98,7 @@ SYMBOL: main-vocab-hook
         main-vocab "run" set
     ] with-global ;
 
-[ default-cli-args ] "command-line" add-startup-hook
+[
+    H{ } user-init-errors set-global
+    default-cli-args
+] "command-line" add-startup-hook

--- a/basis/source-files/errors/debugger/debugger.factor
+++ b/basis/source-files/errors/debugger/debugger.factor
@@ -1,5 +1,5 @@
 USING: accessors debugger io kernel make math.parser
-prettyprint source-files.errors summary ;
+prettyprint source-files.errors command-line summary ;
 IN: source-files.errors.debugger
 
 CONSTANT: +listener-input+ "<Listener input>"
@@ -18,3 +18,5 @@ M: source-file-error error.
     [ error>> error. ]
     tri ;
 
+M: user-init-error error.
+    error>> error. ;


### PR DESCRIPTION
It seems wrong that an error in factor-boot-rc or factor-rc brings the whole process down. It also leads to UX issues like #399. This patch saves off errors during user-init script startup and shows them in the error list.
