### PR TITLE
Fixes issue #440

### DIFF
--- a/core/io/pathnames/pathnames.factor
+++ b/core/io/pathnames/pathnames.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2004, 2009 Slava Pestov, Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors combinators io.backend kernel math math.order
+USING: accessors combinators environment io.backend kernel math math.order
 namespaces sequences splitting strings system ;
 IN: io.pathnames
 
@@ -135,6 +135,10 @@ M: object resolve-symlinks normalize-path ;
 : resource-path ( path -- newpath )
     "resource-path" get prepend-path ;
 
+HOOK: home io-backend ( -- dir )
+
+M: object home "" resource-path ;
+
 GENERIC: vocab-path ( path -- newpath )
 
 GENERIC: absolute-path ( path -- path' )
@@ -148,8 +152,12 @@ M: string absolute-path
             trim-head-separators vocab-path
             absolute-path
         ] [
+            "~/" ?head [
+                trim-head-separators home prepend-path
+                absolute-path
+        ] [    
             current-directory get prepend-path
-        ] if
+        ] if ] if 
     ] if ;
 
 M: object normalize-path ( path -- path' )
@@ -163,6 +171,3 @@ M: pathname absolute-path string>> absolute-path ;
 
 M: pathname <=> [ string>> ] compare ;
 
-HOOK: home io-backend ( -- dir )
-
-M: object home "" resource-path ;


### PR DESCRIPTION
vocab:, resource: and ~/ are special pathnames. Tilde expansion will only
work on unix, because it depends on the os-env HOME variable for expansion.
