### PR TITLE
io.pathnames: removed dependency on environment.

### DIFF
--- a/core/io/pathnames/pathnames.factor
+++ b/core/io/pathnames/pathnames.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2004, 2009 Slava Pestov, Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors combinators environment io.backend kernel math math.order
+USING: accessors combinators io.backend kernel math math.order
 namespaces sequences splitting strings system ;
 IN: io.pathnames
 


### PR DESCRIPTION
Erroneous dependency on basis/environment removed from the io.pathnames USING: statement.
Tested this change with Windows and MacOS.
