### PR TITLE
ui.backend.gtk: better gesture for shift tab

### DIFF
--- a/basis/ui/backend/gtk/gtk.factor
+++ b/basis/ui/backend/gtk/gtk.factor
@@ -113,6 +113,7 @@ CONSTANT: action-key-codes
     H{
         { $ GDK_KEY_BackSpace "BACKSPACE" }
         { $ GDK_KEY_Tab "TAB" }
+        { $ GDK_KEY_ISO_Left_Tab "TAB" }
         { $ GDK_KEY_Return "RET" }
         { $ GDK_KEY_KP_Enter "ENTER" }
         { $ GDK_KEY_Escape "ESC" }


### PR DESCRIPTION
Shift tab is currently broken on my setup (default ubuntu 12.04): factor sends key down and key up gestures with no modifier and no sym (ie T{ key-down })

That's because
gdk emits ISO_Left_Tab for shift + tab.
With this patch, factor silently
transform that in "tab", so "shift tab" emits the following gesture:
T{ key-down { mods { S+ } } { sym "TAB" } }
