### PR TITLE
Added glDrawElementsBaseVertex

### DIFF
--- a/basis/opengl/gl/gl.factor
+++ b/basis/opengl/gl/gl.factor
@@ -2256,6 +2256,7 @@ GL-FUNCTION: void glTexImage2DMultisample { } (  GLenum target, GLsizei samples,
 GL-FUNCTION: void glTexImage3DMultisample { } (  GLenum target, GLsizei samples, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations ) ;
 GL-FUNCTION: void glGetMultisamplefv { } (  GLenum pname, GLuint index, GLfloat* val ) ;
 GL-FUNCTION: void glSampleMaski { } ( GLuint index, GLbitfield mask ) ;
+GL-FUNCTION: void glDrawElementsBaseVertex { glDrawElementsBaseVertexARB } ( GLenum mode, GLsizei count, GLenum type, GLvoid* indices, GLint basevertex ) ;
 
 
 ! OpenGL 3.3

--- a/basis/opengl/gl3/gl3.factor
+++ b/basis/opengl/gl3/gl3.factor
@@ -1167,6 +1167,7 @@ ALIAS: glTexImage2DMultisample gl:glTexImage2DMultisample
 ALIAS: glTexImage3DMultisample gl:glTexImage3DMultisample
 ALIAS: glGetMultisamplefv gl:glGetMultisamplefv
 ALIAS: glSampleMaski gl:glSampleMaski
+ALIAS: glDrawElementsBaseVertex gl:glDrawElementsBaseVertex
 ALIAS: glBindFragDataLocationIndexed gl:glBindFragDataLocationIndexed
 ALIAS: glGetFragDataIndex gl:glGetFragDataIndex
 ALIAS: glGenSamplers gl:glGenSamplers


### PR DESCRIPTION
As defined here:
http://www.opengl.org/sdk/docs/man4/xhtml/glDrawElementsBaseVertex.xml

Available with OpenGL 3.2 or the `ARB_draw_elements_base_vertex` extension.
