### PR TITLE
compression.zlib: add basic documentation

### DIFF
--- a/basis/compression/zlib/zlib-docs.factor
+++ b/basis/compression/zlib/zlib-docs.factor
@@ -1,0 +1,41 @@
+! Copyright (C) 2013 Benjamin Pollack.
+! See http://factorcode.org/license.txt for BSD license.
+USING: help.markup help.syntax kernel math strings byte-arrays ;
+IN: compression.zlib
+
+HELP: <compressed>
+{ $values
+    { "data" byte-array } { "length" integer }
+    { "compressed" compressed }
+}
+{ $description "Creates a new " { $link compressed } ", using the provided bytes as the compressed data and the provided length as the uncompressed length.  You should almost always use " { $link compress } ", rather than using this constructor directly." } ;
+
+HELP: compress
+{ $values
+    { "byte-array" byte-array }
+    { "compressed" compressed }
+}
+{ $description "Compresses the given byte-array, returning a Factor object holding the compressed data." } ;
+
+HELP: compressed
+{ $class-description "The class used to hold compressed data." } ;
+
+HELP: compressed-size
+{ $values
+    { "byte-array" byte-array }
+    { "n" integer }
+}
+{ $description "Returns the maximum number of bytes required to store the compressed version of a byte array." } ;
+
+HELP: uncompress
+{ $values
+    { "compressed" compressed }
+    { "byte-array" byte-array }
+}
+{ $description "Uncompresses a compressed object, returning a byte-array of the underlying data." } ;
+
+ARTICLE: "compression.zlib" "compression.zlib"
+{ $vocab-link "compression.zlib" }
+;
+
+ABOUT: "compression.zlib"


### PR DESCRIPTION
These are very minor doc changes.  I wasn't sure whether to document all the words (the general rule inspecting other doc files seems to be _not_ to document obvious things, such as `zlib-failed`), so I didn't, but I'm happy to go back and do those.
