### PR TITLE
vm: Remove Gestalt call. Fixes #585.

### DIFF
--- a/vm/os-macosx.mm
+++ b/vm/os-macosx.mm
@@ -13,14 +13,6 @@ void factor_vm::c_to_factor_toplevel(cell quot)
 
 void early_init(void)
 {
-	SInt32 version;
-	Gestalt(gestaltSystemVersion,&version);
-	if(version < 0x1050)
-	{
-		std::cout << "Factor requires Mac OS X 10.5 or later.\n";
-		exit(1);
-	}
-
 	[[NSAutoreleasePool alloc] init];
 }
 


### PR DESCRIPTION
The Gestalt call was only being used to detect OSX < 10.5. Since 10.4 is
ancient and there are now implicit 10.8 dependencies, I think it's safe
to remove the version check and get rid of the compiler warning.
