### PR TITLE
Encourage FUEL for adoption into MELPA

### DIFF
--- a/misc/fuel/fuel-pkg.el
+++ b/misc/fuel/fuel-pkg.el
@@ -1,0 +1,3 @@
+(define-package "fuel" "1.0"
+  "Factor's Ultimate Emacs Library"
+  nil)


### PR DESCRIPTION
A convenient way to install FUEL is through Emacs package managers such as MELPA. This way, Factor/Emacs users can simply `M-x package-install fuel`, instead of manually linking to `fu.el` in their Factor installation. Also, this makes it easy for users to edit Factor files, complete with syntax highlighting, on computers where Factor isn't actually installed.

Per https://github.com/milkypostman/melpa/pull/708#issuecomment-16926394, I suggest adding a `fuel-pkg.el` for MELPA support.
