### PR TITLE
Pretty print html vectors

### DIFF
--- a/extra/html/parser/printer/printer-tests.factor
+++ b/extra/html/parser/printer/printer-tests.factor
@@ -2,13 +2,14 @@ USING:
     html.parser html.parser.printer
     io.streams.string
     namespaces
+    strings
     tools.test ;
 IN: html.parser.printer.tests
 
 [
     "          "
 ] [
-    [ 5 #indentations set 2 tab-width set tabs ] with-scope
+    [ 5 #indentations set 2 tab-width set tabs >string ] with-scope
 ] unit-test
 
 [

--- a/extra/html/parser/printer/printer.factor
+++ b/extra/html/parser/printer/printer.factor
@@ -1,7 +1,7 @@
 USING: accessors assocs html.parser html.parser.utils combinators
 continuations hashtables
 hashtables.private io kernel make math
-namespaces prettyprint quotations sequences sequences.repeating splitting
+namespaces prettyprint quotations sequences splitting
 strings unicode.categories ;
 IN: html.parser.printer
 
@@ -73,17 +73,18 @@ SYMBOL: tagstack
         print-tags
     ] with-scope ;
 
-: tabs ( -- str )
-    " " tab-width get #indentations get * repeat ;
+: tabs ( -- vseq )
+    tab-width get #indentations get * CHAR: \s <repetition> ;
 
 M: html-prettyprinter print-opening-tag ( tag -- )
     name>>
-    [ tabs "<" append ">\n" surround write ]
+    [ tabs write "<" write write ">\n" write ]
     ! These tags usually don't have any closing tag associated with them.
     [ { "br" "img" } member? [ #indentations inc ] unless ] bi ;
 
 M: html-prettyprinter print-closing-tag ( tag -- )
-    #indentations dec name>> tabs "</" append ">\n" surround write ;
+    #indentations dec
+    tabs write "</" write name>> write ">\n" write ;
 
 M: html-prettyprinter print-text-tag ( tag -- )
-    text>> [ blank? ] trim [ tabs "\n" surround write ] unless-empty ;
+    text>> [ blank? ] trim [ tabs write write "\n" write ] unless-empty ;


### PR DESCRIPTION
These commits fixes the `prettyprint-html` word which did use to throw an exception. 
