### PR TITLE
Fuel fix ml

### DIFF
--- a/misc/fuel/factor-mode.el
+++ b/misc/fuel/factor-mode.el
@@ -304,7 +304,7 @@ source/docs/tests file. When set to false, you'll be asked only once."
   "\\(TUPLE\\):[ \n\t]+\\(\\w+\\)[ \n\t]+\\([^;]+\\);")
 
 (defconst factor-subclassed-tuple-decl-regex
-  "\\(TUPLE\\):[ \n\t]++\\(\\(?:\\sw\\|\\s_\\)+\\)[ \n\t]+<[ \n\t]+\\(\\(?:\\sw\\|\\s_\\)+\\)[ \n\t]+\\([^;]+\\);")
+  "\\(TUPLE\\):[ \n\t]+\\(\\(?:\\sw\\|\\s_\\)+\\)[ \n\t]+<[ \n\t]+\\(\\(?:\\sw\\|\\s_\\)+\\)[ \n\t]+\\([^;]+\\);")
 
 (defconst factor-constructor-regex
   "<[^ >]+>")


### PR DESCRIPTION
This PR extends the previous work so that multiline font-locking works more robustly. You need (setq-local font-lock-multiline t) and some other setup otherwise font-lock gets fooled and fails to rehighlight modified multi-line USING and TUPLE expressions.
