### PR TITLE
linux/proc: do something with 'TLB size'

### DIFF
--- a/basis/unix/linux/proc/proc.factor
+++ b/basis/unix/linux/proc/proc.factor
@@ -46,7 +46,8 @@ TUPLE: processor-info
     { clflush-size integer }
     { cache-alignment integer }
     { address-sizes array }
-    { power-management string } ;
+    { power-management string }
+    { tlb-size string } ;
 
 
 ERROR: unknown-cpuinfo-line string ;
@@ -90,6 +91,7 @@ ERROR: unknown-cpuinfo-line string ;
         { "stepping" [ string>number >>stepping ] }
         { "vendor_id" [ >>vendor-id ] }
         { "wp" [ "yes" = >>wp? ] }
+        { "TLB size" [ >>tlb-size ] }
         [ unknown-cpuinfo-line ]
     } case ;
 


### PR DESCRIPTION
Right now, parse-proc-cpuinfo throws an exception on my machine, it doesn't handle the "TLB size" line.
- should it throw an exception if there is an unknown line ?
- what to do with TLB size ?

For info, here's what I got on my machine 

```
jon@zik:~/factor$ uname -a
Linux zik 3.2.0-53-generic #81-Ubuntu SMP Thu Aug 22 21:01:03 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux

jon@zik:~/factor$ cat /proc/cpuinfo 
[ snip... ]
bogomips    : 3292.83
TLB size    : 1024 4K pages
clflush size    : 64
```
