### PR TITLE
Fix doc link for furnace user-admin webapp

### DIFF
--- a/basis/furnace/auth/auth-docs.factor
+++ b/basis/furnace/auth/auth-docs.factor
@@ -196,7 +196,7 @@ $nl
 "Authentication realms can be adorned with additional functionality."
 { $subsections "furnace.auth.features" }
 "An administration tool."
-{ $subsections "furnace.auth.user-admin" }
+{ $subsections "webapps.user-admin" }
 "A concrete example."
 { $subsections "furnace.auth.example" } ;
 

--- a/extra/webapps/user-admin/user-admin-docs.factor
+++ b/extra/webapps/user-admin/user-admin-docs.factor
@@ -13,7 +13,7 @@ HELP: make-admin
 { $values { "username" string } }
 { $description "Makes an existing user into an administrator by giving them the " { $link can-administer-users? } " capability, thus allowing them to use the user admin tool." } ;
 
-ARTICLE: "furnace.auth.user-admin" "Furnace user administration tool"
+ARTICLE: "webapps.user-admin" "Furnace user administration tool"
 "The " { $vocab-link "webapps.user-admin" } " vocabulary implements a web application for adding, removing and editing users in authentication realms that use " { $link "furnace.auth.providers.db" } "."
 { $subsections <user-admin> }
 "Access to the web app itself is protected, and only users having an administrative capability can access it:"


### PR DESCRIPTION
Apparently this was moved but the docs didn't get updated.
