### PR TITLE
Fix furnace basic auth; add test

### DIFF
--- a/basis/furnace/auth/basic/basic-tests.factor
+++ b/basis/furnace/auth/basic/basic-tests.factor
@@ -1,0 +1,13 @@
+! Copyright (C) 2013 Jon Harper.
+! See http://factorcode.org/license.txt for BSD license.
+USING: accessors tools.test furnace.auth.basic http.server
+http.server.responses kernel http namespaces ;
+IN: furnace.auth.basic.tests
+
+CONSTANT: GET-AUTH "Basic Zm9vOmJhcg=="
+{ "foo" "bar" } [ GET-AUTH parse-basic-auth ] unit-test
+
+{ t } [ [ <request> "GET" >>method init-request
+  "path" <304> <trivial-responder> "name" <basic-auth-realm>
+   call-responder* >boolean
+] with-scope ] unit-test

--- a/basis/furnace/auth/basic/basic.factor
+++ b/basis/furnace/auth/basic/basic.factor
@@ -27,3 +27,5 @@ M: basic-auth-realm logged-in-username ( realm -- uid )
     drop
     request get "authorization" header parse-basic-auth
     dup [ over check-login swap and ] [ 2drop f ] if ;
+
+M: basic-auth-realm init-realm drop ;


### PR DESCRIPTION
The basic auth feature was broken since 874b123bb067 (5 years :s)
