### PR TITLE
Add .dir-locals.el file for Emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,14 @@
+;; Per-directory local variables for GNU Emacs 23 and later.
+((c++-mode . ((c-basic-offset . 2)
+              (show-trailing-whitespace . t)
+              (indicate-empty-lines . t)
+              (indent-tabs-mode . nil)
+              (eval . (progn
+                        (c-set-offset 'innamespace 0)
+                        (c-set-offset 'topmost-intro 0)
+                        (c-set-offset 'cpp-macro-cont '++)
+                        (c-set-offset 'case-label '+)
+                        (c-set-offset 'member-init-intro '++)
+                        (c-set-offset 'statement-cont '++)
+                        (c-set-offset 'arglist-intro '++)))))
+ (factor-mode . ((factor-indent-level . 4))))


### PR DESCRIPTION
Emacs 23 and later support directory-local variables:

  http://www.gnu.org/s/libtool/manual/emacs/Directory-Variables.html

Factor has a quite nonstandard c++ coding style convention and there are some knobs you have to tweak in Emacs to get it right. Adding a .dir-locals file to the repo would make it easier to adhere to the convention, and as it's invisible to a normal `ls', it shouldn't be a burden on anyone.
