### PR TITLE
alien.libraries.finder: using find-library for some often missing libs

### DIFF
--- a/basis/db/sqlite/ffi/ffi.factor
+++ b/basis/db/sqlite/ffi/ffi.factor
@@ -2,41 +2,38 @@
 ! See http://factorcode.org/license.txt for BSD license.
 ! An interface to the sqlite database. Tested against sqlite v3.1.3.
 ! Not all functions have been wrapped.
-USING: alien compiler kernel math namespaces sequences strings alien.syntax
-system combinators alien.c-types alien.libraries ;
+USING: alien alien.libraries alien.libraries.finder compiler kernel
+math namespaces sequences strings alien.syntax system combinators
+alien.c-types ;
 IN: db.sqlite.ffi
 
-<< "sqlite" {
-        { [ os windows? ]  [ "sqlite3.dll" ] }
-        { [ os macosx? ] [ "/usr/lib/libsqlite3.dylib" ] }
-        { [ os unix? ]  [ "libsqlite3.so" ] }
-    } cond cdecl add-library >>
+<< "sqlite" "sqlite3" find-library cdecl add-library >>
 
 ! Return values from sqlite functions
 CONSTANT: SQLITE_OK           0 ! Successful result
 CONSTANT: SQLITE_ERROR        1 ! SQL error or missing database
-CONSTANT: SQLITE_INTERNAL     2 ! An internal logic error in SQLite 
-CONSTANT: SQLITE_PERM         3 ! Access permission denied 
-CONSTANT: SQLITE_ABORT        4 ! Callback routine requested an abort 
-CONSTANT: SQLITE_BUSY         5 ! The database file is locked 
-CONSTANT: SQLITE_LOCKED       6 ! A table in the database is locked 
-CONSTANT: SQLITE_NOMEM        7 ! A malloc() failed 
-CONSTANT: SQLITE_READONLY     8 ! Attempt to write a readonly database 
-CONSTANT: SQLITE_INTERRUPT    9 ! Operation terminated by sqlite_interrupt() 
-CONSTANT: SQLITE_IOERR       10 ! Some kind of disk I/O error occurred 
-CONSTANT: SQLITE_CORRUPT     11 ! The database disk image is malformed 
-CONSTANT: SQLITE_NOTFOUND    12 ! (Internal Only) Table or record not found 
-CONSTANT: SQLITE_FULL        13 ! Insertion failed because database is full 
-CONSTANT: SQLITE_CANTOPEN    14 ! Unable to open the database file 
-CONSTANT: SQLITE_PROTOCOL    15 ! Database lock protocol error 
-CONSTANT: SQLITE_EMPTY       16 ! (Internal Only) Database table is empty 
-CONSTANT: SQLITE_SCHEMA      17 ! The database schema changed 
-CONSTANT: SQLITE_TOOBIG      18 ! Too much data for one row of a table 
-CONSTANT: SQLITE_CONSTRAINT  19 ! Abort due to contraint violation 
-CONSTANT: SQLITE_MISMATCH    20 ! Data type mismatch 
-CONSTANT: SQLITE_MISUSE      21 ! Library used incorrectly 
-CONSTANT: SQLITE_NOLFS       22 ! Uses OS features not supported on host 
-CONSTANT: SQLITE_AUTH        23 ! Authorization denied 
+CONSTANT: SQLITE_INTERNAL     2 ! An internal logic error in SQLite
+CONSTANT: SQLITE_PERM         3 ! Access permission denied
+CONSTANT: SQLITE_ABORT        4 ! Callback routine requested an abort
+CONSTANT: SQLITE_BUSY         5 ! The database file is locked
+CONSTANT: SQLITE_LOCKED       6 ! A table in the database is locked
+CONSTANT: SQLITE_NOMEM        7 ! A malloc() failed
+CONSTANT: SQLITE_READONLY     8 ! Attempt to write a readonly database
+CONSTANT: SQLITE_INTERRUPT    9 ! Operation terminated by sqlite_interrupt()
+CONSTANT: SQLITE_IOERR       10 ! Some kind of disk I/O error occurred
+CONSTANT: SQLITE_CORRUPT     11 ! The database disk image is malformed
+CONSTANT: SQLITE_NOTFOUND    12 ! (Internal Only) Table or record not found
+CONSTANT: SQLITE_FULL        13 ! Insertion failed because database is full
+CONSTANT: SQLITE_CANTOPEN    14 ! Unable to open the database file
+CONSTANT: SQLITE_PROTOCOL    15 ! Database lock protocol error
+CONSTANT: SQLITE_EMPTY       16 ! (Internal Only) Database table is empty
+CONSTANT: SQLITE_SCHEMA      17 ! The database schema changed
+CONSTANT: SQLITE_TOOBIG      18 ! Too much data for one row of a table
+CONSTANT: SQLITE_CONSTRAINT  19 ! Abort due to contraint violation
+CONSTANT: SQLITE_MISMATCH    20 ! Data type mismatch
+CONSTANT: SQLITE_MISUSE      21 ! Library used incorrectly
+CONSTANT: SQLITE_NOLFS       22 ! Uses OS features not supported on host
+CONSTANT: SQLITE_AUTH        23 ! Authorization denied
 CONSTANT: SQLITE_FORMAT      24 ! Auxiliary database format error
 CONSTANT: SQLITE_RANGE       25 ! 2nd parameter to sqlite3_bind out of range
 CONSTANT: SQLITE_NOTADB      26 ! File opened that is not a database file

--- a/basis/gtk/ffi/ffi.factor
+++ b/basis/gtk/ffi/ffi.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2010 Anton Gorenko.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: alien alien.c-types alien.destructors alien.libraries
-alien.syntax combinators gobject-introspection
+alien.libraries.finder alien.syntax assocs gobject-introspection
 gobject-introspection.standard-types kernel pango.ffi system
 vocabs ;
 IN: gtk.ffi
@@ -15,10 +15,9 @@ LIBRARY: gtk
 
 <<
 "gtk" {
-    { [ os windows? ] [ "libgtk-win32-2.0-0.dll" cdecl add-library ] }
-    { [ os macosx? ] [ drop ] }
-    { [ os unix? ] [ "libgtk-x11-2.0.so" cdecl add-library ] }
-} cond
+    { linux "gtk-x11-2.0" }
+    { windows "libgtk-win32-2.0-0" }
+} os of [ find-library cdecl add-library ] when*
 >>
 
 IMPLEMENT-STRUCTS: GtkTreeIter ;

--- a/extra/readline/ffi/ffi.factor
+++ b/extra/readline/ffi/ffi.factor
@@ -1,17 +1,11 @@
 ! Copyright (C) 2010 Erik Charlebois
 ! See http:// factorcode.org/license.txt for BSD license.
-USING: alien alien.c-types kernel alien.syntax classes.struct
-accessors libc math make unix.types namespaces system
-combinators alien.libraries ;
+USING: alien alien.c-types alien.syntax alien.libraries.finder
+classes.struct accessors kernel libc math make unix.types namespaces
+system combinators alien.libraries ;
 IN: readline.ffi
 
-<<
-"readline" {
-    { [ os windows? ] [ "readline.dll" ] }
-    { [ os macosx? ] [ "libreadline.dylib"  ] }
-    { [ os unix?  ] [ "libreadline.so" ] }
-} cond cdecl add-library
->>
+<< "readline" dup find-library cdecl add-library >>
 LIBRARY: readline
 
 TYPEDEF: void* histdata_t


### PR DESCRIPTION
People often have problem with gtk_init not being found due to missing .so-file. But if you use find-library it will work even if you don't have the -dev package. I've only changed it for some of the most common occurances (see mailing list), but if you like it I can change it for all ffi loading vocabularies.
