### PR TITLE
dlopen using RTLD_GLOBAL

### DIFF
--- a/vm/os-unix.cpp
+++ b/vm/os-unix.cpp
@@ -36,7 +36,7 @@ void sleep_nanos(uint64_t nsec) {
 void factor_vm::init_ffi() { null_dll = dlopen(NULL, RTLD_LAZY); }
 
 void factor_vm::ffi_dlopen(dll* dll) {
-  dll->handle = dlopen(alien_offset(dll->path), RTLD_LAZY);
+  dll->handle = dlopen(alien_offset(dll->path), RTLD_LAZY | RTLD_GLOBAL);
 }
 
 void* factor_vm::ffi_dlsym_raw(dll* dll, symbol_char* symbol) {


### PR DESCRIPTION
This is a change that is needed to get my python pr #983 working correctly on Linux. It's the same problem as described in this julia bug report: https://github.com/JuliaLang/julia/issues/2312 and this python bug: http://bugs.python.org/issue19153

I'm 99% certain that always using the RTLD_GLOBAL flag should be perfectly fine and not disturb anything else. But if it does, then we can add some api to let the user decide what dlopen flags to pass.
