### PR TITLE
formatting: new format specifier for unparsed representation

### DIFF
--- a/basis/formatting/formatting-docs.factor
+++ b/basis/formatting/formatting-docs.factor
@@ -6,7 +6,7 @@ IN: formatting
 HELP: printf
 { $values { "format-string" string } }
 { $description
-    "Writes the arguments (specified on the stack) formatted according to the format string." 
+    "Writes the arguments (specified on the stack) formatted according to the format string."
     $nl
     "Several format specifications exist for handling arguments of different types, and "
     "specifying attributes for the result string, including such things as maximum width, "
@@ -16,8 +16,9 @@ HELP: printf
         { { $snippet "%%" }          "Single %"                   "" }
         { { $snippet "%P.Ds" }       "String format"              "string" }
         { { $snippet "%P.DS" }       "String format uppercase"    "string" }
-        { { $snippet "%c" }          "Character format"           "char" } 
-        { { $snippet "%C" }          "Character format uppercase" "char" } 
+        { { $snippet "%P.Du" }       "Unparsed format"            "object" }
+        { { $snippet "%c" }          "Character format"           "char" }
+        { { $snippet "%C" }          "Character format uppercase" "char" }
         { { $snippet "%+Pd" }        "Integer format"             "fixnum" }
         { { $snippet "%+P.De" }      "Scientific notation"        "fixnum, float" }
         { { $snippet "%+P.DE" }      "Scientific notation"        "fixnum, float" }
@@ -81,11 +82,15 @@ HELP: printf
         "USING: formatting ;"
         "H{ { 1 2 } { 3 4 } } \"%[%d: %d %]\" printf"
         "{ 1:2, 3:4 }" }
+    { $example
+      "USING: calendar formatting ;"
+      "3 years \"%u\" printf"
+      "T{ duration { year 3 } }" }
 } ;
 
 HELP: sprintf
 { $values { "format-string" string } { "result" string } }
-{ $description "Returns the arguments (specified on the stack) formatted according to the format string as a result string." } 
+{ $description "Returns the arguments (specified on the stack) formatted according to the format string as a result string." }
 { $see-also printf } ;
 
 HELP: strftime
@@ -136,5 +141,3 @@ ARTICLE: "formatting" "Formatted printing"
 } ;
 
 ABOUT: "formatting"
-
-

--- a/basis/formatting/formatting.factor
+++ b/basis/formatting/formatting.factor
@@ -2,8 +2,8 @@
 ! See http://factorcode.org/license.txt for BSD license
 USING: accessors arrays assocs calendar combinators fry kernel
 generalizations io io.streams.string macros math math.functions
-math.parser peg.ebnf quotations sequences splitting strings
-unicode.categories unicode.case vectors combinators.smart
+math.parser peg.ebnf prettyprint quotations sequences splitting
+strings unicode.categories unicode.case vectors combinators.smart
 present ;
 FROM: math.parser.private => format-float ;
 IN: formatting
@@ -61,6 +61,7 @@ fmt-c     = "c"                  => [[ [ 1string ] ]]
 fmt-C     = "C"                  => [[ [ 1string >upper ] ]]
 fmt-s     = "s"                  => [[ [ present ] ]]
 fmt-S     = "S"                  => [[ [ present >upper ] ]]
+fmt-u     = "u"                  => [[ [ unparse ] ]]
 fmt-d     = "d"                  => [[ [ >integer number>string ] ]]
 fmt-e     = digits "e"           => [[ first '[ _ format-scientific ] ]]
 fmt-E     = digits "E"           => [[ first '[ _ format-scientific >upper ] ]]
@@ -69,7 +70,7 @@ fmt-x     = "x"                  => [[ [ >hex ] ]]
 fmt-X     = "X"                  => [[ [ >hex >upper ] ]]
 unknown   = (.)*                 => [[ unknown-printf-directive ]]
 
-strings_  = fmt-c|fmt-C|fmt-s|fmt-S
+strings_  = fmt-c|fmt-C|fmt-s|fmt-S|fmt-u
 strings   = pad width strings_   => [[ <reversed> compose-all ]]
 
 numbers_  = fmt-d|fmt-e|fmt-E|fmt-f|fmt-x|fmt-X


### PR DESCRIPTION
Pr that adds a new format specifier `"%u" sprintf` which I've occasionally needed. Often you have a factor object which doesn't implement `present` but you still want to print it. Then you would use this format specifier.
