### PR TITLE
windows.errors: fix #987

### DIFF
--- a/basis/windows/errors/errors.factor
+++ b/basis/windows/errors/errors.factor
@@ -706,7 +706,7 @@ CONSTANT: FORMAT_MESSAGE_MAX_WIDTH_MASK   0x000000FF
 :: n>win32-error-string ( id -- string )
     flags{
         FORMAT_MESSAGE_FROM_SYSTEM
-        FORMAT_MESSAGE_ARGUMENT_ARRAY
+        FORMAT_MESSAGE_IGNORE_INSERTS
     }
     f
     id
@@ -739,7 +739,7 @@ ERROR: windows-error n string ;
     ] [
         dup n>win32-error-string windows-error
     ] if ;
-    
+
 : throw-win32-error ( -- * )
     win32-error-string throw ;
 


### PR DESCRIPTION
Simple fix for #987 Before

```
IN: scratchpad 0xc1 n>win32-error-string .
"Unknown error 0xc1"
```

After

```
IN: scratchpad 0xc1 n>win32-error-string .
"%1 is not a valid Win32 application."
```
