### PR TITLE
csv: empty strings and files are valid csv:s

### DIFF
--- a/basis/csv/csv-tests.factor
+++ b/basis/csv/csv-tests.factor
@@ -100,3 +100,5 @@ IN: csv.tests
 ! FIXME: { { { "as,df" "asdf" } } } [ "\"as,\"df  ,asdf" string>csv ] unit-test
 ! FIXME: { { { "asd\"f\"" "asdf" } } } [ "\"asd\"\"\"f\",asdf" string>csv ] unit-test
 { { { "as,d\"f" "asdf" } } } [ "\"as,\"d\"\"\"\"f,asdf" string>csv ] unit-test
+
+[ { } ] [ "" string>csv ] unit-test

--- a/basis/csv/csv.factor
+++ b/basis/csv/csv.factor
@@ -68,7 +68,7 @@ PRIVATE>
 
 : stream-read-csv ( stream -- rows )
     [ (stream-read-csv) ] { } make
-    dup last { "" } = [ but-last ] when ; inline
+    dup ?last { "" } = [ but-last ] when ; inline
 
 : read-csv ( -- rows )
     input-stream get stream-read-csv ; inline


### PR DESCRIPTION
Here is a very small patch that makes it so the csv vocab can read empty files
