### PR TITLE
ui.backend.windows: correct wndproc signature so that factor works with vs2012

### DIFF
--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -611,7 +611,7 @@ SYMBOL: trace-messages?
 
 ! return 0 if you handle the message, else just let DefWindowProc return its val
 : ui-wndproc ( -- object )
-    c:uint { c:void* c:uint c:long c:long } stdcall [
+    c:uint { c:void* c:uint WPARAM LPARAM } stdcall [
         pick
 
         trace-messages? get-global


### PR DESCRIPTION
Haven't it tested it so much, but the change below seem to be all that was required to make factor work correctly with vs2012 (#997).
