### PR TITLE
ui.backend.gtk: connect ui signals before realizing the widget

### DIFF
--- a/basis/ui/backend/gtk/gtk.factor
+++ b/basis/ui/backend/gtk/gtk.factor
@@ -465,13 +465,12 @@ M:: gtk-ui-backend (open-window) ( world -- )
     gtk_window_set_wmclass
 
     world configure-gl
-
-    win gtk_widget_realize
-    win world window-controls>> configure-window-controls
-
     win im configure-im
     win connect-user-input-signals
     win connect-win-state-signals
+
+    win gtk_widget_realize
+    win world window-controls>> configure-window-controls
 
     win gtk_widget_show_all ;
 
@@ -552,4 +551,3 @@ os unix? os macosx? not and [
 
 M: gtk-ui-backend ui-backend-available?
     "DISPLAY" os-env >boolean ;
-


### PR DESCRIPTION
Simple change of order so that gtk_widget_add_events is called and then gtk_widget_realize. It stops oxygen-gtk from stealing clicks and I also think it is "best practice" recommended by gtk developers.
