### PR TITLE
http.client: make the star-less words not throw on status code errors

### DIFF
--- a/basis/http/client/client-docs.factor
+++ b/basis/http/client/client-docs.factor
@@ -5,7 +5,7 @@ http.client.post-data.private io.encodings.8-bit.latin1 ;
 IN: http.client
 
 HELP: download-failed
-{ $error-description "Thrown by " { $link http-request } " if the server returns a status code other than 200. The " { $slot "response" } " slot can be inspected for the underlying cause of the problem." } ;
+{ $error-description "Thrown by " { $link http-request } " if the server returns a status code not between 200 and 299. The " { $slot "response" } " slot can be inspected for the underlying cause of the problem." } ;
 
 HELP: too-many-redirects
 { $error-description "Thrown by " { $link http-request } " if the server returns a chain of than " { $link max-redirects } " redirections." } ;
@@ -58,7 +58,7 @@ HELP: http-get
 HELP: http-get*
 { $values { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-get } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-post
 { $values { "post-data" object } { "url" "a " { $link url } " or " { $link string } } { "response" response } { "data" sequence } }
@@ -68,7 +68,7 @@ HELP: http-post
 HELP: http-post*
 { $values { "post-data" object } { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-post } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-put
 { $values { "post-data" object } { "url" "a " { $link url } " or " { $link string } } { "response" response } { "data" sequence } }
@@ -78,7 +78,7 @@ HELP: http-put
 HELP: http-put*
 { $values { "post-data" object } { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-put } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-head
 { $values { "url" "a " { $link url } " or " { $link string } } { "response" response } { "data" sequence } }
@@ -88,7 +88,7 @@ HELP: http-head
 HELP: http-head*
 { $values { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-head } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-delete
 { $values { "url" "a " { $link url } " or " { $link string } } { "response" response } { "data" sequence } }
@@ -98,7 +98,7 @@ HELP: http-delete
 HELP: http-delete*
 { $values { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-delete } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-options
 { $values { "url" "a " { $link url } " or " { $link string } } { "response" response } { "data" sequence } }
@@ -108,7 +108,7 @@ HELP: http-options
 HELP: http-options*
 { $values { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-options } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-trace
 { $values { "url" "a " { $link url } " or " { $link string } } { "response" response } { "data" sequence } }
@@ -118,7 +118,7 @@ HELP: http-trace
 HELP: http-trace*
 { $values { "url" "a " { $link url } " or " { $link string } } { "data" sequence } }
 { $description "A variant of " { $link http-trace } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: with-http-get
 { $values { "url" "a " { $link url } " or " { $link string } } { "quot" { $quotation "( chunk -- )" } } { "response" response } }
@@ -128,7 +128,7 @@ HELP: with-http-get
 HELP: with-http-get*
 { $values { "url" "a " { $link url } " or " { $link string } } { "quot" { $quotation "( chunk -- )" } } }
 { $description "A variant of " { $link with-http-get } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: http-request
 { $values { "request" request } { "response" response } { "data" sequence } }
@@ -138,7 +138,7 @@ HELP: http-request
 HELP: http-request*
 { $values { "request" request } { "data" sequence } }
 { $description "A variant of " { $link http-request } " that checks that the response was successful." }
-{ $errors "Throws an error if the HTTP request fails or is not successful." } ;
+{ $errors "Throws an error if the HTTP request fails or if the status code is not between 200 and 299." } ;
 
 HELP: with-http-request
 { $values { "request" request } { "quot" { $quotation "( chunk -- )" } } { "response" response } }

--- a/basis/http/client/client-tests.factor
+++ b/basis/http/client/client-tests.factor
@@ -1,5 +1,5 @@
-USING: accessors http.client http.client.private http
-io.streams.string kernel namespaces sequences tools.test urls ;
+USING: accessors continuations http.client http.client.private http http.server
+io.servers io.streams.string kernel namespaces sequences tools.test urls ;
 IN: http.client.tests
 
 [ "localhost" f ] [ "localhost" parse-host ] unit-test
@@ -52,4 +52,20 @@ IN: http.client.tests
         "server: Factor http.server"
     } [ "\n" join ] [ "\r\n" join ] bi
     [ [ read-response ] with-string-reader ] same?
+] unit-test
+
+: with-httpd ( quot -- )
+    <http-server> 8887 >>insecure f >>secure
+    swap with-threaded-server ; inline
+
+[ 404 ] [
+    [
+        [ "http://localhost:8887" http-get* ]
+        [ response>> code>> ] recover
+    ] with-httpd
+] unit-test
+
+[ 404 ] [
+    [ "http://localhost:8887" http-get ] with-httpd
+    drop code>>
 ] unit-test

--- a/basis/http/client/client.factor
+++ b/basis/http/client/client.factor
@@ -160,15 +160,12 @@ ERROR: download-failed response ;
 : check-response ( response -- response )
     dup code>> success? [ download-failed ] unless ;
 
-: check-response-with-body ( response body -- response body )
-    [ >>body check-response ] keep ;
-
 : with-http-request ( request quot: ( chunk -- ) -- response )
     [ (with-http-request) ] with-destructors ; inline
 
 : http-request ( request -- response data )
     [ [ % ] with-http-request ] B{ } make
-    over content-encoding>> decode check-response-with-body ;
+    over content-encoding>> decode [ >>body ] keep ;
 
 : http-request* ( request -- data )
     http-request swap check-response drop ;


### PR DESCRIPTION
The http.client vocab doesn't offer any convenient way to fetch urls that might return error status codes such as 404 or 502 because the `http-get` words throws an error if the status code is not in 200 - 299.

Most often that's ok because you're just interested in the page content, and not the status code. But then you already have the `http-get*` family of words that throws on http status error codes. And it seems redundant to have both `http-get` and `http-get*` working almost identically and both throwing on status code errors.

So this patch makes `http-get` _not_ throw on status code errors. Reading "between the lines" it seems like that was the idea all along and a simple oversight that the word wasn't changed when `http-get*` was added.
