### PR TITLE
logging.tests: fix test failure that happens if factor is in a non-writable directory

### DIFF
--- a/basis/logging/logging-tests.factor
+++ b/basis/logging/logging-tests.factor
@@ -1,5 +1,6 @@
 IN: logging.tests
-USING: tools.test logging logging.analysis io math ;
+USING: io io.files.temp logging logging.analysis logging.server math namespaces
+tools.test ;
 
 : input-logging-test ( a b -- c ) + ;
 
@@ -13,14 +14,16 @@ USING: tools.test logging logging.analysis io math ;
 
 \ error-logging-test ERROR add-error-logging
 
-"logging-test" [
-    [ 4 ] [ 1 3 input-logging-test ] unit-test
-    
-    [ 4 ] [ 1 3 output-logging-test ] unit-test
-    
-    [ 4/3 ] [ 4 3 error-logging-test ] unit-test
-    
-    [ f ] [ 1 0 error-logging-test ] unit-test
-] with-logging
+temp-directory \ log-root [
+    "logging-test" [
+        [ 4 ] [ 1 3 input-logging-test ] unit-test
 
-[ ] [ "logging-test" { "input-logging-test" } analyze-log-file ] unit-test
+        [ 4 ] [ 1 3 output-logging-test ] unit-test
+
+        [ 4/3 ] [ 4 3 error-logging-test ] unit-test
+
+        [ f ] [ 1 0 error-logging-test ] unit-test
+    ] with-logging
+
+    [ ] [ "logging-test" { "input-logging-test" } analyze-log-file ] unit-test
+] with-variable


### PR DESCRIPTION
trivial fix for the test failures that occur if factor.exe is in an "installed" location
