### PR TITLE
io.sockets: add word addrinfo-error to signal host lookup failures

### DIFF
--- a/basis/io/sockets/sockets-docs.factor
+++ b/basis/io/sockets/sockets-docs.factor
@@ -218,7 +218,8 @@ HELP: send
 
 HELP: resolve-host
 { $values { "addrspec" "an address specifier" } { "seq" "a sequence of address specifiers" } }
-{ $description "Resolves host names to IP addresses." } ;
+{ $description "Resolves host names to IP addresses." }
+{ $errors "Throws an " { $link addrinfo-error } " if the host name cannot be resolved." } ;
 
 HELP: with-local-address
 { $values { "addr" "an " { $link inet4 } " or " { $link inet6 } " address specifier" } { "quot" quotation } }

--- a/basis/io/sockets/sockets-tests.factor
+++ b/basis/io/sockets/sockets-tests.factor
@@ -1,5 +1,5 @@
-USING: io.sockets io.sockets.private sequences math tools.test
-namespaces accessors kernel destructors calendar io.timeouts
+USING: continuations io.sockets io.sockets.private sequences math
+tools.test namespaces accessors kernel destructors calendar io.timeouts
 io.encodings.utf8 io concurrency.promises threads
 io.streams.string present system ;
 IN: io.sockets.tests
@@ -172,3 +172,7 @@ os unix? [
 
 [ 80 ] [ "http" protocol-port ] unit-test
 [ f ] [ f protocol-port ] unit-test
+
+[ t ] [
+    [ "you-cant-resolve-me!" resolve-host ] [ addrinfo-error? ] recover
+] unit-test

--- a/basis/io/sockets/sockets.factor
+++ b/basis/io/sockets/sockets.factor
@@ -228,6 +228,8 @@ M: inet6 present
 
 M: inet6 protocol drop 0 ;
 
+ERROR: addrinfo-error n string ;
+
 <PRIVATE
 
 GENERIC: (get-local-address) ( handle remote -- sockaddr )
@@ -311,7 +313,7 @@ HOOK: (send) io-backend ( packet addrspec datagram -- )
     [ addrinfo>addrspec ] map
     sift ;
 
-HOOK: addrinfo-error io-backend ( n -- )
+HOOK: addrinfo-error-string io-backend ( n -- string )
 
 : prepare-addrinfo ( -- addrinfo )
     addrinfo <struct>
@@ -407,8 +409,11 @@ M: inet present
 C: <inet> inet
 
 M: string resolve-host
-    f prepare-addrinfo f void* <ref>
-    [ getaddrinfo addrinfo-error ] keep void* deref addrinfo memory>struct
+    f prepare-addrinfo f void* <ref> [
+        getaddrinfo 0 or [
+            dup addrinfo-error-string addrinfo-error
+        ] unless-zero
+    ] keep void* deref addrinfo memory>struct
     [ parse-addrinfo-list ] keep freeaddrinfo ;
 
 M: string with-port <inet> ;

--- a/basis/io/sockets/unix/unix.factor
+++ b/basis/io/sockets/unix/unix.factor
@@ -1,7 +1,7 @@
-! Copyright (C) 2004, 2008 Slava Pestov, Ivan Tikhonov. 
+! Copyright (C) 2004, 2008 Slava Pestov, Ivan Tikhonov.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors alien alien.c-types alien.data alien.strings
-classes.struct combinators destructors io.backend.unix
+arrays classes.struct combinators destructors io.backend.unix
 io.encodings.utf8 io.pathnames io.sockets.private kernel libc
 locals math namespaces sequences system unix unix.ffi vocabs ;
 EXCLUDE: io => read write ;
@@ -14,8 +14,8 @@ IN: io.sockets.unix
 : set-socket-option ( fd level opt -- )
     [ handle-fd ] 2dip 1 int <ref> dup byte-length setsockopt io-error ;
 
-M: unix addrinfo-error ( n -- )
-    [ gai_strerror throw ] unless-zero ;
+M: unix addrinfo-error-string ( n -- string )
+    gai_strerror ;
 
 M: unix sockaddr-of-family ( alien af -- addrspec )
     {

--- a/basis/io/sockets/windows/windows.factor
+++ b/basis/io/sockets/windows/windows.factor
@@ -11,8 +11,8 @@ IN: io.sockets.windows
 : set-socket-option ( handle level opt -- )
     [ handle>> ] 2dip 1 int <ref> dup byte-length setsockopt socket-error ;
 
-M: windows addrinfo-error ( n -- )
-    winsock-return-check ;
+M: windows addrinfo-error-string ( n -- string )
+    n>win32-error-string ;
 
 M: windows sockaddr-of-family ( alien af -- addrspec )
     {


### PR DESCRIPTION
In the http daemon I'm writing I need to handle resolve-host failures. Because of my crappy connection I will often get the "Temporary failure in name resolution" which I want to handle by retrying. Factor makes that hard because the actual error thrown is on Linux a string object and on Windows a winsock-exception. 

So to make that easier to handle, I've created a new error type `addrinfo-error`, which is the same on all platforms, with the error code and message in it.
