### PR TITLE
openssl: define a startup-hook so that openssl initializes automatically

### DIFF
--- a/basis/checksums/openssl/openssl.factor
+++ b/basis/checksums/openssl/openssl.factor
@@ -29,7 +29,7 @@ M: evp-md-context dispose*
     handle>> EVP_MD_CTX_destroy ;
 
 : with-evp-md-context ( quot -- )
-    maybe-init-ssl [ <evp-md-context> ] dip with-disposal ; inline
+    [ <evp-md-context> ] dip with-disposal ; inline
 
 : digest-named ( name -- md )
     dup EVP_get_digestbyname

--- a/basis/io/sockets/secure/openssl/openssl.factor
+++ b/basis/io/sockets/secure/openssl/openssl.factor
@@ -125,7 +125,6 @@ M: rsa dispose* handle>> RSA_free ;
         H{ } clone >>sessions ;
 
 M: openssl <secure-context> ( config -- context )
-    maybe-init-ssl
     [
         dup method>> ssl-method SSL_CTX_new
         dup ssl-error <openssl-context> |dispose

--- a/basis/openssl/openssl.factor
+++ b/basis/openssl/openssl.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2007, 2008, Slava Pestov, Elie CHAFTARI.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: init kernel namespaces openssl.libcrypto openssl.libssl
+USING: init io kernel namespaces openssl.libcrypto openssl.libssl
 sequences ;
 IN: openssl
 
@@ -26,12 +26,4 @@ SINGLETON: openssl
     OpenSSL_add_all_digests
     OpenSSL_add_all_ciphers ;
 
-SYMBOL: ssl-initialized?
-
-: maybe-init-ssl ( -- )
-    ssl-initialized? get-global [
-        init-ssl
-        t ssl-initialized? set-global
-    ] unless ;
-
-[ f ssl-initialized? set-global ] "openssl" add-startup-hook
+[ init-ssl ] "openssl" add-startup-hook


### PR DESCRIPTION
Fix for the remaining problem in #1009. I think it is ok to depend on openssl being available.. In the future it would be nice if Factor had hooks for vocab loading. Then you could write something like `[ init-ssl ] "openssl" add-vocab-load-hook` and the quotation would be ran once, when the vocab was first imported. But  alas, I couldn't find any hook like that.
