### PR TITLE
VM: attempt to cancel blocking system calls when ctrl-c is pressed

### DIFF
--- a/vm/main-windows.cpp
+++ b/vm/main-windows.cpp
@@ -1,6 +1,14 @@
 #include "master.hpp"
 
 VM_C_API int wmain(int argc, wchar_t** argv) {
+  HANDLE proc = GetCurrentProcess();
+  HANDLE thread = GetCurrentThread();
+  BOOL res = DuplicateHandle(proc, thread, proc,
+                             &factor::boot_thread, GENERIC_ALL, FALSE, 0);
+  if (!res) {
+    factor::fatal_error("DuplicateHandle() failed", GetLastError());
+    return 1;
+  }
   factor::init_globals();
   factor::start_standalone_factor(argc, argv);
   return 0;

--- a/vm/mvm-windows.cpp
+++ b/vm/mvm-windows.cpp
@@ -2,6 +2,8 @@
 
 namespace factor {
 
+HANDLE boot_thread;
+
 DWORD current_vm_tls_key;
 
 void init_mvm() {

--- a/vm/os-windows.hpp
+++ b/vm/os-windows.hpp
@@ -88,4 +88,6 @@ inline static void breakpoint() { DebugBreak(); }
 #define CODE_TO_FUNCTION_POINTER_CALLBACK(vm, code) (void)0
 #define FUNCTION_CODE_POINTER(ptr) ptr
 #define FUNCTION_TOC_POINTER(ptr) ptr
+
+extern HANDLE boot_thread;
 }


### PR DESCRIPTION
Occasionally Factor get's stuck waiting on something. Either by a bug or a long timeout. On Linux breaking out of the wait is easy by pressing ctrl-c which causes the call to return with the error EINTR. Windows isn't that easy and you have to tell it to cancel the waits otherwise it doesn't "listen" to ctrl-c. So that's what this patch does.

Btw, Haskell and some other VM's also uses the same approach as in the patch in their Windows ports. So the method should work fine in Factor too.
