### PR TITLE
help.lint,tools.deprecation,tools.test: errors that aren't that horrible...

### DIFF
--- a/basis/help/lint/lint.factor
+++ b/basis/help/lint/lint.factor
@@ -23,6 +23,7 @@ T{ error-type-holder
    { icon "vocab:ui/tools/error-list/icons/help-lint-error.tiff" }
    { quot [ lint-failures get values ] }
    { forget-quot [ lint-failures get delete-at ] }
+   { fatal? f }
 } define-error-type
 
 M: help-lint-error error-type drop +help-lint-failure+ ;

--- a/basis/tools/deprecation/deprecation.factor
+++ b/basis/tools/deprecation/deprecation.factor
@@ -27,6 +27,7 @@ T{ error-type-holder
     { icon "vocab:ui/tools/error-list/icons/deprecation-note.tiff" }
     { quot [ deprecation-notes get values ] }
     { forget-quot [ deprecation-notes get delete-at ] }
+    { fatal? f }
 } define-error-type
 
 : <deprecation-note-error> ( error word -- deprecation-note )
@@ -72,7 +73,7 @@ M: deprecation-observer definitions-changed
     [ [ check-deprecations ] each ]
     [ drop initialize-deprecation-notes ] if ;
 
-[ \ deprecation-observer add-definition-observer ] 
+[ \ deprecation-observer add-definition-observer ]
 "tools.deprecation" add-startup-hook
 
 initialize-deprecation-notes

--- a/basis/tools/test/test.factor
+++ b/basis/tools/test/test.factor
@@ -26,6 +26,7 @@ T{ error-type-holder
    { plural "unit test failures" }
    { icon "vocab:ui/tools/error-list/icons/unit-test-error.tiff" }
    { quot [ test-failures get ] }
+   { fatal? f }
 } define-error-type
 
 SYMBOL: verbose-tests?


### PR DESCRIPTION
Deprecation warnings are annoying. If you are using some vocab with deprecated words, your prompt will forever say `:deprecations - show N deprecated word usages`. And there is no way to dismiss that warning. 

Root cause is that deprecation errors have `fatal?` set to `t`. But it and some of its friends are benign and not that fatal at all. 
