### PR TITLE
help.lint.checks: check for disposable leaks and print more details when...

### DIFF
--- a/basis/help/lint/checks/checks-docs.factor
+++ b/basis/help/lint/checks/checks-docs.factor
@@ -1,0 +1,18 @@
+USING: help.markup help.syntax sequences words ;
+IN: help.lint.checks
+
+HELP: check-example
+{ $values { "element" sequence } }
+{ $description "Throws an error if the expected output from the $example is different from the expected, or if it leaks disposables." } ;
+
+HELP: check-values
+{ $values { "word" word } { "element" sequence } }
+{ $description "Throws an error if the $values pair doesnt match the declared stack effect." }
+{ $examples
+  { $unchecked-example
+    "USING: help.lint.checks math ;"
+    ": foo ( x -- y ) ;"
+    "\\ foo { $values { \"a\" number } { \"b\" number } } check-values"
+    "$values don't match stack effect; expected { \"x\" \"y\" }, got { \"a\" \"b\" }\n\nType :help for debugging help."
+    }
+} ;

--- a/basis/tools/destructors/destructors-docs.factor
+++ b/basis/tools/destructors/destructors-docs.factor
@@ -1,25 +1,34 @@
 ! Copyright (C) 2009 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: help.markup help.syntax help.tips quotations destructors ;
+USING: destructors help.markup help.syntax help.tips quotations sequences ;
 IN: tools.destructors
 
 HELP: disposables.
 { $description "Print the number of disposable objects of each class." } ;
 
-HELP: leaks
+HELP: leaks.
 { $values
     { "quot" quotation }
 }
 { $description "Runs a quotation, printing any increases in the number of disposable objects after the quotation returns. The " { $link debug-leaks? } " variable is also switched on while the quotation runs, recording the current continuation in every newly-created disposable object." } ;
 
-TIP: "Use the " { $link leaks } " combinator to track down resource leaks." ;
+HELP: leaks
+{ $values
+  { "quot" quotation }
+  { "disposables" sequence }
+}
+{ $description
+  "Runs the quotation and collects all disposables leaked by it. Used by " { $link leaks. } "."
+} ;
+
+TIP: "Use the " { $link leaks. } " combinator to track down resource leaks." ;
 
 ARTICLE: "tools.destructors" "Destructor tools"
 "The " { $vocab-link "tools.destructors" } " vocabulary provides words for tracking down resource leaks."
 { $subsections
     debug-leaks?
     disposables.
-    leaks
+    leaks.
 }
 { $see-also "destructors" } ;
 

--- a/basis/tools/destructors/destructors-tests.factor
+++ b/basis/tools/destructors/destructors-tests.factor
@@ -3,11 +3,10 @@ IN: tools.destructors.tests
 
 f debug-leaks? set-global
 
-[ [ 3 throw ] leaks ] must-fail
+[ [ 3 throw ] leaks. ] must-fail
 
 [ f ] [ debug-leaks? get-global ] unit-test
 
-[ ] [ [ ] leaks ] unit-test
+[ ] [ [ ] leaks. ] unit-test
 
 [ f ] [ debug-leaks? get-global ] unit-test
-

--- a/basis/tools/destructors/destructors.factor
+++ b/basis/tools/destructors/destructors.factor
@@ -45,10 +45,13 @@ PRIVATE>
     [ disposables get members sort-disposables ] dip
     '[ _ instance? ] filter stack. ;
 
-: leaks ( quot -- )
+: leaks ( quot -- disposables )
     disposables get clone
     t debug-leaks? set-global
     [
         [ call disposables get clone ] dip
     ] [ f debug-leaks? set-global ] [ ] cleanup
-    diff (disposables.) ; inline
+    diff ; inline
+
+: leaks. ( quot -- )
+    leaks (disposables.) ; inline


### PR DESCRIPTION
A patch with two improvements to help-lint.

The first one, kind of suggested by you :), is to check if the `$example` leaks disposables. E.g `100 <buffer>` gives the error "1 disposable(s) leaked in example". 

Second changes `check-values` error from "$values don't match stack effect" to e.g "$values don't match stack effect; expected { "x" "y" }, got { "a" "b" }" which makes it clearer why it complains.
