### PR TITLE
FUEL: make it so fuel-con-error is shown in *fuel debug*

### DIFF
--- a/misc/fuel/fuel-debug.el
+++ b/misc/fuel/fuel-debug.el
@@ -143,13 +143,16 @@ the debugger."
       (fuel-debug--display-output ret)
       (delete-blank-lines)
       (newline)
-      (when (and (not err) success-msg)
+      (cond
+       ((and (not err) success-msg)
         (message "%s" success-msg)
         (insert "\n" success-msg "\n"))
-      (when err
+       ((eq (car err) 'fuel-con-error)
+        (fuel-debug--display-parse-error (second err)))
+       (err
         (fuel-debug--display-restarts err)
         (delete-blank-lines)
-        (newline))
+        (newline)))
       (fuel-debug--display-uses ret)
       (let ((hstr (fuel-debug--help-string err fuel-debug--file)))
         (if fuel-debug-show-short-help
@@ -202,6 +205,7 @@ the debugger."
     (newline)))
 
 (defun fuel-debug--display-output (ret)
+  "Diplays the retort `ret' in fuels debug buffer."
   (let* ((last (fuel-eval--retort-output fuel-debug--last-ret))
          (current (fuel-eval--retort-output ret))
          (llen (length last))
@@ -215,6 +219,11 @@ the debugger."
     (goto-char (point-max))
     (when err
       (insert (format "\nError: %S\n\n" (fuel-eval--error-name err))))))
+
+(defun fuel-debug--display-parse-error (str)
+  (insert
+   (format
+    "FUEL failed to parse the connection response, displayed below:\n\n%s\n\n" str)))
 
 (defun fuel-debug--display-restarts (err)
   (let* ((rs (fuel-eval--error-restarts err))

--- a/misc/fuel/fuel-eval.el
+++ b/misc/fuel/fuel-eval.el
@@ -130,13 +130,11 @@
 (defsubst fuel-eval--retort-p (ret)
   (and (listp ret) (= 3 (length ret))))
 
-(defsubst fuel-eval--make-parse-error-retort (str)
-  (fuel-eval--retort-make (cons 'fuel-parse-retort-error str) nil))
-
 (defun fuel-eval--parse-retort (ret)
   (fuel-log--info "RETORT: %S" ret)
-  (if (fuel-eval--retort-p ret) ret
-    (fuel-eval--make-parse-error-retort ret)))
+  (if (fuel-eval--retort-p ret)
+      ret
+    (list ret nil nil)))
 
 (defsubst fuel-eval--error-name (err) (car err))
 


### PR DESCRIPTION
This is a small but important (I think) patch to make fuel-con-errors show up in _fuel debug_. It makes debugging easier.
