### PR TITLE
calendar.format: allow space or tabs in rfc3339

### DIFF
--- a/basis/calendar/format/format-tests.factor
+++ b/basis/calendar/format/format-tests.factor
@@ -94,3 +94,25 @@ IN: calendar.format.tests
         { second 24 }
     }
 ] [ "2013-04-23T13:50:24" rfc3339>timestamp ] unit-test
+
+[
+    T{ timestamp
+        { year 2001 }
+        { month 12 }
+        { day 15 }
+        { hour 02 }
+        { minute 59 }
+        { second 43+1/10 }
+    }
+] [ "2001-12-15 02:59:43.1Z" rfc3339>timestamp ] unit-test
+
+[
+    T{ timestamp
+        { year 2001 }
+        { month 12 }
+        { day 15 }
+        { hour 02 }
+        { minute 59 }
+        { second 43+1/10 }
+    }
+] [ "2001-12-15	02:59:43.1Z" rfc3339>timestamp ] unit-test

--- a/basis/calendar/format/format.factor
+++ b/basis/calendar/format/format.factor
@@ -171,7 +171,7 @@ M: timestamp year. ( timestamp -- )
 
 : (rfc3339>timestamp) ( -- timestamp )
     read-ymd
-    "Tt" expect
+    "Tt \t" expect
     read-hms
     read1 { { CHAR: . [ read-rfc3339-seconds ] } [ ] } case
     read-rfc3339-gmt-offset


### PR DESCRIPTION
As per http://tools.ietf.org/html/rfc3339

```
NOTE: ISO 8601 defines date and time separated by "T".
Applications using this syntax may choose, for the sake of
readability, to specify a full-date and full-time separated by
(say) a space character.
```

YAML uses spaces or tabs (http://yaml.org/type/timestamp.html) so I added both.
