### PR TITLE
io.launcher.windows.tests: many of the tests can result in utf8-encoded ...

### DIFF
--- a/basis/io/launcher/windows/test/append.factor
+++ b/basis/io/launcher/windows/test/append.factor
@@ -1,2 +1,3 @@
 USE: io
 "Hello appender" print
+"Örjan ågren är åter" print

--- a/basis/io/launcher/windows/windows-tests.factor
+++ b/basis/io/launcher/windows/windows-tests.factor
@@ -1,6 +1,6 @@
 USING: accessors arrays assocs calendar continuations
 environment eval hashtables io io.directories
-io.encodings.ascii io.files io.files.temp io.launcher
+io.encodings.ascii io.encodings.utf8 io.files io.files.temp io.launcher
 io.launcher.windows io.pathnames kernel math namespaces parser
 sequences splitting system tools.test combinators.short-circuit ;
 IN: io.launcher.windows.tests
@@ -92,7 +92,7 @@ IN: io.launcher.windows.tests
         console-vm "-run=listener" 2array >>command
         +closed+ >>stdin
         +stdout+ >>stderr
-    ascii [ lines last ] with-process-reader
+    utf8 [ lines last ] with-process-reader
 ] unit-test
 
 : launcher-test-path ( -- str )
@@ -135,7 +135,7 @@ IN: io.launcher.windows.tests
         <process>
             console-vm "-script" "stderr.factor" 3array >>command
             "err2.txt" temp-file >>stderr
-        ascii <process-reader> stream-lines first
+        utf8 <process-reader> stream-lines first
     ] with-directory
 ] unit-test
 
@@ -147,7 +147,7 @@ IN: io.launcher.windows.tests
     launcher-test-path [
         <process>
             console-vm "-script" "env.factor" 3array >>command
-        ascii <process-reader> stream-contents
+        utf8 <process-reader> stream-contents
     ] with-directory eval( -- alist )
 
     os-envs =
@@ -159,9 +159,9 @@ IN: io.launcher.windows.tests
             console-vm "-script" "env.factor" 3array >>command
             +replace-environment+ >>environment-mode
             os-envs >>environment
-        ascii <process-reader> stream-contents
+        utf8 <process-reader> stream-contents
     ] with-directory eval( -- alist )
-    
+
     os-envs =
 ] unit-test
 
@@ -170,7 +170,7 @@ IN: io.launcher.windows.tests
         <process>
             console-vm "-script" "env.factor" 3array >>command
             { { "A" "B" } } >>environment
-        ascii <process-reader> stream-contents
+        utf8 <process-reader> stream-contents
     ] with-directory eval( -- alist )
 
     "A" of
@@ -182,7 +182,7 @@ IN: io.launcher.windows.tests
             console-vm "-script" "env.factor" 3array >>command
             { { "USERPROFILE" "XXX" } } >>environment
             +prepend-environment+ >>environment-mode
-        ascii <process-reader> stream-contents
+        utf8 <process-reader> stream-contents
     ] with-directory eval( -- alist )
 
     "USERPROFILE" of "XXX" =
@@ -201,7 +201,7 @@ IN: io.launcher.windows.tests
 
 [ "append-test" temp-file delete-file ] ignore-errors
 
-[ "Hello appender\r\nHello appender\r\n" ] [
+{ "Hello appender\r\nÖrjan ågren är åter\r\nHello appender\r\nÖrjan ågren är åter\r\n" } [
     2 [
         launcher-test-path [
             <process>
@@ -210,8 +210,8 @@ IN: io.launcher.windows.tests
             try-process
         ] with-directory
     ] times
-   
-    "append-test" temp-file ascii file-contents
+
+    "append-test" temp-file utf8 file-contents
 ] unit-test
 
 [ "IN: scratchpad " ] [


### PR DESCRIPTION
Makes the tests more resilient to utf8. Some of them failed on my machine because I have unicode characters in some environment variables. I didn't change all of the tests because in some cases it would be unexpected to receive anything other than ascii chars.
