### PR TITLE
VM: fixing some implicit casts from cell to fixnum

### DIFF
--- a/vm/debug.cpp
+++ b/vm/debug.cpp
@@ -79,7 +79,7 @@ void factor_vm::print_byte_array(byte_array* array, cell nesting) {
 
 void factor_vm::print_tuple(tuple* tuple, cell nesting) {
   tuple_layout* layout = untag<tuple_layout>(tuple->layout);
-  cell length = to_fixnum(layout->size);
+  cell length = to_cell(layout->size);
 
   std::cout << " ";
   print_nested_obj(layout->klass, nesting);

--- a/vm/io.cpp
+++ b/vm/io.cpp
@@ -180,7 +180,7 @@ void factor_vm::primitive_fgetc() {
 void factor_vm::primitive_fread() {
   FILE* file = pop_file_handle();
   void* buf = (void*)alien_offset(ctx->pop());
-  fixnum size = unbox_array_size();
+  cell size = unbox_array_size();
 
   if (size == 0) {
     ctx->push(from_unsigned_cell(0));

--- a/vm/quotations.cpp
+++ b/vm/quotations.cpp
@@ -104,9 +104,9 @@ bool quotation_jit::word_safepoint_p(cell obj) {
 }
 
 bool quotation_jit::safepoint_p() {
-  fixnum length = array_capacity(elements.untagged());
+  cell length = array_capacity(elements.untagged());
 
-  for (fixnum i = 0; i < length; i++) {
+  for (cell i = 0; i < length; i++) {
     cell obj = array_nth(elements.untagged(), i);
     switch (tagged<object>(obj).type()) {
       case WORD_TYPE:
@@ -122,9 +122,9 @@ bool quotation_jit::safepoint_p() {
 }
 
 bool quotation_jit::stack_frame_p() {
-  fixnum length = array_capacity(elements.untagged());
+  cell length = array_capacity(elements.untagged());
 
-  for (fixnum i = 0; i < length; i++) {
+  for (cell i = 0; i < length; i++) {
     cell obj = array_nth(elements.untagged(), i);
     if (tagged<object>(obj).type() == WORD_TYPE && !word_safepoint_p(obj))
       return false;


### PR DESCRIPTION
Small fix to make the fixnum/cell casts better. E.g  `unbox_array_size` is declared to return a cell so the variable that receives it should also be declared of type cell instead of fixnum.
