### PR TITLE
ui.tools.deploy,inspector: make the deply tool and slot editor windows f...

### DIFF
--- a/basis/ui/tools/deploy/deploy.factor
+++ b/basis/ui/tools/deploy/deploy.factor
@@ -4,7 +4,7 @@ USING: colors kernel models tools.deploy.config
 tools.deploy.config.editor tools.deploy vocabs namespaces
 models.mapping sequences system accessors fry ui.gadgets ui.render
 ui.gadgets.buttons ui.gadgets.packs ui.gadgets.labels
-ui.gadgets.editors ui.gadgets.borders ui.gestures ui.commands assocs
+ui.gadgets.editors ui.gadgets.borders ui.gadgets.worlds ui.gestures ui.commands assocs
 ui.gadgets.tracks ui ui.tools.listener ui.tools.browser ;
 IN: ui.tools.deploy
 
@@ -107,9 +107,12 @@ deploy-gadget "toolbar" f {
       dup <toolbar> { 10 10 } >>gap add-gadget
     deploy-settings-theme
     dup com-revert ;
-    
+
 : deploy-tool ( vocab -- )
     vocab-name
     [ <deploy-gadget> { 10 10 } <border> ]
-    [ "Deploying “" "”" surround ] bi
-    open-window ;
+    [
+        <world-attributes>
+        swap "Deploying “" "”" surround >>title
+        { small-title-bar close-button } >>window-controls
+    ] bi open-window ;

--- a/basis/ui/tools/inspector/inspector.factor
+++ b/basis/ui/tools/inspector/inspector.factor
@@ -6,7 +6,7 @@ classes io io.styles arrays hashtables math.order sorting refs fonts
 ui.tools.browser ui.commands ui.operations ui.gadgets ui.gadgets.panes
 ui.gadgets.scrollers ui.gadgets.slots ui.gadgets.tracks ui.gestures
 ui.gadgets.buttons ui.gadgets.tables ui.gadgets.status-bar
-ui.gadgets.labeled ui.tools.common ui combinators ;
+ui.gadgets.labeled ui.gadgets.worlds ui.tools.common ui combinators ;
 IN: ui.tools.inspector
 
 TUPLE: inspector-gadget < tool table ;
@@ -101,7 +101,12 @@ M: inspector-gadget focusable-child*
 \ com-push H{ { +listener+ t } } define-command
 
 : slot-editor-window ( close-hook update-hook assoc key key-string -- )
-    [ <value-ref> <slot-editor> ] [ "Slot editor: " prepend ] bi*
+    [ <value-ref> <slot-editor> ]
+    [
+        <world-attributes>
+        swap "Slot editor: " prepend >>title
+        { small-title-bar close-button } >>window-controls
+    ] bi*
     open-status-window ;
 
 : com-edit-slot ( inspector -- )


### PR DESCRIPTION
Fix for profpatsch's floating window hint problem. I only made the deploy tool and slot editor floating, the other windows Factor open is probably better being tiled. But I dont use a tiling wm much so I dont know.
