### PR TITLE
VM: moves the code that clears the roots to the same function that

### DIFF
--- a/vm/cpu-x86.cpp
+++ b/vm/cpu-x86.cpp
@@ -56,6 +56,14 @@ void factor_vm::dispatch_signal_handler(cell* sp, cell* pc, cell handler) {
 
     *pc = (cell)handler_word->entry_point;
   }
+
+  /* Poking with the stack pointer, which the above code does, means
+     that pointers to stack-allocated objects will become
+     corrupted. Therefore the root vectors needs to be cleared because
+     their pointers to stack variables are now garbage. */
+  data_roots.clear();
+  bignum_roots.clear();
+  code_roots.clear();
 }
 
 }

--- a/vm/errors.cpp
+++ b/vm/errors.cpp
@@ -39,13 +39,6 @@ void out_of_memory() {
 /* Allocates memory */
 void factor_vm::general_error(vm_error_type error, cell arg1_, cell arg2_) {
 
-  /* If we got here from memory_protection_error(), then the stack
-     pointer has been fiddled with and the elements of these vectors,
-     which address stack-allocated objects, are bogus and needs to be
-     resetted. */
-  data_roots.clear();
-  bignum_roots.clear();
-  code_roots.clear();
 
   data_root<object> arg1(arg1_, this);
   data_root<object> arg2(arg2_, this);
@@ -74,8 +67,8 @@ void factor_vm::general_error(vm_error_type error, cell arg1_, cell arg2_) {
                       arg1.value(), arg2.value());
     ctx->push(error_object);
 
-    /* Clear the data roots again since arg1 and arg2's destructors
-       won't be called. */
+    /* Clear the data roots since arg1 and arg2's destructors won't be
+       called. */
     data_roots.clear();
 
     /* The unwind-native-frames subprimitive will clear faulting_p


### PR DESCRIPTION
It was suggested by Slava that the bugfix for #1083 slightly misplaced in `general_error` which makes sense. So I moved it to `dispatch_signal_handler` instead. It's the function that destroys the stack so it should be more clear what is going on. :)
