### PR TITLE
FUEL: remove empty (nil) lists of parsed words

### DIFF
--- a/misc/fuel/fuel-markup.el
+++ b/misc/fuel/fuel-markup.el
@@ -423,7 +423,7 @@
       (let ((elems '(($heading "Words"))))
         (push (fuel-markup--parse-classes) elems)
         (push (fuel-markup--parse-words) elems)
-        (reverse elems)))))
+        (reverse (remove nil elems))))))
 
 (defun fuel-markup--describe-words (e)
   (when (cadr e)


### PR DESCRIPTION
Bugfix for a small printing problem in the help browser
