### PR TITLE
curses.ffi: on some linuxes, libncursesw.so is a linker script so find-l...

### DIFF
--- a/extra/curses/ffi/ffi.factor
+++ b/extra/curses/ffi/ffi.factor
@@ -1,13 +1,13 @@
 ! Copyright (C) 2008 Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors alien alien.c-types alien.libraries
+USING: accessors alien alien.c-types alien.libraries alien.libraries.finder
 alien.syntax classes.struct combinators kernel math system unix.types ;
 IN: curses.ffi
 
 << "curses" {
     { [ os windows? ]  [ "libcurses.dll" ] }
     { [ os macosx? ] [ "libcurses.dylib" ] }
-    { [ os unix?  ]  [ "libncursesw.so" ] }
+    { [ os unix?  ]  [ "ncursesw" find-library ] }
 } cond cdecl add-library >>
 
 C-TYPE: SCREEN


### PR DESCRIPTION
the `libncursesw.so` file is a linker script on my machine so you can't load it directly.
