### PR TITLE
tools.gc-decode: vocab for reading words gc maps

### DIFF
--- a/basis/compiler/codegen/gc-maps/gc-maps-tests.factor
+++ b/basis/compiler/codegen/gc-maps/gc-maps-tests.factor
@@ -2,16 +2,9 @@ USING: namespaces byte-arrays make compiler.codegen.gc-maps
 compiler.codegen.relocation bit-arrays accessors classes.struct
 tools.test kernel math sequences alien.c-types
 specialized-arrays boxes compiler.cfg.instructions system
-cpu.architecture ;
+cpu.architecture vm ;
 SPECIALIZED-ARRAY: uint
 IN: compiler.codegen.gc-maps.tests
-
-STRUCT: gc-info
-{ scrub-d-count uint }
-{ scrub-r-count uint }
-{ gc-root-count uint }
-{ derived-root-count uint }
-{ return-address-count uint } ;
 
 SINGLETON: fake-cpu
 
@@ -63,7 +56,7 @@ M: fake-cpu gc-root-offset ;
         ! Return addresses
         uint-array{ 100 } underlying>> %
 
-        ! GC info footer - 16 bytes
+        ! GC info footer - 20 bytes
         S{ gc-info
             { scrub-d-count 5 }
             { scrub-r-count 2 }

--- a/basis/vm/vm-docs.factor
+++ b/basis/vm/vm-docs.factor
@@ -20,3 +20,14 @@ HELP: vm
 HELP: vm-field-offset
 { $values { "field" string } { "offset" number } }
 { $description "Gets the offset in bytes to the named virtual machine field." } ;
+
+HELP: gc-info
+{ $class-description "A struct that defines the sizes of the garbage collection maps for a word. It has the following slots:"
+  { $table
+    { { $slot "scrub-d-count" } "Number of datastack scrub bits per callsite." }
+    { { $slot "scrub-r-count" } "Number of retainstack scrub bits per callsite." }
+    { { $slot "gc-root-count" } "Number of gc root bits per callsite." }
+    { { $slot "derived-root-count" } "Number of derived roots per callsite." }
+    { { $slot "return-address-count" } "Number of gc callsites." }
+  }
+} ;

--- a/basis/vm/vm.factor
+++ b/basis/vm/vm.factor
@@ -91,3 +91,10 @@ STRUCT: dispatch-statistics
 
 { pic-tag-count cell }
 { pic-tuple-count cell } ;
+
+STRUCT: gc-info
+    { scrub-d-count uint read-only }
+    { scrub-r-count uint read-only }
+    { gc-root-count uint read-only }
+    { derived-root-count uint read-only }
+    { return-address-count uint read-only } ;

--- a/extra/tools/gc-decode/gc-decode-docs.factor
+++ b/extra/tools/gc-decode/gc-decode-docs.factor
@@ -4,17 +4,6 @@ IN: tools.gc-decode
 ARTICLE: "tools.gc-decode" "GC maps decoder"
 "A vocab that disassembles words gc maps. It's useful to have when debugging garbage collection issues." ;
 
-HELP: gc-info
-{ $class-description "A struct that defines the sizes of the garbage collection maps for a word. It has the following slots:"
-  { $table
-    { { $slot "scrub-d-count" } "Number of datastack scrub bits per callsite." }
-    { { $slot "scrub-r-count" } "Number of retainstack scrub bits per callsite." }
-    { { $slot "gc-root-count" } "Number of gc root bits per callsite." }
-    { { $slot "derived-root-count" } "Number of derived roots per callsite." }
-    { { $slot "return-address-count" } "Number of gc callsites." }
-  }
-} ;
-
 HELP: word>gc-info
 { $values { "word" word } { "gc-info" gc-info } }
 { $description "Gets the gc-info struct for a word." } ;

--- a/extra/tools/gc-decode/gc-decode-tests.factor
+++ b/extra/tools/gc-decode/gc-decode-tests.factor
@@ -1,4 +1,4 @@
-USING: bit-arrays classes.struct tools.gc-decode tools.test ;
+USING: bit-arrays classes.struct tools.gc-decode tools.test vm ;
 QUALIFIED: effects
 QUALIFIED: llvm.types
 QUALIFIED: unix.process

--- a/extra/tools/gc-decode/gc-decode.factor
+++ b/extra/tools/gc-decode/gc-decode.factor
@@ -1,6 +1,6 @@
 USING: accessors alien alien.c-types alien.data arrays assocs bit-arrays
 bit-arrays.private classes.struct fry grouping kernel math math.statistics
-sequences sequences.repeating words ;
+sequences sequences.repeating vm words ;
 IN: tools.gc-decode
 
 ! Utils
@@ -19,13 +19,6 @@ IN: tools.gc-decode
 : end-address>direct-array ( obj count type -- seq )
     [ heap-size * [ >c-ptr alien-address ] dip - <alien> ] 2keep
     c-direct-array-constructor execute( alien len -- seq ) ;
-
-STRUCT: gc-info
-    { scrub-d-count uint read-only }
-    { scrub-r-count uint read-only }
-    { gc-root-count uint read-only }
-    { derived-root-count uint read-only }
-    { return-address-count uint read-only } ;
 
 : bit-counts ( gc-info -- counts )
     struct-slot-values 3 head ;


### PR DESCRIPTION
Here is a vocab I hope you like. It's main word is `decode-gc-maps` and with it you can read the gc maps for a given word. There's currently no interface to that info in Factor and it's info that is good to have when debugging gc issues. If we ever change the format of the gc maps, this vocab can be used to see that the generated maps looks correct.
