### PR TITLE
Fix the Atom feed generator

### DIFF
--- a/basis/syndication/syndication-tests.factor
+++ b/basis/syndication/syndication-tests.factor
@@ -40,4 +40,4 @@ IN: syndication.tests
         }
     }
 } ] [ "vocab:syndication/test/atom.xml" load-news-file ] unit-test
-[ ] [ "vocab:syndication/test/atom.xml" load-news-file feed>xml xml>string drop ] unit-test
+[ t ] [ "vocab:syndication/test/atom.xml" load-news-file dup feed>xml xml>feed = ] unit-test

--- a/basis/syndication/syndication.factor
+++ b/basis/syndication/syndication.factor
@@ -80,7 +80,7 @@ TUPLE: entry title url description date ;
             [ children>string ] if >>description
         ]
         [
-            { "published" "updated" "issued" "modified" } 
+            { "published" "updated" "issued" "modified" }
             any-tag-named children>string try-parsing-timestamp
             >>date
         ]
@@ -122,7 +122,7 @@ M: byte-array parse-feed [ bytes>xml xml>feed ] with-html-entities ;
     [XML
         <entry>
             <title type="html"><-></title>
-            <link href=<-> />
+            <link rel="alternate" href=<-> />
             <published><-></published>
             <content type="html"><-></content>
         </entry>
@@ -135,7 +135,7 @@ M: byte-array parse-feed [ bytes>xml xml>feed ] with-html-entities ;
     <XML
         <feed xmlns="http://www.w3.org/2005/Atom">
             <title><-></title>
-            <link href=<-> />
+            <link rel="alternate" href=<-> />
             <->
         </feed>
     XML> ;


### PR DESCRIPTION
I wasn't able to read the Atom feed produced by http://planet.factorcode.org/ using the `syndication` vocabulary, so I tried to fix that issue. Here is a simple test case which currently fails with an error:

``` factor
USING: syndication xml ;
"vocab:syndication/test/atom.xml" file>xml xml>feed feed>xml xml>feed
```

The problem is that `feed>xml` generates an ill-formed Atom feed: indeed, `link` tags miss the required `rel="alternate"` attribute.
This pull request adds missing attributes and updates corresponding unit tests to check whether the `feed>xml xml>feed` conversion chain results in the same feed.
