### PR TITLE
VM: GC_BIGNUM must be called in the same scope as the variable declarati...

### DIFF
--- a/vm/bignum.cpp
+++ b/vm/bignum.cpp
@@ -752,12 +752,12 @@ void factor_vm::bignum_divide_unsigned_large_denominator(
   bignum *q = NULL;
   if (quotient != ((bignum**)0)) {
     q = allot_bignum(length_n - length_d, q_negative_p);
-    GC_BIGNUM(q);
   } else {
     q = BIGNUM_OUT_OF_BAND;
   }
+  GC_BIGNUM(q);
 
-  bignum* u = (allot_bignum(length_n, r_negative_p));
+  bignum* u = allot_bignum(length_n, r_negative_p);
   GC_BIGNUM(u);
 
   int shift = 0;

--- a/vm/data_roots.hpp
+++ b/vm/data_roots.hpp
@@ -35,13 +35,18 @@ struct gc_bignum {
   factor_vm* parent;
 
   gc_bignum(bignum** addr, factor_vm* parent) : addr(addr), parent(parent) {
-    parent->check_data_pointer(*addr);
-    parent->bignum_roots.push_back(addr);
+    /* Don't bother with variables holding NULL pointers. */
+    if (*addr) {
+      parent->check_data_pointer(*addr);
+      parent->bignum_roots.push_back(addr);
+    }
   }
 
   ~gc_bignum() {
-    FACTOR_ASSERT(parent->bignum_roots.back() == addr);
-    parent->bignum_roots.pop_back();
+    if (*addr) {
+      FACTOR_ASSERT(parent->bignum_roots.back() == addr);
+      parent->bignum_roots.pop_back();
+    }
   }
 };
 


### PR DESCRIPTION
A previous fix of mine moved a GC_BIGNUM call inside an if-block. Which is wrong because then the gc_bignum destructor is called when the if-block which is sooner than when the variable it protects goes out of scope. It lead to bad unpredictable crashes, but the changes below fixes it.
