### PR TITLE
system: dont let any errors interfere with the shutdown process and just

### DIFF
--- a/core/system/system-docs.factor
+++ b/core/system/system-docs.factor
@@ -1,4 +1,4 @@
-USING: classes.singleton help.markup help.syntax kernel math ;
+USING: classes.singleton help.markup help.syntax init kernel math ;
 IN: system
 
 ABOUT: "system"
@@ -65,7 +65,7 @@ HELP: embedded?
 
 HELP: exit
 { $values { "n" "an integer exit code" } }
-{ $description "Exits the Factor process." } ;
+{ $description "Runs all " { $link shutdown-hooks } " and then exits the Factor process. If an error occurs when the shutdown hooks runs, or when the process is about to terminate, the error is ignored and the process exits with status 255." } ;
 
 HELP: nano-count
 { $values { "ns" integer } }

--- a/core/system/system.factor
+++ b/core/system/system.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2007, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: assocs init kernel.private namespaces ;
+USING: assocs continuations init io kernel.private namespaces ;
 IN: system
 
 SINGLETONS: x86.32 x86.64 arm ppc.32 ppc.64 ;
@@ -42,6 +42,11 @@ PRIVATE>
 
 : vm ( -- path ) \ vm get-global ;
 
+: install-prefix ( -- path ) \ install-prefix get-global ;
+
 : embedded? ( -- ? ) OBJ-EMBEDDED special-object ;
 
-: exit ( n -- * ) do-shutdown-hooks (exit) ;
+: exit ( n -- * )
+    [ do-shutdown-hooks (exit) ] ignore-errors
+    [ "Unexpected error during shutdown!" print ] ignore-errors
+    255 (exit) ;


### PR DESCRIPTION
I think there is a bug in the shutdown process. Just start Factor then, with nothing on the stack, type:

``` factor
IN: scratchpad exit
```

What now happens is that the shutdown hooks run, then the `(exit)` word throws a datastack underflow error which aborts the shutdown process. But the shutdown hooks have already run so Factor can be in a bad state and crash or behave weirdly. 

There's no great way to handle the situation. So what I think is best is just to ignore any errors and exit with an error because you can't recover. That matches the way Python and other VM languages handles shutdown errors. Unfortunately you can't even pretty print the error itself because prettyprint is in basis and the system vocab is in core. 
