### PR TITLE
db.postgresql.lib: if PQsetdbLogin fails, PQfinish must be called

### DIFF
--- a/basis/db/postgresql/lib/lib.factor
+++ b/basis/db/postgresql/lib/lib.factor
@@ -42,8 +42,9 @@ M: postgresql-result-null summary ( obj -- str )
     PGRES_COMMAND_OK PGRES_TUPLES_OK 2array member? ;
 
 : connect-postgres ( host port pgopts pgtty db user pass -- conn )
-    PQsetdbLogin
-    dup PQstatus zero? [ (postgresql-error-message) throw ] unless ;
+    PQsetdbLogin dup PQstatus zero? [
+        [ (postgresql-error-message) ] [ PQfinish ] bi throw
+    ] unless ;
 
 : do-postgresql-statement ( statement -- res )
     db-connection get handle>> swap sql>> PQexec dup postgresql-result-ok? [
@@ -147,7 +148,7 @@ M: postgresql-malloc-destructor dispose ( obj -- )
                     &postgresql-free
                 ] if
             ] with-out-parameters memory>byte-array
-        ] with-destructors 
+        ] with-destructors
     ] [
         drop pq-get-is-null nip [ f ] [ B{ } clone ] if
     ] if ;

--- a/basis/db/postgresql/postgresql-tests.factor
+++ b/basis/db/postgresql/postgresql-tests.factor
@@ -1,8 +1,19 @@
 USING: kernel db.postgresql alien continuations io classes
-prettyprint sequences namespaces tools.test db db.private
+prettyprint sequences math namespaces tools.test db db.private
 db.tuples db.types unicode.case accessors system db.tester ;
 IN: db.postgresql.tests
 
+: nonexistant-db ( -- db )
+    <postgresql-db>
+        "localhost" >>host
+        "fake-user" >>username
+        "no-pass" >>password
+        "dont-exist" >>database ;
+
+! Don't leak connections
+[ ] [
+    2000 [ [ nonexistant-db [ ] with-db ] ignore-errors ] times
+] unit-test
 
 ! Ensure the table exists
 [ ] [ postgresql-test-db [ ] with-db ] unit-test


### PR DESCRIPTION
See http://www.postgresql.org/docs/8.1/static/libpq.html#LIBPQ-CONNECT you just need to call PQfinish if the connect attempt fails, or else the connection lingers
