### PR TITLE
furnace.db: db-persistence needs a dispose word that delegates to its po...

### DIFF
--- a/basis/furnace/db/db.factor
+++ b/basis/furnace/db/db.factor
@@ -4,10 +4,10 @@ USING: kernel accessors continuations namespaces destructors
 db db.private db.pools io.pools http.server http.server.filters ;
 IN: furnace.db
 
-TUPLE: db-persistence < filter-responder pool ;
+TUPLE: db-persistence < filter-responder pool disposed ;
 
 : <db-persistence> ( responder db -- responder' )
-    <db-pool> db-persistence boa ;
+    <db-pool> f db-persistence boa ;
 
 M: db-persistence call-responder*
     [
@@ -15,3 +15,5 @@ M: db-persistence call-responder*
         [ return-connection-later ] [ drop db-connection set ] 2bi
     ]
     [ call-next-method ] bi ;
+
+M: db-persistence dispose* pool>> dispose ;


### PR DESCRIPTION
Here is another file descriptor leak patch. This one was a little trickier to fix because db-persistence needed to be a disposable and only used inside `with-disposal` blocks. So the unit tests had to be restructured a bit to accomodate that. There's probably more test suites that leak in the same way. Im finding a bunch of them using lsof.
