### PR TITLE
csv: need to handle \r because windows lines ends with \r\n

### DIFF
--- a/basis/csv/csv-tests.factor
+++ b/basis/csv/csv-tests.factor
@@ -4,11 +4,11 @@ io.directories ;
 IN: csv.tests
 
 ! I like to name my unit tests
-: named-unit-test ( name output input -- ) 
+: named-unit-test ( name output input -- )
     unit-test drop ; inline
 
 "Fields are separated by commas"
-[ { { "1997" "Ford" "E350" } } ] 
+[ { { "1997" "Ford" "E350" } } ]
 [ "1997,Ford,E350" string>csv ] named-unit-test
 
 "ignores whitespace before and after elements. n.b.specifically prohibited by RFC 4180, which states, 'Spaces are considered part of a field and should not be ignored.'"
@@ -21,7 +21,7 @@ IN: csv.tests
 
 "double quotes mean escaped in quotes"
 [ { { "1997" "Ford" "E350" "Super \"luxurious\" truck" } } ]
-[ "1997,Ford,E350,\"Super \"\"luxurious\"\" truck\"" 
+[ "1997,Ford,E350,\"Super \"\"luxurious\"\" truck\""
     string>csv ] named-unit-test
 
 "Fields with embedded line breaks must be delimited by double-quote characters."
@@ -39,10 +39,10 @@ IN: csv.tests
 [ "\"1997\",\"Ford\",\"E350\"" string>csv ] named-unit-test
 
 "The first record in a csv file may contain column names in each of the fields."
-[ { { "Year" "Make" "Model" } 
+[ { { "Year" "Make" "Model" }
     { "1997" "Ford" "E350" }
     { "2000" "Mercury" "Cougar" } } ]
-[ "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar" 
+[ "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar"
     string>csv ] named-unit-test
 
 
@@ -102,3 +102,10 @@ IN: csv.tests
 { { { "as,d\"f" "asdf" } } } [ "\"as,\"d\"\"\"\"f,asdf" string>csv ] unit-test
 
 [ { } ] [ "" string>csv ] unit-test
+
+[
+    { { "Year" "Make" "Model" }
+      { "1997" "Ford" "E350" }
+    }
+]
+[ "Year,Make,\"Model\"\r\n1997,Ford,E350" string>csv ] unit-test

--- a/basis/csv/csv.factor
+++ b/basis/csv/csv.factor
@@ -12,7 +12,7 @@ CHAR: , delimiter set-global
 <PRIVATE
 
 MEMO: field-delimiters ( delimiter -- field-seps quote-seps )
-    [ "\n" swap prefix ] [ "\"\n" swap prefix ] bi ; inline
+    [ "\r\n" swap prefix ] [ "\r\"\n" swap prefix ] bi ; inline
 
 DEFER: quoted-field,
 
@@ -21,7 +21,8 @@ DEFER: quoted-field,
     [ nip ] [
         {
             { CHAR: "    [ [ CHAR: " , ] when quoted-field, ] }
-            { CHAR: \n   [ ] } ! Error: newline inside string?
+            { CHAR: \n   [ ] } ! Error: cr inside string?
+            { CHAR: \r   [ ] } ! Error: lf inside string?
             [ [ , drop f maybe-escaped-quote ] when* ]
         } case
      ] if ; inline recursive
@@ -85,7 +86,7 @@ PRIVATE>
 <PRIVATE
 
 : needs-escaping? ( cell delimiter -- ? )
-    '[ dup "\n\"" member? [ drop t ] [ _ = ] if ] any? ; inline
+    '[ dup "\n\"\r" member? [ drop t ] [ _ = ] if ] any? ; inline
 
 : escape-quotes ( cell stream -- )
     CHAR: " over stream-write1 swap [


### PR DESCRIPTION
The csv vocab failed on csv files with \r\n line endings (at least for me on windows), like the usa-cities.csv file. The added test shows a csv file that didn't use to parse but now works fine.
