### PR TITLE
benchmark.reverse-complement.tests,mason.report.tests: fix for the test

### DIFF
--- a/extra/benchmark/reverse-complement/reverse-complement-tests.factor
+++ b/extra/benchmark/reverse-complement/reverse-complement-tests.factor
@@ -1,13 +1,9 @@
 IN: benchmark.reverse-complement.tests
-USING: tools.test benchmark.reverse-complement
-checksums checksums.md5
-io.files kernel ;
+USING: benchmark.reverse-complement checksums checksums.md5 io.files
+io.files.temp kernel tools.test ;
 
 [ "c071aa7e007a9770b2fb4304f55a17e5" ] [
     "resource:extra/benchmark/reverse-complement/reverse-complement-test-in.txt"
-    "resource:extra/benchmark/reverse-complement/reverse-complement-test-out.txt"
-    reverse-complement
-
-    "resource:extra/benchmark/reverse-complement/reverse-complement-test-out.txt"
-    md5 checksum-file hex-string
+    "reverse-complement-test-out.txt" temp-file
+    [ reverse-complement ] keep md5 checksum-file hex-string
 ] unit-test

--- a/extra/mason/report/report-tests.factor
+++ b/extra/mason/report/report-tests.factor
@@ -1,6 +1,6 @@
 IN: mason.report.tests
-USING: io.files io.files.temp io.directories kernel mason.report
-mason.common mason.config namespaces tools.test xml xml.writer ;
+USING: io.files io.files.temp io.directories io.directories.hierarchy kernel
+mason.report mason.common mason.config namespaces tools.test xml xml.writer ;
 
 { 0 0 } [ [ ] with-report ] must-infer-as
 
@@ -10,21 +10,24 @@ mason.common mason.config namespaces tools.test xml xml.writer ;
      [ ] [ "report" delete-file ] unit-test ;
 
 "builds" temp-file builds-dir [
-    "resource:extra/mason/report/fake-data/" [
-         [ ] [
-              timings-table pprint-xml
-         ] unit-test
-    
-         [ ] [ successful-report ] unit-test
-         verify-report
-    
-         [ status-error ] [ 1234 compile-failed ] unit-test
-         verify-report
-    
-         [ status-error ] [ 1235 boot-failed ] unit-test
-         verify-report
-    
-         [ status-error ] [ 1236 test-failed ] unit-test
-         verify-report
-    ] with-directory
+    [
+        "resource:extra/mason/report/fake-data/" "." copy-tree
+
+        [ ] [
+            timings-table pprint-xml
+        ] unit-test
+
+        [ ] [ successful-report ] unit-test
+        verify-report
+
+        [ status-error ] [ 1234 compile-failed ] unit-test
+        verify-report
+
+        [ status-error ] [ 1235 boot-failed ] unit-test
+        verify-report
+
+        [ status-error ] [ 1236 test-failed ] unit-test
+        verify-report
+
+    ] with-temp-directory
 ] with-variable


### PR DESCRIPTION
This fixes so that some tests uses temp dirs instead of trying to write to the `resource:`-tree.
