### PR TITLE
tools.deploy.backend: with-variables need to be on the whole block

### DIFF
--- a/basis/tools/deploy/backend/backend.factor
+++ b/basis/tools/deploy/backend/backend.factor
@@ -119,11 +119,14 @@ DEFER: ?make-staging-image
 
 :: make-deploy-image ( vm image vocab config -- manifest )
     make-boot-image
-    config [ bootstrap-profile ?make-staging-image ] with-variables
-    vocab "vocab-manifest-" prepend temp-file :> manifest-file
-    image vocab manifest-file bootstrap-profile deploy-command-line :> flags
-    vm flags run-factor
-    manifest-file parse-vocab-manifest-file ;
+    config [
+        bootstrap-profile :> profile
+        vocab "vocab-manifest-" prepend temp-file :> manifest-file
+        image vocab manifest-file profile deploy-command-line :> flags
+        profile ?make-staging-image
+        vm flags run-factor
+        manifest-file parse-vocab-manifest-file
+    ] with-variables ;
 
 :: make-deploy-image-executable ( vm image vocab config -- manifest )
     vm image vocab config make-deploy-image


### PR DESCRIPTION
The last pr killed a bug but birthed a new one. Sorry bout that. Here is a new commit to fix the error in `make-deploy-image`.
