### PR TITLE
Refactor >list to be a generic word

### DIFF
--- a/basis/lists/lazy/lazy-docs.factor
+++ b/basis/lists/lazy/lazy-docs.factor
@@ -60,7 +60,7 @@ ARTICLE: { "lists.lazy" "manipulation" } "Manipulating lazy lists"
 
 HELP: lazy-cons
 { $values { "car" { $quotation ( -- elt ) } } { "cdr" { $quotation ( -- cons ) } } { "promise" "the resulting cons object" } }
-{ $description "Constructs a cons object for a lazy list from two quotations. The " { $snippet "car" } " quotation should return the head of the list, and the " { $snippet "cons" } " quotation the tail when called. When " { $link cons } " or " { $link cdr } " are called on the lazy-cons object then the appropriate quotation is called." } 
+{ $description "Constructs a cons object for a lazy list from two quotations. The " { $snippet "car" } " quotation should return the head of the list, and the " { $snippet "cons" } " quotation the tail when called. When " { $link cons } " or " { $link cdr } " are called on the lazy-cons object then the appropriate quotation is called." }
 { $see-also cons car cdr nil nil? } ;
 
 { 1lazy-list 2lazy-list 3lazy-list } related-words
@@ -79,7 +79,7 @@ HELP: 3lazy-list
 
 HELP: <memoized-cons>
 { $values { "cons" "a cons object" } { "memoized-cons" "the resulting memoized-cons object" } }
-{ $description "Constructs a cons object that wraps an existing cons object. Requests for the car, cdr and nil? will be remembered after the first call, and the previous result returned on subsequent calls." } 
+{ $description "Constructs a cons object that wraps an existing cons object. Requests for the car, cdr and nil? will be remembered after the first call, and the previous result returned on subsequent calls." }
 { $see-also cons car cdr nil nil? } ;
 
 { lazy-map ltake lfilter lappend lfrom lfrom-by lconcat lcartesian-product lcartesian-product* lcomp lcomp* lmerge lwhile luntil } related-words
@@ -121,11 +121,6 @@ HELP: sequence-tail>list
 { $description "Convert the sequence into a list, starting from " { $snippet "index" } "." }
 { $see-also >list } ;
 
-HELP: >list
-{ $values { "object" object } { "list" "a list" } }
-{ $description "Convert the object into a list. Existing lists are passed through intact, sequences are converted using " { $link sequence-tail>list } " and other objects cause an error to be thrown." } 
-{ $see-also sequence-tail>list } ;
-
 { leach foldl lazy-map ltake lfilter lappend lfrom lfrom-by lconcat lcartesian-product lcartesian-product* lcomp lcomp* lmerge lwhile luntil } related-words
 
 HELP: lconcat
@@ -153,17 +148,17 @@ HELP: lcomp*
 
 HELP: lmerge
 { $values { "list1" "a list" } { "list2" "a list" } { "result" "lazy list merging list1 and list2" } }
-{ $description "Return the result of merging the two lists in a lazy manner." } 
+{ $description "Return the result of merging the two lists in a lazy manner." }
 { $examples
   { $example "USING: lists lists.lazy prettyprint ;" "{ 1 2 3 } >list { 4 5 6 } >list lmerge list>array ." "{ 1 4 2 5 3 6 }" }
 } ;
 
 HELP: lcontents
 { $values { "stream" "a stream" } { "result" string } }
-{ $description "Returns a lazy list of all characters in the file. " { $link car } " returns the next character in the file, " { $link cdr } " returns the remaining characters as a lazy list. " { $link nil? } " indicates end of file." } 
+{ $description "Returns a lazy list of all characters in the file. " { $link car } " returns the next character in the file, " { $link cdr } " returns the remaining characters as a lazy list. " { $link nil? } " indicates end of file." }
 { $see-also llines } ;
 
 HELP: llines
 { $values { "stream" "a stream" } { "result" "a list" } }
-{ $description "Returns a lazy list of all lines in the file. " { $link car } " returns the next lines in the file, " { $link cdr } " returns the remaining lines as a lazy list. " { $link nil? } " indicates end of file." } 
+{ $description "Returns a lazy list of all lines in the file. " { $link car } " returns the next lines in the file, " { $link cdr } " returns the remaining lines as a lazy list. " { $link nil? } " indicates end of file." }
 { $see-also lcontents } ;

--- a/basis/lists/lazy/lazy.factor
+++ b/basis/lists/lazy/lazy.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2004, 2008 Chris Double, Matthew Willis, James Cash.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays combinators io kernel lists math
-promises quotations sequences summary vectors ;
+promises quotations sequences vectors ;
 IN: lists.lazy
 
 M: promise car ( promise -- car )
@@ -12,7 +12,7 @@ M: promise cdr ( promise -- cdr )
 
 M: promise nil? ( cons -- ? )
     force nil? ;
- 
+
 ! Both 'car' and 'cdr' are promises
 TUPLE: lazy-cons-state car cdr ;
 
@@ -241,17 +241,7 @@ M: sequence-cons cdr ( sequence-cons -- cdr )
 M: sequence-cons nil? ( sequence-cons -- ? )
     drop f ;
 
-ERROR: list-conversion-error object ;
-
-M: list-conversion-error summary
-    drop "Could not convert object to list" ;
-
-: >list ( object -- list )
-    {
-        { [ dup sequence? ] [ 0 swap sequence-tail>list ] }
-        { [ dup list? ] [ ] }
-        [ list-conversion-error ]
-    } cond ;
+M: sequence >list 0 swap sequence-tail>list ;
 
 TUPLE: lazy-concat car cdr ;
 
@@ -263,7 +253,7 @@ DEFER: lconcat
     over nil? [ nip lconcat ] [ <lazy-concat> ] if ;
 
 : lconcat ( list -- result )
-    dup nil? [ drop nil ] [ uncons (lconcat) ] if ; 
+    dup nil? [ drop nil ] [ uncons (lconcat) ] if ;
 
 M: lazy-concat car ( lazy-concat -- car )
     car>> car ;

--- a/basis/lists/lists-docs.factor
+++ b/basis/lists/lists-docs.factor
@@ -169,3 +169,6 @@ HELP: lmap>array
 { $values { "list" list } { "quot" quotation } { "array" array } }
 { $description "Executes the quotation on each element of the list, collecting the results in an array." } ;
 
+HELP: >list
+{ $values { "object" object } { "list" "a list" } }
+{ $description "Converts the object into a list." } ;

--- a/basis/lists/lists.factor
+++ b/basis/lists/lists.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2008 James Cash, Daniel Ehrenberg, Chris Double.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: kernel sequences accessors math arrays vectors classes words
-combinators.short-circuit combinators locals ;
+combinators.short-circuit combinators locals summary ;
 IN: lists
 
 ! List Protocol
@@ -9,7 +9,7 @@ MIXIN: list
 GENERIC: car ( cons -- car )
 GENERIC: cdr ( cons -- cdr )
 GENERIC: nil? ( object -- ?   )
-    
+
 TUPLE: cons-state { car read-only } { cdr read-only } ;
 
 C: cons cons-state
@@ -41,9 +41,9 @@ M: object nil? drop f ;
 : 3list ( a b c -- cons ) 2list cons ; inline
 
 : cadr ( list -- elt ) cdr car ; inline
- 
+
 : 2car ( list -- car caar ) [ car ] [ cadr ] bi ; inline
- 
+
 : 3car ( list -- car cadr caddr ) [ car ] [ cadr ] [ cdr cadr ] tri ; inline
 
 : lnth ( n list -- elt ) swap [ cdr ] times car ; inline
@@ -84,14 +84,18 @@ PRIVATE>
     [ [ unswons ] dip cons ] times
     lreverse swap ;
 
-: sequence>list ( sequence -- list )    
+: sequence>list ( sequence -- list )
     <reversed> nil [ swons ] reduce ;
 
 : lmap>array ( ... list quot: ( ... elt -- ... newelt ) -- ... array )
     collector [ leach ] dip { } like ; inline
 
-: list>array ( list -- array )  
+: list>array ( list -- array )
     [ ] lmap>array ;
 
 INSTANCE: cons-state list
 INSTANCE: +nil+ list
+
+GENERIC: >list ( object -- list )
+
+M: list >list ;


### PR DESCRIPTION
This PR aims to make the `>list` conversion word more extensible and consistent with other conversion words, like `>alist`, `>array`, and `>hashtable`. Surprisingly, unlike other conversion words, `>list` doesn't exploit generic dispatch at all - it's hard-coded for lists and sequences using `cond`. So, I moved `>list` from `lists.lazy` to the `lists` vocabulary, made it generic, and added corresponding methods for lists and sequences. These changes don't affect any existing code, since `>list` behaves exactly as before. Both `"lists" test` and `"lists" help-lint` pass successfully.

P.S. I'm sorry for all the trailing whitespaces that have been removed. I have it done automatically by vim.
