### PR TITLE
fuel.eval: wrap fuel-pprint in a without-limits so fuel output isn't tru...

### DIFF
--- a/extra/fuel/eval/eval-tests.factor
+++ b/extra/fuel/eval/eval-tests.factor
@@ -1,4 +1,12 @@
 ! Copyright (C) 2009 Jose Antonio Ortega Ruiz.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: tools.test fuel.eval ;
+USING: fuel.eval io.streams.string math namespaces random.data sequences
+tools.test ;
 IN: fuel.eval.tests
+
+! Make sure prettyprint doesn't limit output.
+
+{ t } [
+    1000 random-string fuel-eval-result set-global
+    [ fuel-send-retort ] with-string-writer length 1000 >
+] unit-test

--- a/extra/fuel/eval/eval.factor
+++ b/extra/fuel/eval/eval.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2009 Jose Antonio Ortega Ruiz.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays continuations debugger fuel.pprint io
-io.streams.string kernel listener namespaces sequences
+io.streams.string kernel listener namespaces prettyprint.config sequences
 vocabs.parser ;
 
 IN: fuel.eval
@@ -52,7 +52,8 @@ t fuel-eval-res-flag set-global
     fuel-eval-error get-global
     fuel-eval-result get-global
     fuel-eval-output get-global 3array
-    fuel-pprint flush nl "<~FUEL~>" write nl flush ;
+    [ fuel-pprint ] without-limits
+    flush nl "<~FUEL~>" write nl flush ;
 
 : (fuel-begin-eval) ( -- )
     fuel-push-status fuel-forget-status ;


### PR DESCRIPTION
This fixes the problem that happened in fuel due to the earlier `string-limit?` fix.
