### PR TITLE
frame-pointer? attribute not needed?

### DIFF
--- a/basis/compiler/cfg/builder/alien/alien.factor
+++ b/basis/compiler/cfg/builder/alien/alien.factor
@@ -48,7 +48,7 @@ IN: compiler.cfg.builder.alien
 
 : caller-parameters ( params -- reg-inputs stack-inputs )
     [ abi>> ] [ parameters>> ] [ return>> ] tri
-    '[ 
+    '[
         _ unbox-parameters
         _ prepare-struct-caller struct-return-area set
         (caller-parameters)
@@ -71,7 +71,7 @@ M: array dlsym-valid? '[ _ dlsym ] any? ;
     {
         { [ dup library-dll dll-valid? not ] [
             [ library-dll dll-path ] [ dlerror>> ] bi
-            cfg get word>> no-such-library-error drop 
+            cfg get word>> no-such-library-error drop
         ] }
         { [ 2dup library-dll dlsym-valid? not ] [
             drop dlerror cfg get word>> no-such-symbol-error
@@ -160,7 +160,7 @@ M: #alien-assembly emit-node
 
 : callee-parameters ( params -- vregs reps reg-outputs stack-outputs )
     [ abi>> ] [ return>> ] [ parameters>> ] tri
-    '[ 
+    '[
         _ prepare-struct-callee struct-return-area set
         _ [ base-type ] map (callee-parameters)
     ] with-param-regs* ;
@@ -176,9 +176,6 @@ M: #alien-assembly emit-node
     [ [ stack-params get ] dip [ return>> ] [ abi>> ] bi stack-cleanup ] bi
     "stack-cleanup" set-word-prop ;
 
-: needs-frame-pointer ( -- )
-    cfg get t >>frame-pointer? drop ;
-
 : emit-callback-body ( nodes -- )
     [ last #return? t assert= ] [ but-last emit-nodes ] bi ;
 
@@ -188,10 +185,7 @@ M: #alien-assembly emit-node
 M: #alien-callback emit-node
     dup params>> xt>> dup
     [
-        needs-frame-pointer
-
         begin-word
-
         {
             [ params>> callee-parameters ##callback-inputs, ]
             [ params>> box-parameters ]

--- a/basis/compiler/cfg/cfg.factor
+++ b/basis/compiler/cfg/cfg.factor
@@ -24,7 +24,6 @@ M: basic-block hashcode* nip id>> ;
 TUPLE: cfg { entry basic-block } word label
 spill-area-size spill-area-align
 stack-frame
-frame-pointer?
 post-order linear-order
 predecessors-valid? dominance-valid? loops-valid? ;
 

--- a/basis/compiler/cfg/linear-scan/linear-scan.factor
+++ b/basis/compiler/cfg/linear-scan/linear-scan.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2008, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: kernel accessors assocs sequences namespaces make locals
-cpu.architecture
+USING: kernel accessors assocs sequences namespaces make
+combinators cpu.architecture
 compiler.cfg
 compiler.cfg.rpo
 compiler.cfg.registers
@@ -31,15 +31,11 @@ IN: compiler.cfg.linear-scan
 
 ! SSA liveness must have been computed already
 
-:: (linear-scan) ( cfg machine-registers -- )
-    cfg number-instructions
-    cfg compute-live-intervals machine-registers allocate-registers
-    cfg assign-registers
-    cfg resolve-data-flow
-    cfg check-numbering ;
-
-: admissible-registers ( cfg -- regs )
-    drop machine-registers ;
-
 : linear-scan ( cfg -- cfg' )
-    dup dup admissible-registers (linear-scan) ;
+    dup {
+        [ number-instructions ]
+        [ compute-live-intervals machine-registers allocate-registers ]
+        [ assign-registers ]
+        [ resolve-data-flow ]
+        [ check-numbering ]
+    } cleave ;


### PR DESCRIPTION
I think the frame-pointer? slot in cfg can be removed and it simplifies the compiler a little as you can see below. Previously it was used to exclude RBP from register allocation in alien callbacks. But why? Maybe that is a remnant from an older Factor version? I've run the changes below with test-all on linux 64 bit and windows 32 bit, and it seem to work. 
