### PR TITLE
python.objects: fix <py-cfunction> need to malloc-struct PyMethodDef

### DIFF
--- a/extra/python/ffi/ffi.factor
+++ b/extra/python/ffi/ffi.factor
@@ -28,7 +28,7 @@ CONSTANT: METH_COEXIST  0x0040
 C-TYPE: PyCFunction
 
 STRUCT: PyMethodDef
-    { ml_name void* }
+    { ml_name c-string }
     { ml_meth PyCFunction* }
     { ml_flags int }
     { ml_doc c-string } ;

--- a/extra/python/objects/objects.factor
+++ b/extra/python/objects/objects.factor
@@ -1,5 +1,5 @@
-USING: alien.c-types alien.data alien.libraries classes.struct kernel
-python.errors python.ffi ;
+USING: accessors alien.c-types alien.data alien.libraries classes.struct
+io.encodings.ascii io.encodings.utf8 kernel libc python.errors python.ffi ;
 IN: python.objects
 
 ! The None object
@@ -68,8 +68,15 @@ IN: python.objects
     dup unsteal-ref PyList_SetItem check-zero ;
 
 ! Functions
+: <PyMethodDef> ( alien name doc/f -- cfunction )
+    PyMethodDef malloc-struct &free
+    swap [ utf8 malloc-string &free >>ml_doc ] when*
+    swap ascii malloc-string &free >>ml_name
+    swap >>ml_meth
+    METH_VARARGS >>ml_flags ;
+
 : <py-cfunction> ( alien -- cfunction )
-    f swap METH_VARARGS f PyMethodDef <struct-boa> f f
+    "cfunction" f <PyMethodDef> f f
     ! It's not clear from the docs whether &Py_DecRef is right for
     ! PyCFunction_NewEx, but I'm betting on it.
     PyCFunction_NewEx check-new-ref ;

--- a/extra/python/python-tests.factor
+++ b/extra/python/python-tests.factor
@@ -1,6 +1,6 @@
 USING: accessors alien arrays assocs calendar continuations destructors
-destructors.private fry kernel math namespaces python python.errors python.ffi
-python.objects sequences strings tools.test ;
+destructors.private fry kernel math memory namespaces python python.errors
+python.ffi python.objects sequences strings tools.test ;
 IN: python
 
 : py-test ( result quot -- )
@@ -151,4 +151,20 @@ IN: python
 ! Modules
 [ t ] [
     "os" py-import PyModule_GetDict dup Py_IncRef &Py_DecRef py-dict-size 100 >
+] py-test
+
+! CFunctions
+{ f } [
+    1234 <alien> <py-cfunction> "__doc__" getattr py>
+] py-test
+
+{ "cfunction" } [
+    1234 <alien> <py-cfunction>
+    ! Force nursery flush
+    10000 [ 1000 0xff <array> drop ] times
+    "__name__" getattr py>
+] py-test
+
+{ 3 } [
+    1234 <alien> <py-cfunction> drop always-destructors get length
 ] py-test


### PR DESCRIPTION
I completely misused the PyMethodDef struct. This patch should fix the callback crashes.
