### PR TITLE
python: both METH_VARARGS METH_KEYWORDS needed in ml_flags should fix #1...

### DIFF
--- a/extra/python/ffi/ffi.factor
+++ b/extra/python/ffi/ffi.factor
@@ -36,6 +36,7 @@ STRUCT: PyMethodDef
 FUNCTION: PyObject* PyCFunction_NewEx ( PyMethodDef* ml,
                                         PyObject* self,
                                         PyObject* module ) ;
+FUNCTION: int PyCFunction_GetFlags ( PyObject* op ) ;
 
 CALLBACK: PyObject* PyCallback ( PyObject* self,
                                  PyObject* args,

--- a/extra/python/objects/objects.factor
+++ b/extra/python/objects/objects.factor
@@ -1,5 +1,6 @@
 USING: accessors alien.c-types alien.data alien.libraries classes.struct
-io.encodings.ascii io.encodings.utf8 kernel libc python.errors python.ffi ;
+io.encodings.ascii io.encodings.utf8 kernel libc math python.errors
+python.ffi ;
 IN: python.objects
 
 ! The None object
@@ -73,7 +74,7 @@ IN: python.objects
     swap [ utf8 malloc-string &free >>ml_doc ] when*
     swap ascii malloc-string &free >>ml_name
     swap >>ml_meth
-    METH_VARARGS >>ml_flags ;
+    METH_VARARGS METH_KEYWORDS bitor >>ml_flags ;
 
 : <py-cfunction> ( alien -- cfunction )
     "cfunction" f <PyMethodDef> f f

--- a/extra/python/python-tests.factor
+++ b/extra/python/python-tests.factor
@@ -154,8 +154,14 @@ IN: python
 ] py-test
 
 ! CFunctions
-{ f } [
-    1234 <alien> <py-cfunction> "__doc__" getattr py>
+{ t } [
+    1234 <alien> "foo" f <PyMethodDef>
+    ml_flags>> METH_VARARGS METH_KEYWORDS bitor =
+] unit-test
+
+{ f 3 } [
+    1234 <alien> <py-cfunction>
+    [ "__doc__" getattr py> ] [ PyCFunction_GetFlags ] bi
 ] py-test
 
 { "cfunction" } [
@@ -168,3 +174,23 @@ IN: python
 { 3 } [
     1234 <alien> <py-cfunction> drop always-destructors get length
 ] py-test
+
+! Callbacks
+: py-map ( -- alien )
+    "__builtin__" py-import "map" getattr ;
+
+: py-map-call ( alien-cb -- seq )
+    [
+        <py-cfunction> py-map swap { 1 2 } >py 2array array>py-tuple f
+        call-object-full
+    ] with-callback py> ;
+
+: always-33-fun ( -- alien )
+    [ 3drop 33 >py ] PyCallback ;
+
+{ V{ 33 33 } } [ always-33-fun py-map-call ] py-test
+
+: id-fun ( -- alien )
+    [ drop nip py> first >py ] PyCallback ;
+
+{ V{ 1 2 } } [ id-fun py-map-call ] py-test


### PR DESCRIPTION
Should fix the callback bug once and for all!
