### PR TITLE
math.parser improvements ?

### DIFF
--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -83,7 +83,7 @@ M: real pprint*
 
 M: float pprint*
     dup fp-nan? [
-        \ NAN: [ fp-nan-payload >hex text ] pprint-prefix
+        \ NAN: [ double>bits >hex text ] pprint-prefix
     ] [
         number-base get {
             { 10 [ number>string text ] }

--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -81,8 +81,11 @@ M: real pprint*
         [ unsupported-number-base ]
     } case ;
 
+: payload-nan? ( f -- ? )
+    dup fp-nan? [ fp-nan-payload 0x8000000000000 = not ] [ drop f ] if ;
+
 M: float pprint*
-    dup fp-nan? [
+    dup payload-nan? [
         \ NAN: [ double>bits >hex text ] pprint-prefix
     ] [
         number-base get {

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -173,7 +173,7 @@ CONSTANT: min-magnitude-2 -1074
     dup first-bignum bignum= [ drop most-negative-fixnum ] [ neg ] if ;
 
 : fp-?neg ( n -- -n )
-    double>bits 63 2^ bitxor bits>double ;
+    double>bits 63 2^ bitor bits>double ;
 
 : ?neg ( n/f -- -n/f )
     [
@@ -183,6 +183,11 @@ CONSTANT: min-magnitude-2 -1074
             [ neg ]
         } cond
     ] [ f ] if* ; inline
+
+: ?pos ( n/f -- +n/f )
+    dup fp-nan? [
+        double>bits 63 2^ bitnot bitand bits>double
+    ] when ; inline
 
 : add-ratio? ( n/f -- ? )
     dup real? [ dup >integer number= not ] [ drop f ] if ;
@@ -222,8 +227,8 @@ DEFER: @neg-digit
 : @exponent-first-char ( float-parse i number-parse n char -- float-parse n/f )
     {
         { CHAR: - [ [ @exponent-digit ] require-next-digit ?neg ] }
-        { CHAR: + [ [ @exponent-digit ] require-next-digit ] }
-        [ @exponent-digit ]
+        { CHAR: + [ [ @exponent-digit ] require-next-digit ?pos ] }
+        [ @exponent-digit ?pos ]
     } case ; inline
 
 : ->exponent ( float-parse i number-parse n -- float-parse' n/f )
@@ -353,8 +358,8 @@ DEFER: @neg-digit
 : @first-char ( i number-parse n char -- n/f )
     {
         { CHAR: - [ [ @neg-first-digit ] require-next-digit ?neg ] }
-        { CHAR: + [ [ @pos-first-digit ] require-next-digit ] }
-        [ @pos-first-digit ]
+        { CHAR: + [ [ @pos-first-digit ] require-next-digit ?pos ] }
+        [ @pos-first-digit ?pos ]
     } case ; inline
 
 : @neg-first-digit-no-radix ( i number-parse n char -- n/f )
@@ -372,8 +377,8 @@ DEFER: @neg-digit
 : @first-char-no-radix ( i number-parse n char -- n/f )
     {
         { CHAR: - [ [ @neg-first-digit-no-radix ] require-next-digit ?neg ] }
-        { CHAR: + [ [ @pos-first-digit-no-radix ] require-next-digit ] }
-        [ @pos-first-digit-no-radix ]
+        { CHAR: + [ [ @pos-first-digit-no-radix ] require-next-digit ?pos ] }
+        [ @pos-first-digit-no-radix ?pos ]
     } case ; inline
 
 PRIVATE>

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -169,12 +169,19 @@ CONSTANT: min-magnitude-2 -1074
         [ make-float-bin-exponent ]
     } cond ;
 
+: bignum-?neg ( n -- -n )
+    dup first-bignum bignum= [ drop most-negative-fixnum ] [ neg ] if ;
+
+: fp-?neg ( n -- -n )
+    double>bits 63 2^ bitxor bits>double ;
+
 : ?neg ( n/f -- -n/f )
     [
-        dup bignum? [
-            dup first-bignum bignum=
-            [ drop most-negative-fixnum ] [ neg ] if
-        ] [ neg ] if
+        {
+            { [ dup bignum? ] [ bignum-?neg ] }
+            { [ dup fp-nan? ] [ fp-?neg ] }
+            [ neg ]
+        } cond
     ] [ f ] if* ; inline
 
 : add-ratio? ( n/f -- ? )

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -177,8 +177,11 @@ CONSTANT: min-magnitude-2 -1074
         ] [ neg ] if
     ] [ f ] if* ; inline
 
+: add-ratio? ( n/f -- ? )
+    dup real? [ dup >integer number= not ] [ drop f ] if ;
+
 : ?add-ratio ( m n/f -- m+n/f )
-    dup ratio? [ + ] [ 2drop f ] if ; inline
+    dup add-ratio? [ + ] [ 2drop f ] if ; inline
 
 : @abort ( i number-parse n x -- f )
     4drop f ; inline

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -572,7 +572,7 @@ PRIVATE>
 
 M: float >base
     {
-        { [ over fp-nan? ] [ 2drop "0/0." ] }
+        { [ over fp-nan? ] [ drop fp-sign "-0/0." "0/0." ? ] }
         { [ over 1/0. =  ] [ 2drop "1/0." ] }
         { [ over -1/0. = ] [ 2drop "-1/0." ] }
         { [ over  0.0 fp-bitwise= ] [ 2drop  "0.0" ] }

--- a/core/syntax/syntax-docs.factor
+++ b/core/syntax/syntax-docs.factor
@@ -56,7 +56,6 @@ ARTICLE: "syntax-ratios" "Ratio syntax"
 { $code
     "75/33"
     "1/10"
-    "-5/-6"
     "1+1/3"
     "-10-1/7"
 }

--- a/core/syntax/syntax-docs.factor
+++ b/core/syntax/syntax-docs.factor
@@ -92,6 +92,22 @@ ARTICLE: "syntax-floats" "Float syntax"
     "1/3. ."
     "0.3333333333333333"
 }
+{ $example
+    "1/0.5 ."
+    "2.0"
+}
+{ $example
+    "1/2.5 ."
+    "0.4"
+}
+{ $example
+    "1+1/2. ."
+    "1.5"
+}
+{ $example
+    "1+1/2.5 ."
+    "1.4"
+}
 "The special float values have their own syntax:"
 { $table
 { "Positive infinity" { $snippet "1/0." } }


### PR DESCRIPTION
Hi,
This pr cleans up the syntax docs which showed "-5/-6" which is not supported anymore (probably since 2009), so I think it's safe to remove it from the docs.

Also, This pr adds support for "1+1/3." to produce the float 1.33333333333 ( we already had support for "1/3." which produces 0.3333333333). Also add in the docs examples like 1/2.5 or 1+1/2.5 for 0.4 and 1.4

I was thinking of more changes but wanted to discuss first:
- string>number throws an exception for 1/0, but returns f for other invalid strings. Should it also return f for 1/0? Or just add a note in the doc that this will throw an exception?
- Should the following be parsed as numbers ?
  - "1+1"
  - "1+1."
  - "1+1/1"
  - "1+1/0."
  - "1+1/."
  - "1+2/1" 
  - "1+2/2"
  - "1+5/2"

My first thought was to only allow the part after "+" to be >0 and <1, but for compatibility with the previous check ("ratio?"), I did "dup >integer number= not"
cheers,
Jon
