### PR TITLE
prettyprinter, locale independant float printing

### DIFF
--- a/basis/calendar/format/format.factor
+++ b/basis/calendar/format/format.factor
@@ -150,7 +150,7 @@ M: timestamp year. ( timestamp -- )
 ! Should be enough for anyone, allows to not do a fancy
 ! algorithm to detect infinite decimals (e.g 1/3)
 : ss.SSSSSS ( timestamp -- )
-    second>> >float "%09.6f" format-float write ;
+    second>> >float "0" 9 6 "f" "C" format-float write ;
 
 : (timestamp>rfc3339) ( timestamp -- )
     {

--- a/basis/formatting/formatting-docs.factor
+++ b/basis/formatting/formatting-docs.factor
@@ -139,7 +139,7 @@ HELP: strftime
 } ;
 
 ARTICLE: "formatting" "Formatted printing"
-"The " { $vocab-link "formatting" } " vocabulary is used for formatted printing."
+"The " { $vocab-link "formatting" } " vocabulary is used for english formatted printing."
 { $subsections
     printf
     sprintf

--- a/basis/formatting/formatting.factor
+++ b/basis/formatting/formatting.factor
@@ -30,8 +30,7 @@ IN: formatting
     [ 0 ] [ string>number ] if-empty ;
 
 : format-simple ( x digits string -- string )
-    [ [ >float ] [ number>string ] bi* "%." ] dip
-    surround format-float ;
+    [ >float "" -1 ] 2dip "" format-float ;
 
 : format-scientific ( x digits -- string ) "e" format-simple ;
 

--- a/basis/formatting/formatting.factor
+++ b/basis/formatting/formatting.factor
@@ -30,7 +30,7 @@ IN: formatting
     [ 0 ] [ string>number ] if-empty ;
 
 : format-simple ( x digits string -- string )
-    [ >float "" -1 ] 2dip "" format-float ;
+    [ >float "" -1 ] 2dip "C" format-float ;
 
 : format-scientific ( x digits -- string ) "e" format-simple ;
 

--- a/basis/stack-checker/known-words/known-words.factor
+++ b/basis/stack-checker/known-words/known-words.factor
@@ -420,7 +420,7 @@ M: object infer-call* \ call bad-macro-input ;
     { fixnum>float { fixnum } { float } }
 
     ! float
-    { (format-float) { float byte-array } { byte-array } }
+    { (format-float) { float byte-array fixnum fixnum byte-array byte-array } { byte-array } }
     { bits>float { integer } { float } }
     { float* { float float } { float } }
     { float+ { float float } { float } }

--- a/core/bootstrap/primitives.factor
+++ b/core/bootstrap/primitives.factor
@@ -476,7 +476,7 @@ tuple
     { "bits>float" "math" "primitive_bits_float" ( n -- x ) }
     { "double>bits" "math" "primitive_double_bits" ( x -- n ) }
     { "float>bits" "math" "primitive_float_bits" ( x -- n ) }
-    { "(format-float)" "math.parser.private" "primitive_format_float" ( n format -- byte-array ) }
+    { "(format-float)" "math.parser.private" "primitive_format_float" ( n fill width precision format locale -- byte-array ) }
     { "bignum*" "math.private" "primitive_bignum_multiply" ( x y -- z ) }
     { "bignum+" "math.private" "primitive_bignum_add" ( x y -- z ) }
     { "bignum-" "math.private" "primitive_bignum_subtract" ( x y -- z ) }

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -488,12 +488,13 @@ M: ratio >base
 
 <PRIVATE
 
-: fix-float ( str exponent -- newstr )
-    2dup first swap member? [
-         [ [ split1 ] keep swap [ fix-float ] dip ] [ glue ] bi
-    ] [
-        drop CHAR: . over member? [ ".0" append ] unless
-    ] if ;
+: (fix-float) ( str-no-exponent -- newstr )
+    CHAR: . over member? [ ".0" append ] unless ; inline
+
+: fix-float ( str exponent-char -- newstr )
+    over index [
+        cut [ (fix-float) ] dip append
+    ] [ (fix-float) ] if* ; inline
 
 : mantissa-expt-normalize ( mantissa expt -- mantissa' expt' )
     [ dup log2 52 swap - [ shift 52 2^ 1 - bitand ] [ 1022 + neg ] bi ]
@@ -553,7 +554,8 @@ M: ratio >base
         [ format-string ] 4dip [ format-string ] bi@ (format-float)
         dup [ 0 = ] find drop format-head
     ] [
-        "C" = [ [ "G" = ] [ "E" = ] bi or "E" "e" ? fix-float ] [ drop ] if
+        "C" = [ [ "G" = ] [ "E" = ] bi or CHAR: E CHAR: e ? fix-float ]
+        [ drop ] if
     ] 2bi ; inline
 
 : float>base ( n radix -- str )

--- a/vm/math.cpp
+++ b/vm/math.cpp
@@ -1,6 +1,7 @@
 #include "master.hpp"
 #include <sstream>
 #include <iomanip>
+#include <stdexcept>
 
 namespace factor {
 
@@ -220,7 +221,14 @@ void factor_vm::primitive_format_float() {
   char* fill = alien_offset(ctx->pop());
   double value = untag_float_check(ctx->peek());
   std::ostringstream localized_stream;
-  localized_stream.imbue(std::locale(locale));
+  try {
+    localized_stream.imbue(std::locale(locale));
+  } catch (const runtime_error& error) {
+    byte_array* array = allot_byte_array(1);
+    array->data<char>()[0] = '\0';
+    ctx->replace(tag<byte_array>(array));
+    return;
+  }
   switch (format[0]) {
     case 'f': localized_stream << std::fixed; break;
     case 'e': localized_stream << std::scientific; break;


### PR DESCRIPTION
Hi,
this pr fixes the float printing https://github.com/slavapestov/factor/issues/1044
it changes the following:
- add a new primitive  (so need to bootstrap) format-float-C that always uses the C locale by using c++ stringstreams. The formatting is passed by parameters instead of a format string. use the new primitive in math.parser and calendar.format
- remove "fix-float" from the previous format-float because it would specifically look for the "." separator which doesn't work for some locales. the formatting vocabulary still uses format-float so is correctly locale dependant, but the output my differ a bit from before since we don't fix-float, so 2.0 can print as 2 depending on the format string.

What do you think ?