### PR TITLE
Numbers2

### DIFF
--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -82,7 +82,7 @@ M: real pprint*
 
 M: float pprint*
     dup fp-nan? [
-        \ NAN: [ fp-nan-payload >hex text ] pprint-prefix
+        \ NAN: [ double>bits >hex text ] pprint-prefix
     ] [
         number-base get {
             { 16 [ [ >hex ] "0x" pprint-prefixed-number ] }

--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -82,7 +82,11 @@ M: real pprint*
 
 M: float pprint*
     dup fp-nan? [
-        \ NAN: [ double>bits >hex text ] pprint-prefix
+        dup fp-nan-payload 50 2^ 1 - bitand 0 = [
+           fp-sign "-0/0." "0/0." ? text
+        ] [
+           \ NAN: [ double>bits >hex text ] pprint-prefix
+        ] if
     ] [
         number-base get {
             { 16 [ [ >hex ] "0x" pprint-prefixed-number ] }

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -41,7 +41,8 @@ TUPLE: number-parse
     digit> pick radix>> over > ; inline
 
 : ?make-ratio ( num denom/f -- ratio/f )
-    [ / ] [ drop f ] if* ; inline
+    ! don't use number= to allow 0. for "1/0."
+    [ dup 0 = [ 2drop f ] [ / ] if ] [ drop f ] if* ; inline
 
 TUPLE: float-parse
     { radix fixnum read-only }


### PR DESCRIPTION
More changes to math.parser. We can cherry-pick the commits we want.
- 78d9c873516293d534cc9291b008dfcdb84eee88 removes the 0 division exception and outputs f instead for consistency. Not sure if that's good or not
- 6a95b098eb14b6fa9b09fa83017de024b6271567 allows to see the sign of NaNs by printing the full 64 bits instead of only the 52 lsb. The added msb are either "7ff" (positive nan) or "fff" (negative nan). Also before this patch, "NAN: 1" printed as "NAN: 1", but now we will always see the much longer form "NAN: 7ff0000000000001".
- 78d9c873516293d534cc9291b008dfcdb84eee88 tries to make some NaNs nicer by printing "0/0." or "-0/0." when the payload 50 lsb bits are 0. These are the NaNs returned by most standard functions or cpu instructions (for example the sse DIVSD instruction) , but the sign is totally unreliable:
  - "0/0." and "-1 fsqrt" return "-0/0" (hex 0xfff8000000000000)
  - -1 flog returns "0/0." (hex 0x7ff8000000000000)
    So I think 78d9c873516293d534cc9291b008dfcdb84eee88 can't be merged yet because "0/0." outputting "-0/0." breaks homoiconicity. Maybe we can just special case "0/0." to be "NAN: 7ff8000000000000"; Or we can ignore the sign when printing "0/0.". I think I prefer the first solution to avoid prettyprintg "NAN: 7ff8000000000000" and "NAN: fff8000000000000" the same way.

What do you think ?
