### PR TITLE
Remove sub-primitive wrapper words in threads.private?

### DIFF
--- a/basis/bootstrap/assembler/ppc.factor
+++ b/basis/bootstrap/assembler/ppc.factor
@@ -793,7 +793,7 @@ IN: bootstrap.ppc
     3 jit-switch-context
     jit-push-param ;
 
-[ jit-set-context ] \ (set-context) define-sub-primitive
+[ jit-set-context ] \ set-context define-sub-primitive
 
 : jit-pop-quot-and-param ( -- )
     3 ds-reg 0 jit-load-cell
@@ -815,7 +815,7 @@ IN: bootstrap.ppc
     jit-push-param
     jit-jump-quot ;
 
-[ jit-start-context ] \ (start-context) define-sub-primitive
+[ jit-start-context ] \ start-context define-sub-primitive
 
 : jit-delete-current-context ( -- )
     jit-load-context
@@ -825,7 +825,7 @@ IN: bootstrap.ppc
 [
     jit-delete-current-context
     jit-set-context
-] \ (set-context-and-delete) define-sub-primitive
+] \ set-context-and-delete define-sub-primitive
 
 : jit-start-context-and-delete ( -- )
     jit-save-context
@@ -842,6 +842,6 @@ IN: bootstrap.ppc
 
 [
     jit-start-context-and-delete
-] \ (start-context-and-delete) define-sub-primitive
+] \ start-context-and-delete define-sub-primitive
 
 [ "bootstrap.ppc" forget-vocab ] with-compilation-unit

--- a/basis/bootstrap/assembler/x86.32.factor
+++ b/basis/bootstrap/assembler/x86.32.factor
@@ -302,7 +302,7 @@ IN: bootstrap.x86
     ds-reg 4 ADD
     ds-reg [] EDX MOV ;
 
-[ jit-set-context ] \ (set-context) define-sub-primitive
+[ jit-set-context ] \ set-context define-sub-primitive
 
 : jit-save-quot-and-param ( -- )
     EDX ds-reg MOV
@@ -338,7 +338,7 @@ IN: bootstrap.x86
     EAX EDX [] MOV
     jit-jump-quot ;
 
-[ jit-start-context ] \ (start-context) define-sub-primitive
+[ jit-start-context ] \ start-context define-sub-primitive
 
 : jit-delete-current-context ( -- )
     jit-load-vm
@@ -348,7 +348,7 @@ IN: bootstrap.x86
 [
     jit-delete-current-context
     jit-set-context
-] \ (set-context-and-delete) define-sub-primitive
+] \ set-context-and-delete define-sub-primitive
 
 : jit-start-context-and-delete ( -- )
     jit-load-vm
@@ -376,4 +376,4 @@ IN: bootstrap.x86
 
 [
     jit-start-context-and-delete
-] \ (start-context-and-delete) define-sub-primitive
+] \ start-context-and-delete define-sub-primitive

--- a/basis/bootstrap/assembler/x86.64.factor
+++ b/basis/bootstrap/assembler/x86.64.factor
@@ -277,7 +277,7 @@ IN: bootstrap.x86
     RSP 8 ADD
     jit-push-param ;
 
-[ jit-set-context ] \ (set-context) define-sub-primitive
+[ jit-set-context ] \ set-context define-sub-primitive
 
 : jit-pop-quot-and-param ( -- )
     arg1 ds-reg [] MOV
@@ -297,7 +297,7 @@ IN: bootstrap.x86
     jit-push-param
     jit-jump-quot ;
 
-[ jit-start-context ] \ (start-context) define-sub-primitive
+[ jit-start-context ] \ start-context define-sub-primitive
 
 : jit-delete-current-context ( -- )
     vm-reg "delete_context" jit-call-1arg ;
@@ -305,7 +305,7 @@ IN: bootstrap.x86
 [
     jit-delete-current-context
     jit-set-context
-] \ (set-context-and-delete) define-sub-primitive
+] \ set-context-and-delete define-sub-primitive
 
 ! Resets the active context and instead the passed in quotation
 ! becomes the new code that it executes.
@@ -333,4 +333,4 @@ IN: bootstrap.x86
 
 [
     jit-start-context-and-delete
-] \ (start-context-and-delete) define-sub-primitive
+] \ start-context-and-delete define-sub-primitive

--- a/basis/stack-checker/known-words/known-words.factor
+++ b/basis/stack-checker/known-words/known-words.factor
@@ -292,11 +292,11 @@ M: object infer-call* \ call bad-macro-input ;
 \ (fopen) { byte-array byte-array } { alien } define-primitive
 \ (identity-hashcode) { object } { fixnum } define-primitive
 \ (save-image) { byte-array byte-array object } { } define-primitive
-\ (set-context) { object alien } { object } define-primitive
-\ (set-context-and-delete) { object alien } { } define-primitive
+\ set-context { object alien } { object } define-primitive
+\ set-context-and-delete { object alien } { } define-primitive
 \ (sleep) { integer } { } define-primitive
-\ (start-context) { object quotation } { object } define-primitive
-\ (start-context-and-delete) { object quotation } { } define-primitive
+\ start-context { object quotation } { object } define-primitive
+\ start-context-and-delete { object quotation } { } define-primitive
 \ (word) { object object object } { word } define-primitive \ (word) make-flushable
 \ <array> { integer object } { array } define-primitive \ <array> make-flushable
 \ <byte-array> { integer } { byte-array } define-primitive \ <byte-array> make-flushable

--- a/basis/threads/threads.factor
+++ b/basis/threads/threads.factor
@@ -9,34 +9,19 @@ FROM: assocs => change-at ;
 IN: threads
 
 <PRIVATE
-PRIMITIVE: (set-context) ( obj context -- obj' )
-PRIMITIVE: (set-context-and-delete) ( obj context -- * )
+PRIMITIVE: set-context ( obj context -- obj' )
+PRIMITIVE: set-context-and-delete ( obj context -- * )
 PRIMITIVE: (sleep) ( nanos -- )
-PRIMITIVE: (start-context) ( obj quot -- obj' )
-PRIMITIVE: (start-context-and-delete) ( obj quot -- * )
+PRIMITIVE: start-context ( obj quot: ( obj -- * ) -- obj' )
+PRIMITIVE: start-context-and-delete ( obj quot: ( obj -- * ) -- * )
 PRIMITIVE: callstack-for ( context -- array )
 PRIMITIVE: context-object-for ( n context -- obj )
 PRIMITIVE: datastack-for ( context -- array )
 PRIMITIVE: retainstack-for ( context -- array )
 
-! Wrap sub-primitives; we don't want them inlined into callers
-! since their behavior depends on what frames are on the callstack
 : context ( -- context )
     CONTEXT-OBJ-CONTEXT context-object ; inline
 
-: set-context ( obj context -- obj' )
-    (set-context) ; inline
-
-: start-context ( obj quot: ( obj -- * ) -- obj' )
-    (start-context) ; inline
-
-: set-context-and-delete ( obj context -- * )
-    (set-context-and-delete) ; inline
-
-: start-context-and-delete ( obj quot: ( obj -- * ) -- * )
-    (start-context-and-delete) ; inline
-
-! Context introspection
 : namestack-for ( context -- namestack )
     [ CONTEXT-OBJ-NAMESTACK ] dip context-object-for ;
 

--- a/core/bootstrap/primitives.factor
+++ b/core/bootstrap/primitives.factor
@@ -375,10 +375,10 @@ tuple
     { "fixnum>" "math.private" ( x y -- ? ) }
     { "fixnum>=" "math.private" ( x y -- ? ) }
     { "string-nth-fast" "strings.private" ( n string -- ch ) }
-    { "(set-context)" "threads.private" ( obj context -- obj' ) }
-    { "(set-context-and-delete)" "threads.private" ( obj context -- * ) }
-    { "(start-context)" "threads.private" ( obj quot -- obj' ) }
-    { "(start-context-and-delete)" "threads.private" ( obj quot -- * ) }
+    { "set-context" "threads.private" ( obj context -- obj' ) }
+    { "set-context-and-delete" "threads.private" ( obj context -- * ) }
+    { "start-context" "threads.private" ( obj quot: ( obj -- * ) -- obj' ) }
+    { "start-context-and-delete" "threads.private" ( obj quot: ( obj -- * ) -- * ) }
 } [ first3 make-sub-primitive ] each
 
 ! Primitive words


### PR DESCRIPTION
Inside `threads.private` are these "simple" primitive definitions with a warning that we need to have these primitives wrapped in an inline word that calls them:

``` factor
PRIMITIVE: (set-context) ( obj context -- obj' )
PRIMITIVE: (set-context-and-delete) ( obj context -- * )
PRIMITIVE: (start-context) ( obj quot -- obj' )
PRIMITIVE: (start-context-and-delete) ( obj quot -- * )

! Wrap sub-primitives; we don't want them inlined into callers
! since their behavior depends on what frames are on the callstack

: set-context ( obj context -- obj' )
    (set-context) ; inline

: start-context ( obj quot: ( obj -- * ) -- obj' )
    (start-context) ; inline

: set-context-and-delete ( obj context -- * )
    (set-context-and-delete) ; inline

: start-context-and-delete ( obj quot: ( obj -- * ) -- * )
    (start-context-and-delete) ; inline
```

Is this still needed?  I removed the aliases and renamed the words (like `(set-context)` becomes `set-context`) and the tests seem to pass.

How would I test for the problem the warning is describing?
