### PR TITLE
math.parser: support >base for byte-array

### DIFF
--- a/core/math/parser/parser-tests.factor
+++ b/core/math/parser/parser-tests.factor
@@ -224,6 +224,7 @@ unit-test
 { "0.0" } [ 0.0 >hex ] unit-test
 { "1.0p-1074" } [ 1 bits>double >hex ] unit-test
 { "-0.0" } [ -0.0 >hex ] unit-test
+[ "deadbeef" ] [ B{ 222 173 190 239 } >hex ] unit-test
 
 { "1.0p0" } [ 1.0 >bin ] unit-test
 { "1.1p2" } [ 6.0 >bin ] unit-test

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -486,6 +486,9 @@ M: ratio >base
         [ drop "+" glue ]
     } case ;
 
+M: byte-array >base
+    [ >base ] curry { } map-as concat ;
+
 <PRIVATE
 
 : fix-float ( str -- newstr )


### PR DESCRIPTION
Hey! I've added byte-array support to math.parser >base, so now I can do things like:
"license.txt" sha-256 checksum-file >hex .

Please, let me know if it was a bad idea, otherwise please pull.

Also, I was only able to test this on my older Factor installation v0.96, because that's the latest stable release that works in Windows.