### PR TITLE
Fix incorrect alien.syntax documentation for FUNCTION:

### DIFF
--- a/basis/alien/syntax/syntax-docs.factor
+++ b/basis/alien/syntax/syntax-docs.factor
@@ -26,7 +26,7 @@ HELP: LIBRARY:
 { $notes "Logical library names are defined with the " { $link add-library } " word." } ;
 
 HELP: FUNCTION:
-{ $syntax "FUNCTION: return name ( parameters ) ;" }
+{ $syntax "FUNCTION: return name ( parameters )" }
 { $values { "return" "a C return type" } { "name" "a C function name" } { "parameters" "a comma-separated sequence of type/name pairs; " { $snippet "type1 arg1, type2 arg2, ..." } } }
 { $description "Defines a new word " { $snippet "name" } " which calls the C library function with the same " { $snippet "name" } " in the logical library given by the most recent " { $link POSTPONE: LIBRARY: } " declaration."
 $nl
@@ -40,17 +40,12 @@ $nl
 }
 "You can define a word for invoking it:"
 { $unchecked-example
-    "LIBRARY: foo\nFUNCTION: void the_answer ( c-string question, int value ) ;"
+    "LIBRARY: foo\nFUNCTION: void the_answer ( c-string question, int value )"
     "\"the question\" 42 the_answer"
     "The answer to the question is 42."
 } }
 "Using the " { $link c-string } " type instead of " { $snippet "char*" } " causes the FFI to automatically convert Factor strings to C strings. See " { $link "c-strings" } " for more information on using strings with the FFI."
-{ $notes "Note that the parentheses and commas are only syntax sugar and can be omitted; they serve no purpose other than to make the declaration easier to read. The following definitions are equivalent:"
-{ $code
-    "FUNCTION: void glHint ( GLenum target, GLenum mode ) ;"
-    "FUNCTION: void glHint GLenum target GLenum mode ;"
-}
-"To make a Factor word with a name different from the C function, use " { $link POSTPONE: FUNCTION-ALIAS: } "." } ;
+{ $notes "To make a Factor word with a name different from the C function, use " { $link POSTPONE: FUNCTION-ALIAS: } "." } ;
 
 HELP: FUNCTION-ALIAS:
 { $syntax "FUNCTION-ALIAS: factor-name


### PR DESCRIPTION
The library docs indicate that you need a semicolon at the end of
a `FUNCTION:` definition, but that's actually a syntax error. Likewise,
while the parentheses and commas may at one point have been optional,
they emphatically aren't anymore. This patch brings the documentation in
line with the code.