### PR TITLE
openssl: only set RSA keys if required to do so

### DIFF
--- a/basis/io/sockets/secure/openssl/openssl.factor
+++ b/basis/io/sockets/secure/openssl/openssl.factor
@@ -123,17 +123,21 @@ TUPLE: rsa < disposable handle ;
 
 M: rsa dispose* handle>> RSA_free ;
 
+: needs-rsa-key ( ctx -- ? )
+    handle>> SSL_CTX_need_tmp_rsa 0 = not ; inline
+
 : generate-eph-rsa-key ( ctx -- )
-    [ handle>> ]
-    [| ctx |
-        RSA_new :> rsa-struct
-            rsa-struct
-            ctx config>> ephemeral-key-bits>>
-            RSA_F4 number>bn &BN_clear_free
-            f RSA_generate_key_ex
-        ssl-error rsa-struct <rsa> &dispose handle>>
-    ] bi
-    SSL_CTX_set_tmp_rsa ssl-error ;
+    dup needs-rsa-key [
+        [ handle>> ]
+        [| ctx |
+            RSA_new :> rsa-struct
+                rsa-struct
+                ctx config>> ephemeral-key-bits>>
+                RSA_F4 number>bn &BN_clear_free
+                f RSA_generate_key_ex
+            ssl-error rsa-struct <rsa> &dispose handle>>
+        ] bi
+    SSL_CTX_set_tmp_rsa ssl-error ] [ drop ] if ;
 
 : <openssl-context> ( config ctx -- context )
     openssl-context new-disposable

--- a/basis/openssl/libssl/libssl.factor
+++ b/basis/openssl/libssl/libssl.factor
@@ -410,6 +410,9 @@ FUNCTION: void SSL_CTX_set_tmp_rsa_callback ( SSL_CTX* ctx, void* rsa )
 
 FUNCTION: void* BIO_f_ssl (  )
 
+: SSL_CTX_need_tmp_rsa ( ctx -- n )
+    SSL_CTRL_NEED_TMP_RSA 0 f SSL_CTX_ctrl ;
+
 : SSL_CTX_set_tmp_rsa ( ctx rsa -- n )
     [ SSL_CTRL_SET_TMP_RSA 0 ] dip SSL_CTX_ctrl ;
 


### PR DESCRIPTION
Modern OpenSSL and LibreSSL both do not require SSL_CTX_set_tmp_rsa to be called unless SSL_CTX_need_tmp_rsa returns true, and LibreSSL and OpenSSL compiled with deprecation warnings both will fail if this happens. This commit resolves that.

With this change, it becomes possible to use LibreSSL in place of OpenSSL with Factor.