### PR TITLE
Allow specifying vocabulary roots on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Common arguments:
         -run=ui.tools    run Factor development UI
     -e=<code>        evaluate <code>
     -no-user-init    suppress loading of .factor-rc
+    -roots=<paths>   a list of path-delimited extra vocab roots
 
 Enter
     "command-line" help

--- a/basis/command-line/command-line-tests.factor
+++ b/basis/command-line/command-line-tests.factor
@@ -30,3 +30,7 @@ IN: command-line
     { "factor" "-foo" "a" "b" "c" } parse-command-line
     executable get script get command-line get
 ] unit-test
+
+{ "a:b:c" } [ { "factor" "-roots=a:b:c" } parse-command-line
+    "roots" get-global
+] unit-test

--- a/basis/command-line/command-line.factor
+++ b/basis/command-line/command-line.factor
@@ -48,6 +48,10 @@ SYMBOL: command-line
         ".factor-roots" rc-path dup exists? [
             utf8 file-lines harvest [ add-vocab-root ] each
         ] [ drop ] if
+        "roots" get [
+            os windows? ";" ":" ?
+            split [ add-vocab-root ] each
+        ] when*
     ] when ;
 
 : var-param ( name value -- ) swap set-global ;

--- a/basis/command-line/startup/startup.factor
+++ b/basis/command-line/startup/startup.factor
@@ -27,6 +27,7 @@ Common arguments:
     -fep                enter fep mode immediately
     -nosignals          turn off OS signal handling
     -console            open console if possible
+    -roots=<paths>      a list of \"" write os windows? ";" ":" ? write "\"-delimited extra vocab roots
 
 Enter
     \"command-line\" help


### PR DESCRIPTION
Fixes #1498