### PR TITLE
Make VSC work on OS X again

### DIFF
--- a/basis/editors/visual-studio-code/visual-studio-code.factor
+++ b/basis/editors/visual-studio-code/visual-studio-code.factor
@@ -20,7 +20,7 @@ MEMO: visual-studio-code-invocation ( -- array )
     ] unless* ;
 
 M: macosx find-visual-studio-code-invocation
-    { "open" "-n" "-b" "-r" "com.microsoft.VSCode" "--args" } ;
+    { "open" "-b" "com.microsoft.VSCode" "--args" } ;
 
 ERROR: can't-find-visual-studio-code ;
 


### PR DESCRIPTION
`-r` isn't an argument to `open`, and `-n` seems exactly the opposite of what we want in most circumstances.