### PR TITLE
Switch Chloe, and lots of our other HTML assets, from XHTML to HTML5

### DIFF
--- a/basis/html/html.factor
+++ b/basis/html/html.factor
@@ -1,13 +1,17 @@
 ! Copyright (C) 2004, 2009 Chris Double, Daniel Ehrenberg,
 ! Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: kernel xml.data xml.writer xml.syntax urls.encoding ;
+USING: accessors kernel xml.data xml.writer xml.syntax 
+urls.encoding ;
 IN: html
+
+TUPLE: empty-prolog < prolog ;
+M: empty-prolog write-xml drop ;
+: <empty-prolog> ( -- prolog ) \ empty-prolog new ;
 
 : simple-page ( title head body -- xml )
     <XML
-        <?xml version="1.0"?>
-        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+        <!DOCTYPE html>
         <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
             <head>
                 <title><-></title>
@@ -15,7 +19,7 @@ IN: html
             </head>
             <body><-></body>
         </html>
-    XML> ;
+    XML> <empty-prolog> >>prolog ;
 
 : render-error ( message -- xml )
     [XML <span class="error"><-></span> XML] ;

--- a/basis/html/templates/chloe/chloe-tests.factor
+++ b/basis/html/templates/chloe/chloe-tests.factor
@@ -10,7 +10,7 @@ IN: html.templates.chloe.tests
 
 : run-template ( quot -- string )
     with-string-writer [ "\r\n\t" member? ] reject
-    "?>" split1 nip ; inline
+    [ CHAR: \s = ] trim ; inline
 
 : test-template ( name -- template )
     "vocab:html/templates/chloe/test/"

--- a/basis/html/templates/chloe/compiler/compiler.factor
+++ b/basis/html/templates/chloe/compiler/compiler.factor
@@ -176,9 +176,7 @@ ERROR: unknown-chloe-tag tag ;
 
 : compile-prologue ( xml -- )
     [
-        [ prolog>> [ write-xml ] [code-with] ]
-        [ before>> compile-chunk ]
-        bi
+        before>> compile-chunk
     ] compile-quot
     [ if-not-nested ] [code] ;
 

--- a/basis/xml/writer/writer.factor
+++ b/basis/xml/writer/writer.factor
@@ -142,9 +142,10 @@ M: public-id write-xml
 
 M: doctype-decl write-xml
     ?indent "<!DOCTYPE " write
-    [ name>> write bl ]
-    [ external-id>> [ write-xml bl ] when* ]
-    [ internal-subset>> write-internal-subset ">" write ] tri ;
+    [ name>> write ]
+    [ external-id>> [ bl write-xml ] when* ]
+    [ internal-subset>> [ bl write-internal-subset ] when* ] tri
+    ">" write ;
 
 M: directive write-xml
     "<!" write text>> write CHAR: > write1 nl ;

--- a/extra/webapps/calculator/calculator.xml
+++ b/extra/webapps/calculator/calculator.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' ?>
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
-
 <html>
 	<head> <title>Calculator</title> </head>
 

--- a/extra/webapps/counter/counter.xml
+++ b/extra/webapps/counter/counter.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' ?>
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
-
 <html>
 	<body>
 		<h1><t:label t:name="counter" /></h1>

--- a/extra/webapps/help/search.xml
+++ b/extra/webapps/help/search.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' ?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/extra/webapps/ip/ip.xml
+++ b/extra/webapps/ip/ip.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' ?>
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 <html>
 	<body>Your IP address is: <t:label t:name="ip" />

--- a/extra/webapps/mason/download-package.xml
+++ b/extra/webapps/mason/download-package.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' ?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 

--- a/extra/webapps/mason/download-release.xml
+++ b/extra/webapps/mason/download-release.xml
@@ -1,8 +1,5 @@
 <?xml version='1.0' ?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 
 	<t:title>Factor binary package for <t:label t:name="platform" /></t:title>

--- a/extra/webapps/todo/todo.xml
+++ b/extra/webapps/todo/todo.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' ?>
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
-
 <html>
 
 	<t:style t:include="resource:extra/webapps/todo/todo.css" />

--- a/extra/websites/concatenative/page.xml
+++ b/extra/websites/concatenative/page.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' ?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 	<t:chloe xmlns:t="http://factorcode.org/chloe/1.0">


### PR DESCRIPTION
This converts Chloe fully to generate HTML5, not XHTML. The changes are fairly minor; mostly it's adding `<!DOCTYPE html>` to a bunch of the built-in apps, and killing the existing XML prolog generation.