### PR TITLE
fix confusing typo in "?" docs

### DIFF
--- a/core/kernel/kernel-docs.factor
+++ b/core/kernel/kernel-docs.factor
@@ -142,7 +142,7 @@ HELP: clone
 { $contract "Outputs a new object equal to the given object. This is not guaranteed to actually copy the object; it does nothing with immutable objects, and does not copy words either. However, sequences and tuples can be cloned to obtain a shallow copy of the original." } ;
 
 HELP: ?
-{ $values { "?" "a generalized boolean" } { "true" object } { "false" object } { "true/false" "one two input objects" } }
+{ $values { "?" "a generalized boolean" } { "true" object } { "false" object } { "true/false" "one of two input objects" } }
 { $description "Chooses between two values depending on the boolean value of " { $snippet "cond" } "." } ;
 
 HELP: boolean


### PR DESCRIPTION
I was reading the docs about `?` to refresh my memory, and it took me a second to understand what was meant by `one two input objects`:

![onetwo](https://cloud.githubusercontent.com/assets/3238748/13905292/333e1412-ee92-11e5-8213-8d08dd05dfd5.png)

