### PR TITLE
Increased font size in help

### DIFF
--- a/basis/help/stylesheet/stylesheet.factor
+++ b/basis/help/stylesheet/stylesheet.factor
@@ -19,10 +19,13 @@ IN: help.stylesheet
 : font-size-heading ( -- n )
     4/3 default-font-size * >integer ;
 
+: font-size-span ( -- n )
+    13/12 default-font-size * >integer ;
+
 SYMBOL: default-span-style
 H{
     { font-name $ default-sans-serif-font-name }
-    { font-size $ default-font-size }
+    { font-size $ font-size-span }
     { font-style plain }
 } default-span-style set-global
 


### PR DESCRIPTION
Something I had forgotten to do last summer. I found text in the help browser very small, and this makes it more readable.