### PR TITLE
Atom package: update paths

### DIFF
--- a/misc/atom/README.md
+++ b/misc/atom/README.md
@@ -4,11 +4,11 @@ This is a syntax highlighting package for Factor.
 
 You can install this by copying this folder to:
 
-  cp -r /path/to/factor/mis/atom ~/.atom/languages-factor
+  cp -r /path/to/factor/misc/atom ~/.atom/packages/language-factor
 
 Or symlinking it:
 
-  ln -sf /path/to/factor/misc/atom ~/.atom/languages-factor
+  ln -sf /path/to/factor/misc/atom ~/.atom/packages/language-factor
 
 This was initially generated from the Textmate bundle:
 


### PR DESCRIPTION
I've noticed that Atom package installation paths are a bit off and decided to fix them.

Also I think that `language-factor` name will be more conventional than `languages-factor` (because all Atom language packages tend to be named as `language-*`), so I've decided to change the name it too.

Please note that the package name currently is just a recommendation, so nothing will go wrong if some guys have it installed under the old name.

I have a further interest to publish that Atom package to https://atom.io/packages and support it in an external repository, so it'd become more accessible to the Atom users (_the_ standard way of installing and updating the package is to download it from https://atom.io/packages central package repository); what would you guys say?