### PR TITLE
A rollup of fixes for you, guys

### DIFF
--- a/basis/io/launcher/launcher-docs.factor
+++ b/basis/io/launcher/launcher-docs.factor
@@ -28,10 +28,10 @@ $nl
 "To specify redirection, set the " { $snippet "stdin" } ", " { $snippet "stdout" } " and " { $snippet "stderr" } " slots of a " { $link process } " to one of the following values:"
 { $list
     { { $link f } " - default value; the stream is either inherited from the current process, or is a " { $link <process-stream> } " pipe" }
-    { { $link +closed+ } " - the stream is closed; reads will return end of file and writes will fails" }
+    { { $link +closed+ } " - the stream is closed; reads will return end of file and writes will fail" }
     { { $link +stdout+ } " - a special value for the " { $snippet "stderr" } " slot only, indicating that the standard output and standard error streams should be merged" }
     { "a path name - the stream is sent to the given file, which must exist for input and is created automatically on output" }
-    { "an " { $link appender } " wrapping a path name - output is sent to the end given file, as with " { $link <file-appender> } }
+    { "an " { $link appender } " wrapping a path name - output is sent to the end of the given file, as with " { $link <file-appender> } }
     { "a file stream or a socket - the stream is connected to the given Factor stream, which cannot be used again from within Factor and must be closed after the process has been started" }
 } ;
 

--- a/basis/models/arrow/arrow-docs.factor
+++ b/basis/models/arrow/arrow-docs.factor
@@ -7,7 +7,7 @@ HELP: arrow
 { $examples
     "The following code displays a label showing the result of applying " { $link sq } " to the value 5:"
     { $code
-        "USING: models ui.gadgets.labels ui.gadgets.panes ;"
+        "USING: models models.arrow math.parser ui.gadgets.labels ui.gadgets.panes ;"
         "5 <model> [ sq ] <arrow> [ number>string ] <arrow>"
         "<label-control> gadget."
     }

--- a/basis/stack-checker/stack-checker-docs.factor
+++ b/basis/stack-checker/stack-checker-docs.factor
@@ -5,7 +5,7 @@ IN: stack-checker
 ARTICLE: "inference-simple" "Straight-line stack effects"
 "The simplest case is when a piece of code does not have any branches or recursion, and just pushes literals and calls words."
 $nl
-"Pushing a literal has stack effect " { $snippet "( -- x )" } ". The stack effect of a most words is always known statically from the declaration. Stack effects of " { $link POSTPONE: inline } " words and " { $link "macros" } ", may depend on literals pushed on the stack prior to the call, and this case is discussed in " { $link "inference-combinators" } "."
+"Pushing a literal has stack effect " { $snippet "( -- x )" } ". The stack effect of most words is always known statically from the declaration. Stack effects of " { $link POSTPONE: inline } " words and " { $link "macros" } ", may depend on literals pushed on the stack prior to the call, and this case is discussed in " { $link "inference-combinators" } "."
 $nl
 "The stack effect of each element in a code snippet is composed. The result is then the stack effect of the snippet."
 $nl

--- a/basis/timers/timers-docs.factor
+++ b/basis/timers/timers-docs.factor
@@ -2,7 +2,7 @@ USING: help.markup help.syntax calendar quotations system ;
 IN: timers
 
 HELP: timer
-{ $class-description "A timer. Can be passed to " { $link stop-timer } "." } ;
+{ $class-description "A timer. Can be passed to " { $link start-timer } ", " { $link stop-timer } " and " { $link restart-timer } "." } ;
 
 HELP: start-timer
 { $values { "timer" timer } }

--- a/basis/ui/gestures/gestures-docs.factor
+++ b/basis/ui/gestures/gestures-docs.factor
@@ -351,7 +351,7 @@ ARTICLE: "keyboard-gestures" "Keyboard gestures"
 }
 "The " { $link S+ } " modifier is only ever used with the above action keys; alphanumeric input input with the shift key is delivered without the " { $link S+ } " modifier set, instead the input itself is upper case. For example, the gesture corresponding to " { $snippet "s" } " with the Control and Shift keys pressed is presented as "
 { $code "T{ key-down f { C+ } \"S\" }" }
-"The " { $snippet "RET" } " and " { $snippet "TAB" } " keys are never delivered in their literal form (" { $snippet "\"\\n\"" } " and " { $snippet "\"\\t\"" } ;
+"The " { $snippet "RET" } " and " { $snippet "TAB" } " keys are never delivered in their literal form (" { $snippet "\"\\n\"" } " and " { $snippet "\"\\t\"" } ")." ;
 
 ARTICLE: "ui-user-input" "Free-form keyboard input"
 "Whereas keyboard gestures are intended to be used for keyboard shortcuts, certain gadgets such as text fields need to accept free-form keyboard input. This can be done by implementing a generic word:"

--- a/basis/ui/tools/browser/browser.factor
+++ b/basis/ui/tools/browser/browser.factor
@@ -11,7 +11,7 @@ ui.gadgets.panes ui.gadgets.scrollers ui.gadgets.status-bar
 ui.theme ui.gadgets.theme ui.gadgets.toolbar ui.gadgets.tracks
 ui.gadgets.viewports ui.gadgets.worlds ui.gestures ui.pens.solid
 ui.render ui.text ui.tools.common ui.tools.browser.history
-ui.tools.browser.popups vocabs ;
+ui.tools.browser.popups unicode vocabs ;
 IN: ui.tools.browser
 
 TUPLE: browser-gadget < tool history scroller search-field popup ;
@@ -97,7 +97,7 @@ CONSTANT: next 1
     <scroller> >>scroller scroller>> white-interior 1 track-add ;
 
 : search-browser ( string browser -- )
-    '[ <apropos-search> _ show-help ] unless-empty ;
+    '[ [ blank? ] trim <apropos-search> _ show-help ] unless-empty ;
 
 : <search-field> ( browser -- field )
     '[ _ search-browser ] <action-field>

--- a/core/words/words-docs.factor
+++ b/core/words/words-docs.factor
@@ -137,7 +137,7 @@ $nl
   }
   {
       { $snippet "\"predicating\"" }
-      " Set on class predicates, stores the corresponding class word"
+      "Set on class predicates, stores the corresponding class word."
   }
   {
       { { $snippet "\"reading\"" } ", " { $snippet "\"writing\"" } }


### PR DESCRIPTION
These are mostly minor documentation fixes - wording and typos - plus a fix for the browser's search field: make it trim whitespace before search, for consistency with the apropos word.