### PR TITLE
extra: add vocab to wrap tools.test for Exercism.io

### DIFF
--- a/extra/exercism/testing/testing-docs.factor
+++ b/extra/exercism/testing/testing-docs.factor
@@ -1,0 +1,106 @@
+! See http://factorcode.org/license.txt for BSD license.
+USING: io.directories help.markup help.syntax multiline strings exercism.testing.private tools.test ;
+IN: exercism.testing
+
+HELP: verify-config
+    { $description
+      "Verifies a configuration. Called on running " { $link choose-suite } "."
+
+      $nl "When " { $link project-env } " is " { $link dev-env } ", then " { $snippet "config.json" } " is checked for internal consistency and consistency with the filesystem, and that all of the " { $snippet "exercises" } " directory's " { $link child-directories } " contain at least " { $snippet "exercise-tests.factor" } " and " { $snippet "exercise-example.factor" } ". If an error is found, the operation is aborted."
+
+      $nl "When " { $link project-env } " is " { $link user-env } ", then the exercises folders in the current directory are checked to have both an implementation and unit tests; if not all do, then the operation is aborted."
+    }
+    { $notes
+      { $snippet "config.json" } "'s " { $snippet "problems" } " and " { $snippet "deprecated" } " keys should not share any values. " { $snippet "problems" } " should match the " { $snippet "exercises" } " directory's " { $link child-directories } " exactly, and " { $snippet "deprecated" } " should not share any entries with " { $snippet "exercises" } "."
+    } ;
+
+HELP: run-exercism-test
+    { $values { "exercise" string } }
+    { $description
+      "Runs the Exercism test with slug " { $snippet "exercise"} " from the current directory."
+
+      $nl "To test user solutions to Exercism exercises, start Factor in the " { $snippet "exercism/factor" } " directory, or " { $link set-current-directory } " there from the Listener."
+
+      $nl "To test server-side example solutions to Exercism exercises, start Factor in the " { $snippet "exercism/xfactor" } " git repository, or " { $link set-current-directory } " there from the Listener."
+    }
+
+    { $examples
+      { $example
+        "USING: io.directories exercism.testing ;"
+        "\"/home/you/exercism/factor\" set-current-directory"
+        "\"hello-world\" run-exercism-test"
+
+        "testing exercise: hello-world
+Unit Test: { { \"Hello, World!\" } [ \"\" hello-name ] }
+Unit Test: { { \"Hello, Alice!\" } [ \"Alice\" hello-name ] }
+Unit Test: { { \"Hello, Bob!\" } [ \"Bob\" hello-name ] }
+"
+      }
+
+      { $example
+        "USING: io.directories exercism.testing ;"
+        "\"/home/you/git/exercism/xfactor\" set-current-directory"
+        "\"hello-world\" run-exercism-test with-directory"
+
+        "testing exercise: hello-world
+Unit Test: { { \"Hello, World!\" } [ \"\" hello-name ] }
+Unit Test: { { \"Hello, Alice!\" } [ \"Alice\" hello-name ] }
+Unit Test: { { \"Hello, Bob!\" } [ \"Bob\" hello-name ] }
+"
+      }
+    } ;
+
+HELP: run-all-exercism-tests
+    { $description
+      "Runs all Exercism exercise tests found in the " { $link exercises-folder } " in the current directory." } ;
+
+HELP: choose-suite
+    { $values { "arg" string } }
+    { $description
+      "Runs tests for problem named " { $snippet "arg" } ", or runs all tests if " { $snippet "arg" } " is "
+      { $snippet "\"run-all\"" } ". If " { $snippet "arg" } " is "{ $snippet "\"VERIFY\"" } ", then just " { $link verify-config } " is called on the current directory."
+    } ;
+
+HELP: guess-project-env
+    { $description
+      "Guesses (fairly accurately) whether the current directory is " { $link dev-env } " (exercism/xfactor git repository) or " { $link user-env } " (the " { $snippet "exercism/factor" } " Exercism folder)."
+    } ;
+
+
+ARTICLE: "exercism.testing" "Running unit tests on Exercism.io exercises"
+    "Both Factor and " { $url "http://exercism.io" } "'s backends have fairly strict naming conventions, which makes unit testing Factor code for Exercism on the client and server side simultaneously a little bit tricky."
+
+    $nl "This vocabulary aims to make testing Exercism exercise code as easy as " { $link POSTPONE: unit-test } " on both the client and server, while still allowing users and Exercism collaborators to use the tried and true " { $link POSTPONE: unit-test } "."
+
+    $nl "Whether server-side or user-facing tests are run is controlled by a variable upon which words dispatch: " { $link project-env } ". It is given its value by " { $vocab-link "exercism.testing" } "'s " { $link POSTPONE: MAIN: } ", or by calling " { $link guess-project-env } " directly."
+
+    $nl "This vocabulary may be most fit for packaging into a binary or running from a terminal:\n\n"
+    { $snippet "factor -run=exercism.testing run-all" }
+
+    $nl "Detecting environment type:"
+    { $subsections
+      guess-project-env
+    }
+
+    "Verifying environment configuration:"
+    { $subsections
+      verify-config
+    }
+
+    "Testing exercises:"
+    { $subsections
+      run-exercism-test
+      run-all-exercism-tests
+    }
+
+    "Errors:"
+    { $subsections
+      not-an-exercism-folder
+      wrong-project-env
+      not-user-env
+      not-dev-env
+    }
+
+    ;
+
+ABOUT: "exercism.testing"

--- a/extra/exercism/testing/testing-tests.factor
+++ b/extra/exercism/testing/testing-tests.factor
@@ -1,0 +1,67 @@
+! See http://factorcode.org/license.txt for BSD license.
+USING: tools.test exercism.testing exercism.testing.private ;
+FROM: namespaces => get set ;
+IN: exercism.testing.tests
+
+
+{
+    "exercises/hello-world/hello-world-tests.factor"
+    "exercises/hello-world/hello-world-example.factor"
+} [
+    T{ dev-env } project-env set
+    "hello-world" exercise>filenames
+] unit-test
+
+{
+    "exercises/leap/leap-tests.factor"
+    "exercises/leap/leap-example.factor"
+} [
+    T{ dev-env } project-env set
+    "leap" exercise>filenames
+] unit-test
+
+{
+    "hello-world/hello-world-tests.factor"
+    "hello-world/hello-world.factor"
+} [
+    T{ user-env } project-env set
+    "hello-world" exercise>filenames
+] unit-test
+
+{
+    "leap/leap-tests.factor"
+    "leap/leap.factor"
+} [
+    T{ user-env } project-env set
+    "leap" exercise>filenames
+] unit-test
+
+T{ dev-env } project-env set
+{ t } [ { } { "hello-world" } config-exclusive? ] unit-test
+{ t } [ { "hello-world" } { } config-exclusive? ] unit-test
+{ t } [ { } { }               config-exclusive? ] unit-test
+{ f } [ { "hello-world" }
+          { "hello-world" }
+          config-exclusive? ] unit-test
+
+{ t } [ { } { } { } config-matches-fs? ] unit-test
+{ t } [
+          { "hello-world" }
+          { "hello-world" }
+          { }
+        config-matches-fs? ] unit-test
+{ t } [
+          { "hello-world" }
+          { "hello-world" }
+          { "blah" }
+        config-matches-fs? ] unit-test
+{ f } [
+          { "hello-world" }
+          { "blah" }
+          { "blah" }
+        config-matches-fs? ] unit-test
+{ f } [
+          { "blah" }
+          { "hello-world" }
+          { "blah" }
+        config-matches-fs? ] unit-test

--- a/extra/exercism/testing/testing.factor
+++ b/extra/exercism/testing/testing.factor
@@ -1,0 +1,232 @@
+! See http://factorcode.org/license.txt for BSD license.
+USING: accessors arrays assocs classes.tuple combinators
+    command-line formatting io io.directories io.encodings.utf8
+    io.files io.files.info io.launcher io.pathnames json.reader
+    kernel locals math multiline parser present sequences sets
+    sorting summary system tools.test vocabs.loader ;
+QUALIFIED: namespaces
+QUALIFIED: sets
+IN: exercism.testing
+
+<PRIVATE
+
+
+: child-directories ( path -- directories )
+    directory-entries
+    [ directory? ] filter
+    [ name>>     ] map ;
+
+CONSTANT: name-clashes { "hello-world" }
+
+TUPLE: config
+        { problems   array }
+        { deprecated array } ; final
+
+SYMBOL: project-env
+ERROR:  wrong-project-env word ;
+
+TUPLE: user-env ; final
+M:     user-env present
+    drop "user-env" ;
+ERROR: not-user-env  < wrong-project-env ; final
+M:     not-user-env  summary
+    word>> name>> "can't use word %s in dev environment" sprintf ;
+
+TUPLE: dev-env ; final
+M:     dev-env present
+    drop "dev-env" ;
+ERROR: not-dev-env  < wrong-project-env ; final
+M:     not-dev-env  summary
+    word>> name>> "can't use word %s in user environment"  sprintf ;
+
+ERROR:  not-an-exercism-folder word ;
+M:      not-an-exercism-folder summary
+    word>> name>> "exercism.testing: %s: current directory is not an exercism folder" sprintf ;
+
+
+HOOK: exercises-folder project-env ( -- dirname )
+M: dev-env  exercises-folder  "exercises" ; inline
+M: user-env exercises-folder  "."         ; inline
+M: f        exercises-folder  \ exercises-folder not-an-exercism-folder ;
+
+
+HOOK: exercise>filenames project-env
+    ( test-name -- example-filename tests-filename )
+M: dev-env exercise>filenames
+    dup exercises-folder prepend-path prepend-path
+    { "-tests.factor" "-example.factor" }
+    [ append ] with map first2 ;
+
+M: user-env exercise>filenames
+    dup prepend-path
+    { "-tests.factor" ".factor" } [ append ] with map
+    first2 ;
+
+: (handle-name-clash) ( -- )
+    vocab-roots namespaces:get reverse vocab-roots namespaces:set ;
+
+HOOK: handle-name-clash project-env ( -- )
+M: dev-env handle-name-clash
+    exercises-folder prepend-path-path add-vocab-root
+    (handle-name-clash) ; inline
+
+M: user-env handle-name-clash
+    add-vocab-root
+    (handle-name-clash) ; inline
+
+
+HOOK: get-config-data project-env ( -- config )
+M: dev-env get-config-data
+    "config.json" path>json
+    { "problems" "deprecated" } [ swap at ] with map
+    config slots>tuple ;
+
+M: user-env get-config-data
+    \ get-config-data not-user-env ;
+
+
+HOOK: exercise-exists? project-env ( exercise -- ? )
+M:: dev-env exercise-exists? ( name -- ? )
+    name
+    [ get-config-data problems>> member? ]
+    [ exercises-folder prepend-path exists? ]
+    bi and
+    [ name exercise>filenames [ exists? ] bi@ and ]
+    [ f ]
+    if ;
+
+M: user-env exercise-exists?
+    dup exercise>filenames [ exists? ] tri@ and and ;
+
+M: f exercise-exists?
+    drop \ exercise-exists? not-an-exercism-folder ;
+
+
+HOOK: config-exclusive? project-env ( problems deprecated -- ? )
+M: dev-env config-exclusive?
+    sets:intersect { } = ;
+
+M: user-env config-exclusive?
+    \ config-exclusive? not-dev-env ;
+
+
+HOOK: config-matches-fs? project-env ( dirs problems deprecated -- ? )
+M: dev-env config-matches-fs?
+    [ over ] dip sets:intersect { } = -rot
+    [ natural-sort ] bi@ = and ;
+
+M: user-env config-matches-fs?
+    \ config-matches-fs? not-dev-env ;
+
+: (run-exercism-test) ( exercise -- )
+    dup name-clashes member? [ handle-name-clash ] when
+    [ "\ntesting exercise: %s\n\n" printf ]
+    [ exercise>filenames ]
+    bi
+    run-file run-test-file ;
+
+: wd-git-name ( -- name )
+    "git rev-parse --show-toplevel" utf8 [ contents ] with-process-reader*
+    nip 0 =
+    [ path-components last dup length 1 - head ]
+    [ drop "" ]
+    if ;
+
+PRIVATE>
+
+
+HOOK: verify-config project-env ( -- )
+M: dev-env verify-config
+    get-config-data dup problems>> [ deprecated>> ] dip 2dup
+    [ config-exclusive? ] 2dip
+
+    swap exercises-folder child-directories -rot
+    config-matches-fs?
+    and
+
+    exercises-folder child-directories
+    [ exercise>filenames [ exists? ] bi@ and ] all?
+    and
+
+    [ "config.json and exercises OK" print ]
+    [ "invalid config.json\n"
+      print 2 exit ]
+    if ;
+
+M: user-env verify-config
+    exercises-folder child-directories
+    [ exercise>filenames [ exists? ] bi@ and ] all?
+
+    [ "config OK: all problems have implementations and unit tests" print ]
+    [ "invalid config: problems are missing implementations or tests\n"
+      print 2 exit ]
+    if ;
+
+M: f verify-config
+    \ verify-config not-an-exercism-folder ;
+
+
+HOOK: run-exercism-test project-env ( exercise -- )
+M: dev-env run-exercism-test
+    (run-exercism-test) ;
+
+M: user-env run-exercism-test
+    (run-exercism-test) ;
+
+M: f run-exercism-test
+    drop \ run-exercism-test not-an-exercism-folder ;
+
+
+: run-all-exercism-tests ( -- )
+    exercises-folder child-directories [ run-exercism-test ] each ;
+
+: choose-suite ( arg -- )
+    {
+      { [ dup "VERIFY"  =      ] [ drop verify-config ] }
+      { [ dup "run-all" =      ] [ drop verify-config run-all-exercism-tests ] }
+      { [ dup exercise-exists? ] [ verify-config run-exercism-test ] }
+        [ verify-config "exercism.testing: choose-suite: bad last argument `%s', expected 'run-all' or an exercise slug\n\n" printf ]
+    } cond ;
+
+: guess-project-env ( -- )
+    "exercises" { ".keep" "hello-world" }
+    [ append-path ] with map
+    {
+      "config.json"
+      ".git"
+      ".gitignore"
+      "exercises"
+    }
+    append
+    [ exists? ] all?
+    "xfactor"
+    [ wd-git-name = ]
+    [ ".." prepend-path absolute-path current-directory namespaces:get = ]
+    bi and and dup [ T{ dev-env } project-env namespaces:set ] when
+
+    {
+      "hello-world"
+    } [ exists? ] all?
+    dup [ T{ user-env } project-env namespaces:set ] when
+
+    xor
+    [
+      current-directory project-env [ namespaces:get ] bi@
+      "working directory OK: %s is a %s \n" printf
+    ]
+    [
+      current-directory namespaces:get
+      "exercism.testing: `%s' is not an `exercism/factor' folder or `xfactor' git project \n\n" printf
+      f project-env namespaces:set
+    ] if ;
+
+: exercism-testing-main ( -- )
+    ! guess-project-env
+    (command-line) last
+    dup "factor" =
+    [ "need a command-line argument" throw ]
+    [ choose-suite ]
+    if ;
+
+guess-project-env
+MAIN: exercism-testing-main


### PR DESCRIPTION
The exercism.testing vocabulary makes it easier
for Exercism users and
http://github.com/exercism/xfactor collaborators
to run unit-tests on exercise code, by providing
a common interface to tools.test for both cases.

Because the vocabulary is intended to work on the
current directory, it relies on filesystem state
and unfortunately much of its code is not easily
unit-test-able. However, the vocab itself has
been rigorously tested and verified by yours
truly so it does exactly what it should in all
cases I can think of.

See exercism.testing's documentation for more
information.

**Why do I think this should be in Factor's standard library?**

There are many things that I think make Factor a Joy (heh) to program in, but a big one is its massive standard library which doesn't seem to be afraid of getting bigger. 

Factor's naming conventions coupled with Exercism's naming conventions make writing Factor code in an Exercism context a little bit tricky. The goal of https://github.com/exercism/xfactor is to get people interested in Factor by making it easy and fun to solve Exercism exercises.

Because Factor doesn't yet have an easy way to portably distribute a library to users (think npm for Node.js or pip for Python), and because it's not reasonable to expect all Exercism users to have `git` and the knowledge to install and use a third-party Factor library (and because for most other Exercism tracks, at least the client-side unit testing code is part of the standard library), I think an effective and easy way to distribute this library to Exercism users interested in Factor is to put it in the standard library.

Users have Factor, and they will also have code that lets them use the canonical `tools.test` on Exercism.

Please let me know what you think. :)

(By the way: It's called `exercism.testing` because I'll probably add an [`exercism.client`](https://github.com/exercism/cli) later.)
