### PR TITLE
For upstream

### DIFF
--- a/basis/checksums/openssl/openssl.factor
+++ b/basis/checksums/openssl/openssl.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2008, 2010, 2016 Slava Pestov, Alexander Ilin
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors alien.c-types alien.data checksums
-checksums.stream destructors io kernel openssl openssl.libcrypto
+checksums.stream destructors fry io kernel openssl openssl.libcrypto
 sequences ;
 IN: checksums.openssl
 
@@ -35,6 +35,9 @@ M: evp-md-context dispose*
 : set-digest ( name ctx -- )
     handle>> swap digest-named f EVP_DigestInit_ex ssl-error ;
 
+: checksum-method ( data checksum method: ( ctx data -- ctx' ) -- value )
+    [ initialize-checksum-state ] dip '[ swap @ get-checksum ] with-disposal ; inline
+
 PRIVATE>
 
 M: openssl-checksum initialize-checksum-state ( checksum -- evp-md-context )
@@ -50,7 +53,7 @@ M: evp-md-context get-checksum ( ctx -- value )
     memory>byte-array ;
 
 M: openssl-checksum checksum-bytes ( bytes checksum -- value )
-    initialize-checksum-state [ swap add-checksum-bytes get-checksum ] with-disposal ;
+    [ add-checksum-bytes ] checksum-method ;
 
 M: openssl-checksum checksum-stream ( stream checksum -- value )
-    initialize-checksum-state [ swap add-checksum-stream get-checksum ] with-disposal ;
+    [ add-checksum-stream ] checksum-method ;

--- a/basis/checksums/stream/stream-docs.factor
+++ b/basis/checksums/stream/stream-docs.factor
@@ -1,0 +1,7 @@
+USING: checksums help.markup help.syntax ;
+IN: checksums.stream
+
+ARTICLE: "checksums.stream" "stream-checksum"
+"The instances of the " { $link stream-checksum } " mixin must implement " { $link checksum-stream } "." ;
+
+ABOUT: "checksums.stream"

--- a/basis/db/errors/errors.factor
+++ b/basis/db/errors/errors.factor
@@ -48,7 +48,7 @@ TUPLE: sql-index-exists < sql-error name ;
 : <sql-index-exists> ( name -- error )
     f swap sql-index-exists boa ;
 
-: ignore-error ( quot word -- )
+: ignore-error ( quot check: ( error -- ? ) -- )
     '[ dup @ [ drop ] [ rethrow ] if ] recover ; inline
 
 : ignore-table-exists ( quot -- )

--- a/basis/db/errors/errors.factor
+++ b/basis/db/errors/errors.factor
@@ -43,6 +43,11 @@ TUPLE: sql-database-exists < sql-error message ;
 : <sql-database-exists> ( message -- error )
     f swap sql-database-exists boa ;
 
+TUPLE: sql-index-exists < sql-error name ;
+
+: <sql-index-exists> ( name -- error )
+    f swap sql-index-exists boa ;
+
 : ignore-error ( quot word -- )
     '[ dup @ [ drop ] [ rethrow ] if ] recover ; inline
 
@@ -60,3 +65,6 @@ TUPLE: sql-database-exists < sql-error message ;
 
 : ignore-database-exists ( quot -- )
     [ sql-database-exists? ] ignore-error ; inline
+
+: ignore-index-exists ( quot -- )
+    [ sql-index-exists? ] ignore-error ; inline

--- a/basis/db/queries/queries.factor
+++ b/basis/db/queries/queries.factor
@@ -206,6 +206,9 @@ M: db-connection <count-statement> ( query -- statement )
         "," join % ")" %
     ] "" make sql-command ;
 
+: ensure-index ( index-name table-name columns -- )
+    '[ _ _ _ create-index ] ignore-index-exists ;
+
 : drop-index ( index-name -- )
     [ "drop index " % % ] "" make sql-command ;
 

--- a/basis/db/sqlite/errors/errors-tests.factor
+++ b/basis/db/sqlite/errors/errors-tests.factor
@@ -21,5 +21,13 @@ db.sqlite kernel locals tools.test ;
             { [ sql-table-exists? ] [ table>> "foo" = ] } 1&&
         ] must-fail-with
 
+        "create index main_index on foo(id);" sql-command
+
+        [
+            "create index main_index on foo(id);" sql-command
+        ] [
+            { [ sql-index-exists? ] [ name>> "main_index" = ] } 1&&
+        ] must-fail-with
+
     ] with-db
 ] with-test-file

--- a/basis/db/sqlite/errors/errors.factor
+++ b/basis/db/sqlite/errors/errors.factor
@@ -14,6 +14,8 @@ AlreadyExists = " already exists"
 SqliteError =
     "table " (!(AlreadyExists).)+:table AlreadyExists
       => [[ table >string <sql-table-exists> ]]
+    | "index " (!(AlreadyExists).)+:name AlreadyExists
+      => [[ name >string <sql-index-exists> ]]
     | "no such table: " .+:table
       => [[ table >string <sql-table-missing> ]]
     | .*:error

--- a/basis/db/sqlite/errors/errors.factor
+++ b/basis/db/sqlite/errors/errors.factor
@@ -7,20 +7,13 @@ IN: db.sqlite.errors
 TUPLE: unparsed-sqlite-error error ;
 C: <unparsed-sqlite-error> unparsed-sqlite-error
 
-SINGLETONS: table-exists table-missing ;
-
-: sqlite-table-error ( table message -- error )
-    {
-        { table-exists [ <sql-table-exists> ] }
-    } case ;
-
 EBNF: parse-sqlite-sql-error
 
-TableMessage = " already exists" => [[ table-exists ]]
+AlreadyExists = " already exists"
 
 SqliteError =
-    "table " (!(TableMessage).)+:table TableMessage:message
-      => [[ table >string message sqlite-table-error ]]
+    "table " (!(AlreadyExists).)+:table AlreadyExists
+      => [[ table >string <sql-table-exists> ]]
     | "no such table: " .+:table
       => [[ table >string <sql-table-missing> ]]
     | .*:error

--- a/basis/io/directories/windows/windows.factor
+++ b/basis/io/directories/windows/windows.factor
@@ -36,10 +36,6 @@ M: windows delete-file ( path -- )
     [ (delete-file) ]
     [ \ file-delete-failed boa rethrow ] recover ;
 
-M: windows copy-file ( from to -- )
-    make-parent-directories
-    [ normalize-path ] bi@ 0 CopyFile win32-error=0/f ;
-
 M: windows make-directory ( path -- )
     normalize-path
     f CreateDirectory win32-error=0/f ;

--- a/basis/tools/scaffold/scaffold-tests.factor
+++ b/basis/tools/scaffold/scaffold-tests.factor
@@ -20,6 +20,14 @@ IN: tools.scaffold.tests
     [ \ undocumented-word (help.) ] with-string-writer
 ] unit-test
 
+{
+"HELP: iota-tuple
+{ $class-description \"\" } ;
+" }
+[
+    [ \ iota-tuple (help.) ] with-string-writer
+] unit-test
+
 { sequence t } [ "seq" lookup-type ] unit-test
 { sequence t } [ "seq'" lookup-type ] unit-test
 { sequence t } [ "newseq" lookup-type ] unit-test

--- a/basis/tools/scaffold/scaffold.factor
+++ b/basis/tools/scaffold/scaffold.factor
@@ -185,6 +185,10 @@ M: object add-using ( object -- )
         ] if
     ] when* ;
 
+: class-description. ( word -- )
+    drop
+    "{ $class-description \"\" } ;" print ;
+
 : symbol-description. ( word -- )
     drop
     "{ $var-description \"\" } ;" print ;
@@ -194,11 +198,11 @@ M: object add-using ( object -- )
     "{ $description \"\" } ;" print ;
 
 : docs-body. ( word/symbol -- )
-    dup symbol? [
-        symbol-description.
-    ] [
-        [ $values. ] [ $description. ] bi
-    ] if ;
+    {
+        { [ dup class? ] [ class-description. ] }
+        { [ dup symbol? ] [ symbol-description. ] }
+        [ [ $values. ] [ $description. ] bi ]
+    } cond ;
 
 : docs-header. ( word -- )
     "HELP: " write name>> print ;

--- a/basis/windows/ole32/ole32-docs.factor
+++ b/basis/windows/ole32/ole32-docs.factor
@@ -1,0 +1,10 @@
+! Copyright (C) 2016 Alexander Ilin.
+! See http://factorcode.org/license.txt for BSD license.
+USING: help.markup help.syntax kernel windows.kernel32 ;
+IN: windows.ole32
+
+HELP: create-guid
+{ $values
+    { "GUID" GUID }
+}
+{ $description "Generate a new random " { $link GUID } " value." } ;

--- a/basis/windows/ole32/ole32-tests.factor
+++ b/basis/windows/ole32/ole32-tests.factor
@@ -1,6 +1,7 @@
-USING: kernel tools.test windows.ole32 alien.c-types
-classes.struct specialized-arrays windows.kernel32
-windows.com.syntax ;
+USING: alien.c-types classes.struct kernel math sequences
+specialized-arrays
+specialized-arrays.instances.alien.c-types.uchar tools.test
+windows.com.syntax windows.kernel32 windows.ole32 ;
 SPECIALIZED-ARRAY: uchar
 IN: windows.ole32.tests
 
@@ -29,3 +30,5 @@ IN: windows.ole32.tests
 [ "{01234567-89ab-cdef-0123-456789abcdef}" ]
 [ "{01234567-89ab-cdef-0123-456789abcdef}" string>guid guid>string ]
 unit-test
+
+{ 0 } [ 10 [ create-guid ] replicate duplicates length ] unit-test

--- a/basis/windows/ole32/ole32.factor
+++ b/basis/windows/ole32/ole32.factor
@@ -21,6 +21,7 @@ TYPEDEF: REFGUID REFIID
 TYPEDEF: REFGUID REFCLSID
 
 FUNCTION: HRESULT CoCreateInstance ( REFGUID rclsid, LPUNKNOWN pUnkOuter, DWORD dwClsContext, REFGUID riid, LPUNKNOWN out_ppv )
+FUNCTION: HRESULT CoCreateGuid ( GUID* pguid )
 FUNCTION: BOOL IsEqualGUID ( REFGUID rguid1, REFGUID rguid2 )
 FUNCTION: int StringFromGUID2 ( REFGUID rguid, LPOLESTR lpsz, int cchMax )
 FUNCTION: HRESULT CLSIDFromString ( LPOLESTR lpsz, REFGUID out_rguid )
@@ -133,6 +134,9 @@ TUPLE: ole32-error code message ;
 
 CONSTANT: GUID-STRING-LENGTH
     $[ "{01234567-89ab-cdef-0123-456789abcdef}" length ]
+
+: create-guid ( -- GUID )
+    GUID <struct> dup CoCreateGuid check-ole32-error ;
 
 : string>guid ( string -- guid )
     "{-}" split harvest

--- a/core/checksums/checksums-docs.factor
+++ b/core/checksums/checksums-docs.factor
@@ -36,7 +36,7 @@ HELP: checksum-lines
 
 HELP: checksum-file
 { $values { "path" "a pathname specifier" } { "checksum" "a checksum specifier" } { "value" byte-array } }
-{ $contract "Computes the checksum of all data in a file." }
+{ $description "Computes the checksum of all data in a file." }
 { $examples
     { $example
         "USING: checksums checksums.crc32 prettyprint ;"

--- a/core/checksums/checksums-docs.factor
+++ b/core/checksums/checksums-docs.factor
@@ -58,6 +58,9 @@ $nl
 }
 "Checksums should implement at least one of " { $link checksum-bytes } " and " { $link checksum-stream } ". Implementing " { $link checksum-lines } " is optional."
 $nl
+"In the default implementation " { $link checksum-bytes } " is abstract, and " { $link checksum-stream } " is implemented by calling it with the stream contents fully read into memory. If you want your checksum to be the other way around, that is, "  { $link checksum-bytes } " to be implemented by calling " { $link checksum-stream } ", consider using the " { $snippet "stream-checksum" } " mixin:"
+{ $vocab-subsection "stream-checksum" "checksums.stream" }
+$nl
 "Utilities:"
 { $subsections
     checksum-file

--- a/core/checksums/checksums.factor
+++ b/core/checksums/checksums.factor
@@ -23,9 +23,11 @@ GENERIC: initialize-checksum-state ( checksum -- checksum-state )
 
 GENERIC: checksum-block ( bytes checksum-state -- )
 
+GENERIC# add-checksum-bytes 1 ( checksum-state bytes -- checksum-state' )
+
 GENERIC: get-checksum ( checksum-state -- value )
 
-: add-checksum-bytes ( checksum-state data -- checksum-state )
+M: checksum-state add-checksum-bytes ( checksum-state data -- checksum-state' )
     over bytes>> [ push-all ] keep
     [ dup length pick block-size>> >= ]
     [


### PR DESCRIPTION
A new batch of updates has arrived.

In this branch:
- removed the blocking copy-file implementation on Windows;
- added default cross-platform move-file implementation;
- added create-guid in windows.ole32;
- added ensure-index in db.queries and related error tuple, with an SQLite implementation and tests;
- reworked checksums.openssl to adhere to the common interface: initialize-checksum-state, add-checksum-bytes/stream, get-checksum;
- plus some documentation fixes and updates.