### PR TITLE
io.launcher.windows: hide window of the launched process

### DIFF
--- a/basis/io/launcher/launcher-docs.factor
+++ b/basis/io/launcher/launcher-docs.factor
@@ -11,6 +11,9 @@ ARTICLE: "io.launcher.detached" "Running processes in the background"
 "By default, " { $link run-process } " waits for the process to complete. To run a process without waiting for it to finish, set the " { $snippet "detached" } " slot of a " { $link process } ", or use the following word:"
 { $subsections run-detached } ;
 
+ARTICLE: "io.launcher.hidden" "Running hidden processes"
+"By default, child processes can create and display their own (console and other) windows. To signal to a process that it should stay hidden, set the " { $snippet "hidden" } " slot of the " { $link process } " before running it. The processes are free to ignore this signal." ;
+
 ARTICLE: "io.launcher.environment" "Setting environment variables"
 "The " { $snippet "environment" } " slot of a " { $link process } " contains an association mapping environment variable names to values. The interpretation of environment variables is operating system-specific."
 $nl
@@ -338,6 +341,7 @@ ARTICLE: "io.launcher" "Operating system processes"
     "io.launcher.lifecycle"
     "io.launcher.command"
     "io.launcher.detached"
+    "io.launcher.hidden"
     "io.launcher.environment"
     "io.launcher.redirection"
     "io.launcher.priority"

--- a/basis/io/launcher/launcher.factor
+++ b/basis/io/launcher/launcher.factor
@@ -255,7 +255,7 @@ PRIVATE>
             (pipe) |dispose
             (pipe) |dispose {
                 [
-                    rot >process
+                    rot >process t >>hidden
                         [ swap in>> or ] change-stdin
                         [ swap out>> or ] change-stdout
                     run-detached

--- a/basis/io/launcher/launcher.factor
+++ b/basis/io/launcher/launcher.factor
@@ -13,6 +13,7 @@ TUPLE: process < identity-tuple
 
 command
 detached
+hidden
 
 environment
 environment-mode

--- a/basis/io/launcher/windows/windows-tests.factor
+++ b/basis/io/launcher/windows/windows-tests.factor
@@ -224,6 +224,10 @@ SYMBOLS: out-path err-path ;
     out-path get-global utf8 file-contents
 ] unit-test
 
+{ t "This is a hidden process.\r\n" } [
+    "cmd /c echo.This is a hidden process." utf8 (process-stream) hidden>> swap stream-contents
+] unit-test
+
 [ "IN: scratchpad " ] [
     console-vm-path "-run=listener" 2array
     ascii [ "USE: system 0 exit" print flush lines last ] with-process-stream

--- a/basis/io/launcher/windows/windows.factor
+++ b/basis/io/launcher/windows/windows.factor
@@ -1,15 +1,15 @@
 ! Copyright (C) 2007, 2010 Doug Coleman, Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors alien alien.c-types alien.data arrays assocs
-classes classes.struct combinators concurrency.flags
-continuations debugger destructors init io io.backend
-io.backend.windows io.files io.files.private io.files.windows
-io.launcher io.launcher.private io.pathnames io.pipes
-io.pipes.windows io.ports kernel libc locals make math
-namespaces prettyprint sequences specialized-arrays splitting
-splitting.monotonic strings system threads windows
+classes classes.struct combinators combinators.short-circuit
+concurrency.flags continuations debugger destructors init io
+io.backend io.backend.windows io.files io.files.private
+io.files.windows io.launcher io.launcher.private io.pathnames
+io.pipes io.pipes.windows io.ports kernel libc literals locals
+make math namespaces prettyprint sequences specialized-arrays
+splitting splitting.monotonic strings system threads windows
 windows.errors windows.handles windows.kernel32 windows.types
-combinators.short-circuit ;
+windows.user32 ;
 SPECIALIZED-ARRAY: ushort
 SPECIALIZED-ARRAY: void*
 IN: io.launcher.windows
@@ -123,7 +123,13 @@ TUPLE: CreateProcess-args
     ] when ;
 
 : fill-startup-info ( process args -- process args )
-    dup lpStartupInfo>> STARTF_USESTDHANDLES >>dwFlags drop ;
+    over hidden>> [ dup lpStartupInfo>> ] dip
+    [
+        flags{ STARTF_USESTDHANDLES STARTF_USESHOWWINDOW } >>dwFlags
+        SW_HIDE >>wShowWindow
+    ] [
+        STARTF_USESTDHANDLES >>dwFlags
+    ] if drop ;
 
 : make-CreateProcess-args ( process -- args )
     default-CreateProcess-args


### PR DESCRIPTION
As a result of this patch, all the child processes start completely hidden from view: their main windows are not displayed on screen, and they are not shown on the taskbar. This is to avoid flashing of the console windows when a program in Factor calls external utilities.

What do you think? Is there a better way to include this feature? Maybe make it optional?