### PR TITLE
Win32 error cleanup

### DIFF
--- a/basis/alien/libraries/windows/windows.factor
+++ b/basis/alien/libraries/windows/windows.factor
@@ -1,8 +1,9 @@
-USING: alien.libraries io.pathnames system windows.errors ;
+USING: alien.libraries io.pathnames system windows.errors
+windows.kernel32 ;
 IN: alien.libraries.windows
 
 M: windows >deployed-library-path
     file-name ;
 
 M: windows dlerror ( -- message )
-    win32-error-string ;
+    GetLastError n>win32-error-string ;

--- a/basis/calendar/windows/windows.factor
+++ b/basis/calendar/windows/windows.factor
@@ -31,7 +31,7 @@ IN: calendar.windows
 M: windows gmt-offset ( -- hours minutes seconds )
     TIME_ZONE_INFORMATION <struct>
     dup GetTimeZoneInformation {
-        { TIME_ZONE_ID_INVALID [ win32-error-string throw ] }
+        { TIME_ZONE_ID_INVALID [ win32-error ] }
         { TIME_ZONE_ID_UNKNOWN [ Bias>> ] }
         { TIME_ZONE_ID_STANDARD [ Bias>> ] }
         { TIME_ZONE_ID_DAYLIGHT [ [ Bias>> ] [ DaylightBias>> ] bi + ] }

--- a/basis/io/directories/windows/windows.factor
+++ b/basis/io/directories/windows/windows.factor
@@ -31,7 +31,7 @@ ERROR: file-delete-failed path error ;
 : (delete-file) ( path -- )
     dup DeleteFile 0 = [
         GetLastError ERROR_ACCESS_DENIED =
-        [ delete-read-only-file ] [ throw-win32-error ] if
+        [ delete-read-only-file ] [ win32-error ] if
     ] [ drop ] if ;
 
 M: windows delete-file ( path -- )

--- a/basis/io/directories/windows/windows.factor
+++ b/basis/io/directories/windows/windows.factor
@@ -48,8 +48,7 @@ M: windows delete-directory ( path -- )
     RemoveDirectory win32-error=0/f ;
 
 : find-first-file ( path WIN32_FIND_DATA -- WIN32_FIND_DATA HANDLE )
-    [ nip ] [ FindFirstFile ] 2bi
-    [ INVALID_HANDLE_VALUE = [ win32-error-string throw ] when ] keep ;
+    [ nip ] [ FindFirstFile ] 2bi check-invalid-handle ;
 
 : find-next-file ( HANDLE WIN32_FIND_DATA -- WIN32_FIND_DATA/f )
     [ nip ] [ FindNextFile ] 2bi 0 = [

--- a/basis/io/files/info/windows/windows.factor
+++ b/basis/io/files/info/windows/windows.factor
@@ -42,8 +42,7 @@ TUPLE: windows-file-info < file-info-tuple attributes ;
 
 : find-first-file-stat ( path -- WIN32_FIND_DATA )
     WIN32_FIND_DATA <struct> [
-        FindFirstFile
-        [ INVALID_HANDLE_VALUE = [ win32-error ] when ] keep
+        FindFirstFile check-invalid-handle
         FindClose win32-error=0/f
     ] keep ;
 

--- a/basis/io/files/info/windows/windows.factor
+++ b/basis/io/files/info/windows/windows.factor
@@ -19,7 +19,7 @@ TUPLE: windows-file-info < file-info-tuple attributes ;
 
 : get-compressed-file-size ( path -- n )
     { DWORD } [ GetCompressedFileSize ] with-out-parameters
-    over INVALID_FILE_SIZE = [ win32-error-string throw ] [ >64bit ] if ;
+    over INVALID_FILE_SIZE = [ win32-error ] [ >64bit ] if ;
 
 : set-windows-size-on-disk ( file-info path -- file-info )
     over attributes>> +compressed+ swap member? [
@@ -183,7 +183,7 @@ CONSTANT: names-buf-length 16384
     [ path-length FindNextVolume ] with-out-parameters
     swap 0 = [
         GetLastError ERROR_NO_MORE_FILES =
-        [ drop f ] [ win32-error-string throw ] if
+        [ drop f ] [ win32-error ] if
     ] [ alien>native-string ] if ;
 
 : find-volumes ( -- array )

--- a/basis/io/files/windows/windows.factor
+++ b/basis/io/files/windows/windows.factor
@@ -399,7 +399,7 @@ M: windows home
     WIN32_FIND_STREAM_DATA <struct>
     0
     [ FindFirstStream ] keepd
-    over -1 <alien> = [
+    over INVALID_HANDLE_VALUE = [
         2drop throw-win32-error
     ] [
         1vector swap file-streams-rest

--- a/basis/io/files/windows/windows.factor
+++ b/basis/io/files/windows/windows.factor
@@ -117,7 +117,7 @@ M: windows init-io ( -- )
 : handle>file-size ( handle -- n/f )
     (handle>file-size) [
         GetLastError ERROR_INVALID_FUNCTION =
-        [ f ] [ throw-win32-error ] if
+        [ f ] [ win32-error ] if
     ] unless* ;
 
 ERROR: seek-before-start n ;
@@ -400,7 +400,7 @@ M: windows home
     0
     [ FindFirstStream ] keepd
     over INVALID_HANDLE_VALUE = [
-        2drop throw-win32-error
+        2drop win32-error
     ] [
         1vector swap file-streams-rest
     ] if ;

--- a/basis/io/files/windows/windows.factor
+++ b/basis/io/files/windows/windows.factor
@@ -76,7 +76,7 @@ SYMBOL: master-completion-port
             { [ dup integer? ] [ ] }
             { [ dup array? ] [
                 first dup eof?
-                [ drop 0 ] [ n>win32-error-string throw ] if
+                [ drop 0 ] [ throw-windows-error ] if
             ] }
         } cond
     ] with-timeout ;
@@ -147,7 +147,7 @@ M: windows handle-length ( handle -- n/f )
         GetLastError {
             { [ dup expected-io-error? ] [ drop f ] }
             { [ dup eof? ] [ drop t ] }
-            [ n>win32-error-string throw ]
+            [ throw-windows-error ]
         } cond
     ] [ f ] if ;
 

--- a/basis/io/sockets/secure/windows/windows.factor
+++ b/basis/io/sockets/secure/windows/windows.factor
@@ -14,7 +14,7 @@ M: openssl ssl-certificate-verification-supported? f ;
 
 : load-windows-cert-store ( string -- HCERTSTORE )
     [ f ] dip CertOpenSystemStore
-    [ win32-error-string throw ] when-zero ;
+    [ win32-error ] when-zero ;
 
 : X509-NAME. ( X509_NAME -- )
     f 0 X509_NAME_oneline

--- a/basis/windows/errors/authors.txt
+++ b/basis/windows/errors/authors.txt
@@ -1,1 +1,2 @@
 Doug Coleman
+Alexander Ilin

--- a/basis/windows/errors/errors.factor
+++ b/basis/windows/errors/errors.factor
@@ -717,9 +717,6 @@ CONSTANT: FORMAT_MESSAGE_MAX_WIDTH_MASK   0x000000FF
     [ drop "Unknown error 0x" id 0xffff,ffff bitand >hex append ]
     [ alien>native-string [ blank? ] trim ] if ;
 
-: win32-error-string ( -- str )
-    GetLastError n>win32-error-string ;
-
 ERROR: windows-error n string ;
 
 : (win32-error) ( n -- )

--- a/basis/windows/errors/errors.factor
+++ b/basis/windows/errors/errors.factor
@@ -744,7 +744,7 @@ ERROR: windows-error n string ;
     win32-error-string throw ;
 
 : check-invalid-handle ( handle -- handle )
-    dup INVALID_HANDLE_VALUE = [ throw-win32-error ] when ;
+    dup INVALID_HANDLE_VALUE = [ win32-error ] when ;
 
 CONSTANT: expected-io-errors
     ${

--- a/basis/windows/errors/errors.factor
+++ b/basis/windows/errors/errors.factor
@@ -719,23 +719,18 @@ CONSTANT: FORMAT_MESSAGE_MAX_WIDTH_MASK   0x000000FF
 
 ERROR: windows-error n string ;
 
-: (win32-error) ( n -- )
-    [ dup win32-error-string windows-error ] unless-zero ;
+: throw-windows-error ( n -- * )
+    dup n>win32-error-string windows-error ;
 
-: win32-error ( -- )
-    GetLastError (win32-error) ;
+: n>win32-error-check ( n -- )
+    [ throw-windows-error ] unless-zero ;
 
+! Note that win32-error* words throw GetLastError code.
+: win32-error ( -- ) GetLastError n>win32-error-check ;
 : win32-error=0/f ( n -- ) { 0 f } member? [ win32-error ] when ;
 : win32-error>0 ( n -- ) 0 > [ win32-error ] when ;
 : win32-error<0 ( n -- ) 0 < [ win32-error ] when ;
-: win32-error<>0 ( n -- ) zero? [ win32-error ] unless ;
-
-: n>win32-error-check ( n -- )
-    dup ERROR_SUCCESS = [
-        drop
-    ] [
-        dup n>win32-error-string windows-error
-    ] if ;
+: win32-error<>0 ( n -- ) [ win32-error ] unless-zero ;
 
 : check-invalid-handle ( handle -- handle )
     dup INVALID_HANDLE_VALUE = [ win32-error ] when ;

--- a/basis/windows/errors/errors.factor
+++ b/basis/windows/errors/errors.factor
@@ -740,9 +740,6 @@ ERROR: windows-error n string ;
         dup n>win32-error-string windows-error
     ] if ;
 
-: throw-win32-error ( -- * )
-    win32-error-string throw ;
-
 : check-invalid-handle ( handle -- handle )
     dup INVALID_HANDLE_VALUE = [ win32-error ] when ;
 
@@ -758,11 +755,7 @@ CONSTANT: expected-io-errors
     expected-io-errors member? ;
 
 : expected-io-error ( error-code -- )
-    dup expected-io-error? [
-        drop
-    ] [
-        throw-win32-error
-    ] if ;
+    expected-io-error? [ win32-error ] unless ;
 
 : io-error ( return-value -- )
     { 0 f } member? [ GetLastError expected-io-error ] when ;

--- a/basis/windows/registry/registry.factor
+++ b/basis/windows/registry/registry.factor
@@ -45,11 +45,7 @@ CONSTANT: registry-value-max-length 16384
     f 0 KEY_ALL_ACCESS f create-key* drop ;
 
 : close-key ( hkey -- )
-    RegCloseKey dup ERROR_SUCCESS = [
-        drop
-    ] [
-        n>win32-error-string throw
-    ] if ;
+    RegCloseKey n>win32-error-check ;
 
 :: with-open-registry-key ( key subkey mode quot -- )
     key subkey mode open-key :> hkey
@@ -82,7 +78,7 @@ PRIVATE>
             key value-name ptr1 lpType buffer
             grow-buffer reg-query-value-ex
         ] [
-            ret n>win32-error-string throw
+            ret throw-windows-error
         ] if
     ] if ;
 

--- a/extra/talks/tc-lisp-talk/tc-lisp-talk.factor
+++ b/extra/talks/tc-lisp-talk/tc-lisp-talk.factor
@@ -456,7 +456,7 @@ xyz
     \"TIME_ZONE_INFORMATION\" <c-object>
     dup GetTimeZoneInformation {
         { TIME_ZONE_ID_INVALID [
-            win32-error-string throw
+            win32-error
         ] }
         { TIME_ZONE_ID_STANDARD [
             TIME_ZONE_INFORMATION-Bias


### PR DESCRIPTION
Hello, dear readers of my full-pull blog!

  In this issue I'd like to unify the throwing of win32 errors in different parts of code, and also use the existing INVALID_HANDLE_VALUE constant instead of the "-1 <alien>" that some people came up with.

  For some reason, applying the last commit in this series leads to gdi+-error being thrown an startup. I, for the life of me, can't track the reason. Can you help me?
