### PR TITLE
NaNs

### DIFF
--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -83,7 +83,7 @@ M: real pprint*
 
 M: float pprint*
     dup fp-nan? [
-        \ NAN: [ fp-nan-payload >hex text ] pprint-prefix
+        \ NAN: [ double>bits >hex text ] pprint-prefix
     ] [
         number-base get {
             { 10 [ number>string text ] }

--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -82,8 +82,8 @@ M: real pprint*
     } case ;
 
 : nan-with-payload? ( f -- ? )
-    [ fp-nan? ] [ 0/0. fp-bitwise= not ]
-    bi and ; inline
+    [ fp-nan? ] [ 0/0. fp-bitwise= not ] [ -0/0. fp-bitwise= not ]
+    tri and and ; inline
 
 M: float pprint*
     dup nan-with-payload? [

--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -81,8 +81,12 @@ M: real pprint*
         [ unsupported-number-base ]
     } case ;
 
+: nan-with-payload? ( f -- ? )
+    [ fp-nan? ] [ 0/0. fp-bitwise= not ]
+    bi and ; inline
+
 M: float pprint*
-    dup fp-nan? [
+    dup nan-with-payload? [
         \ NAN: [ double>bits >hex text ] pprint-prefix
     ] [
         number-base get {

--- a/basis/prettyprint/prettyprint-tests.factor
+++ b/basis/prettyprint/prettyprint-tests.factor
@@ -20,6 +20,7 @@ IN: prettyprint.tests
 { "0x1.0p3" } [ 16 number-base [ 8.0 unparse ] with-variable ] unit-test
 { "1267650600228229401496703205376" } [ 1 100 shift unparse ] unit-test
 { "NAN: 7ff80000deafbeef" } [ NAN: 7ff80000deafbeef unparse ] unit-test
+{ "0/0." } [ 0/0. unparse ] unit-test
 
 { "+" } [ \ + unparse ] unit-test
 

--- a/basis/prettyprint/prettyprint-tests.factor
+++ b/basis/prettyprint/prettyprint-tests.factor
@@ -21,6 +21,7 @@ IN: prettyprint.tests
 { "1267650600228229401496703205376" } [ 1 100 shift unparse ] unit-test
 { "NAN: 7ff80000deafbeef" } [ NAN: 7ff80000deafbeef unparse ] unit-test
 { "0/0." } [ 0/0. unparse ] unit-test
+{ "-0/0." } [ -0/0. unparse ] unit-test
 
 { "+" } [ \ + unparse ] unit-test
 

--- a/basis/prettyprint/prettyprint-tests.factor
+++ b/basis/prettyprint/prettyprint-tests.factor
@@ -19,6 +19,7 @@ IN: prettyprint.tests
 [ 8 number-base [ 8.0 unparse ] with-variable ] [ unsupported-number-base? ] must-fail-with
 { "0x1.0p3" } [ 16 number-base [ 8.0 unparse ] with-variable ] unit-test
 { "1267650600228229401496703205376" } [ 1 100 shift unparse ] unit-test
+{ "NAN: 7ff80000deafbeef" } [ NAN: 7ff80000deafbeef unparse ] unit-test
 
 { "+" } [ \ + unparse ] unit-test
 

--- a/core/math/parser/parser-tests.factor
+++ b/core/math/parser/parser-tests.factor
@@ -1,4 +1,5 @@
-USING: layouts literals math math.parser sequences tools.test ;
+USING: kernel layouts literals math math.parser
+math.parser.private sequences splitting tools.test ;
 
 { f }
 [ f string>number ]
@@ -196,13 +197,18 @@ unit-test
 [ 2+1/2 -1 >base ] [ invalid-radix? ] must-fail-with
 [ 123.456 7 >base ] [ invalid-radix? ] must-fail-with
 
-{ "0/0." } [ 0.0 0.0 / number>string ] unit-test
+{  "0/0." } [ 0.0 0.0 / ?pos number>string ] unit-test
+{ "-0/0." } [ 0.0 0.0 / ?neg number>string ] unit-test
 
 { "1/0." } [ 1.0 0.0 / number>string ] unit-test
 
 { "-1/0." } [ -1.0 0.0 / number>string ] unit-test
 
-{ t } [ "0/0." string>number fp-nan? ] unit-test
+{ t } [  "0/0." string>number fp-nan? ] unit-test
+{ t } [ "-0/0." string>number fp-nan? ] unit-test
+
+{ f } [  "0/0." string>number fp-sign ] unit-test
+{ t } [ "-0/0." string>number fp-sign ] unit-test
 
 { 1/0. } [ "1/0." string>number ] unit-test
 

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -174,7 +174,7 @@ CONSTANT: min-magnitude-2 -1074
     [ drop most-negative-fixnum ] [ neg ] if ; inline
 
 : nan-neg ( n -- -n )
-    double>bits 63 2^ bitxor bits>double ; inline
+    double>bits 63 2^ bitor bits>double ; inline
 
 : ?neg ( n/f -- -n/f )
     [
@@ -184,6 +184,11 @@ CONSTANT: min-magnitude-2 -1074
             [ neg ]
         } cond
     ] [ f ] if* ; inline
+
+: ?pos ( n/f -- +n/f )
+    dup fp-nan? [
+        double>bits 63 2^ bitnot bitand bits>double
+    ] when ; inline
 
 : ?add-ratio ( m n/f -- m+n/f )
     dup ratio? [ + ] [ 2drop f ] if ; inline
@@ -220,8 +225,8 @@ DEFER: @neg-digit
 : @exponent-first-char ( float-parse i number-parse n char -- float-parse n/f )
     {
         { CHAR: - [ [ @exponent-digit ] require-next-digit ?neg ] }
-        { CHAR: + [ [ @exponent-digit ] require-next-digit ] }
-        [ @exponent-digit ]
+        { CHAR: + [ [ @exponent-digit ] require-next-digit ?pos ] }
+        [ @exponent-digit ?pos ]
     } case ; inline
 
 : ->exponent ( float-parse i number-parse n -- float-parse' n/f )
@@ -351,8 +356,8 @@ DEFER: @neg-digit
 : @first-char ( i number-parse n char -- n/f )
     {
         { CHAR: - [ [ @neg-first-digit ] require-next-digit ?neg ] }
-        { CHAR: + [ [ @pos-first-digit ] require-next-digit ] }
-        [ @pos-first-digit ]
+        { CHAR: + [ [ @pos-first-digit ] require-next-digit ?pos ] }
+        [ @pos-first-digit ?pos ]
     } case ; inline
 
 : @neg-first-digit-no-radix ( i number-parse n char -- n/f )
@@ -370,8 +375,8 @@ DEFER: @neg-digit
 : @first-char-no-radix ( i number-parse n char -- n/f )
     {
         { CHAR: - [ [ @neg-first-digit-no-radix ] require-next-digit ?neg ] }
-        { CHAR: + [ [ @pos-first-digit-no-radix ] require-next-digit ] }
-        [ @pos-first-digit-no-radix ]
+        { CHAR: + [ [ @pos-first-digit-no-radix ] require-next-digit ?pos ] }
+        [ @pos-first-digit-no-radix ?pos ]
     } case ; inline
 
 PRIVATE>

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -169,12 +169,20 @@ CONSTANT: min-magnitude-2 -1074
         [ make-float-bin-exponent ]
     } cond ;
 
+: bignum-neg ( n -- -n )
+    dup first-bignum bignum=
+    [ drop most-negative-fixnum ] [ neg ] if ; inline
+
+: nan-neg ( n -- -n )
+    double>bits 63 2^ bitxor bits>double ; inline
+
 : ?neg ( n/f -- -n/f )
     [
-        dup bignum? [
-            dup first-bignum bignum=
-            [ drop most-negative-fixnum ] [ neg ] if
-        ] [ neg ] if
+        {
+            { [ dup bignum? ] [ bignum-neg ] }
+            { [ dup fp-nan? ] [ nan-neg ] }
+            [ neg ]
+        } cond
     ] [ f ] if* ; inline
 
 : ?add-ratio ( m n/f -- m+n/f )

--- a/core/math/parser/parser.factor
+++ b/core/math/parser/parser.factor
@@ -569,7 +569,7 @@ PRIVATE>
 
 M: float >base
     {
-        { [ over fp-nan? ] [ 2drop "0/0." ] }
+        { [ over fp-nan? ] [ drop fp-sign "-0/0." "0/0." ? ] }
         { [ over 1/0. =  ] [ 2drop "1/0." ] }
         { [ over -1/0. = ] [ 2drop "-1/0." ] }
         { [ over  0.0 fp-bitwise= ] [ 2drop  "0.0" ] }

--- a/core/syntax/syntax-docs.factor
+++ b/core/syntax/syntax-docs.factor
@@ -97,7 +97,8 @@ ARTICLE: "syntax-floats" "Float syntax"
 { $table
 { "Positive infinity" { $snippet "1/0." } }
 { "Negative infinity" { $snippet "-1/0." } }
-{ "Not-a-number" { $snippet "0/0." } }
+{ "Not-a-number (positive)" { $snippet "0/0." } }
+{ "Not-a-number (negative)" { $snippet "-0/0." } }
 }
 "A Not-a-number literal with an arbitrary payload can also be input:"
 { $subsections POSTPONE: NAN: }

--- a/core/syntax/syntax-docs.factor
+++ b/core/syntax/syntax-docs.factor
@@ -659,8 +659,8 @@ HELP: NAN:
 { $examples
     { $example
         "USE: prettyprint"
-        "NAN: 80000deadbeef ."
-        "NAN: 80000deadbeef"
+        "NAN: 7ff80000deadbeef ."
+        "NAN: 7ff80000deadbeef"
     }
 } ;
 

--- a/core/syntax/syntax-docs.factor
+++ b/core/syntax/syntax-docs.factor
@@ -101,6 +101,11 @@ ARTICLE: "syntax-floats" "Float syntax"
 }
 "A Not-a-number literal with an arbitrary payload can also be input:"
 { $subsections POSTPONE: NAN: }
+"To see the 64 bit value of " { $snippet "0/0." } " on your platform, execute the following code :"
+{ $code
+    "USING: io math math.parser ;"
+    "\"NAN: \" write 0/0. double>bits >hex print"
+}
 "Hexadecimal, octal and binary float literals are also supported. These consist of a hexadecimal, octal or binary literal with a decimal point and a mandatory base-two exponent expressed as a decimal number after " { $snippet "p" } " or " { $snippet "P" } ":"
 { $example
     "8.0 0x1.0p3 = ."


### PR DESCRIPTION
So I set out to improve factor's printing of NaNs...
Before this PR, all nans prettyprintted as "NAN: payload" (no sign), and `number>string`'d as 0/0.. So for prettyprint, both negative and positive nans with the same payload had the same prettyprinted representation.
Also, entering 0/0. in the listener showed as `NAN: 8000000000000`

At commit b875554ff03, both these issues are fixed (there's a catch, I made the prettyprinter use  `0/0. fp-bitwise=` and I'm not sure if 0/0. is the same value on all platform. So a float might prettyprint as 0/0. on some platform and NAN: xxx on another.. Or the prettyprinted representation "0/0." might unparse to different floats, whereas before NAN: XXX was more precise. Not sure if that's a problem) 

After that, I was thinking that glibc prints nans as "-nan" or "nan", so we could use "0/0." and "-0/0." for number>string. And prettyprint "-0/0." as "-0/0." instead of `NAN: fff8000000000000`
But on my hardware, 0/0. is actually NAN: fff8000000000000 (negative nan) (same for -1 fsqrt ; or other operations with NaNs). So I had to add some code to force the sign of nans in the parse for 0/0. and -0/0.

So depending on what people like, we can merge this PR fully, or just until b875554ff03. What do you think ?
