### PR TITLE
ui.gadgets.tables: implement cell-dim and draw-cell for the f class

### DIFF
--- a/basis/ui/gadgets/tables/tables.factor
+++ b/basis/ui/gadgets/tables/tables.factor
@@ -67,6 +67,9 @@ rows ;
 GENERIC: cell-dim ( font cell -- width height padding )
 GENERIC: draw-cell ( font cell -- )
 
+M: f cell-dim 2drop 0 0 0 ;
+M: f draw-cell 2drop ;
+
 : single-line ( str -- str' )
     dup [ "\r\n" member? ] any? [ string-lines " " join ] when ;
 


### PR DESCRIPTION
I'd like to propose this update for the table gadget. I was creating a window based on the error-list tool design. I needed to display a sequence of tuples as rows, with some slots as the columns. I found that without this patch if there are `f` objects in the cells, the table will throw

```
Generic word cell-dim does not define a method for the POSTPONE: f class.
Dispatching on object: f
```

and fail to render the world. With this fix it renders the table with some empty cells.

What do you think?