### PR TITLE
windows.com.syntax: remove return-type-name import

### DIFF
--- a/basis/windows/com/syntax/syntax.factor
+++ b/basis/windows/com/syntax/syntax.factor
@@ -3,7 +3,7 @@ alien.parser effects kernel windows.ole32 parser lexer splitting
 grouping sequences namespaces assocs quotations generalizations
 accessors words macros alien.syntax fry arrays layouts math
 classes.struct windows.kernel32 locals ;
-FROM: alien.parser.private => parse-pointers return-type-name ;
+FROM: alien.parser.private => parse-pointers ;
 IN: windows.com.syntax
 
 <PRIVATE


### PR DESCRIPTION
This fixes the bootstrap, which was broken in 907d63c16b.