### PR TITLE
bootstrap.image-docs: fix the list of supported architectures

### DIFF
--- a/basis/bootstrap/image/image-docs.factor
+++ b/basis/bootstrap/image/image-docs.factor
@@ -17,7 +17,7 @@ HELP: jit-define
 HELP: make-image
 { $values { "arch" string } }
 { $description "Creates a bootstrap image from sources, where " { $snippet "architecture" } " is one of the following:"
-{ $code "\"x86.32\"" "\"unix-x86.64\"" "\"windows-x86.64\"" "\"linux-ppc\"" }
+{ $code "\"windows-x86.32\"" "\"unix-x86.32\"" "\"windows-x86.64\"" "\"unix-x86.64\"" }
   "The new image file is written to the " { $link resource-path } " and is named " { $snippet "boot." { $emphasis "architecture" } ".image" } "." } ;
 
 HELP: make-jit


### PR DESCRIPTION
I need you to verify this, because I don't know whether "linux-ppc" is still supported or not, and whether "x86.32" is a valid way to specify a target architecture for `make-image`. I have updated the docs so that the list now matches the `image-names` constant, which is used by the `make-images`, about which I also have no idea if it's working or not.

What I do know is that whenever I need to build a win-32 bootstrap (with ctrl-break support) for the latest `master`, I come to `make-image` and try the first item on the list: "x86.32". And it doesn't work! It gives me weird errors about some missing `jit-update-tib` assembler function. Not very helpful, especially since the whole process is very chicken-and-egg confusing. Having went through it about four times now (several months apart), I think I got the hang of it:

- I must get the latest `master` sources;
- apply my `ctrl-break` patch;
- resolve merge conflicts;
- run build.cmd in the 32-bit VS2015 environment;
- make sure it builds factor.exe, and see the bootstrap fail;
- disable fetching the bootstrap image in build.cmd;
- run the factor.exe and execute `make-image` with the correct parameter (**not** "x86.32" as the help suggests) to produce the bootstrap image;
- run build.cmd again to create the full factor.image.