### PR TITLE
Editor sizing

### DIFF
--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -2,7 +2,7 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs calendar colors.constants
 combinators combinators.short-circuit documents
-documents.elements fry grouping kernel locals make math
+documents.elements fry grouping kernel strings locals make math
 math.functions math.order math.ranges math.rectangles
 math.vectors models models.arrow namespaces opengl sequences
 sorting splitting timers ui.baseline-alignment ui.clipboards

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -213,9 +213,24 @@ M: editor draw-gadget*
         [ draw-lines ] [ draw-caret ] bi
     ] with-variable ;
 
+: dim-by-minmax ( editor -- dim ) 
+    [ font>> ] keep
+        [ dup max-rows>> "" resize-string [ drop CHAR: \n ] map
+            swap max-cols>> "" resize-string [ drop CHAR: x ] map append text-dim ]
+        [ control-value text-dim ]
+        [ dup min-rows>> "" resize-string [ drop CHAR: \n ] map
+            swap min-cols>> "" resize-string [ drop CHAR: x ] map append text-dim ]
+    2tri vmax vmin { 1 0 } v+ ;
+
+: dim-by-text ( editor -- dim )
+    [ font>> ] [ control-value ] bi text-dim { 1 0 } v+ ;
+
 M: editor pref-dim*
     ! Add some space for the caret.
-    [ font>> ] [ control-value ] bi text-dim { 1 0 } v+ ;
+    dup { [ min-cols>> ] [ min-rows>> ] [ max-cols>> ] [ max-rows>> ] } cleave and and and
+    [ dim-by-minmax ]
+    [ dim-by-text ]
+    if ;
 
 M: editor baseline font>> font-metrics ascent>> ;
 

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -213,24 +213,37 @@ M: editor draw-gadget*
         [ draw-lines ] [ draw-caret ] bi
     ] with-variable ;
 
-: dim-by-minmax ( editor -- dim ) 
-    [ font>> ] keep
-        [ dup max-rows>> "" resize-string [ drop CHAR: \n ] map
-            swap max-cols>> "" resize-string [ drop CHAR: x ] map append text-dim ]
-        [ control-value text-dim ]
-        [ dup min-rows>> "" resize-string [ drop CHAR: \n ] map
-            swap min-cols>> "" resize-string [ drop CHAR: x ] map append text-dim ]
-    2tri vmax vmin { 1 0 } v+ ;
+<PRIVATE
 
-: dim-by-text ( editor -- dim )
-    [ font>> ] [ control-value ] bi text-dim { 1 0 } v+ ;
+: row,col-dim ( font r c -- dim )
+    "" resize-string [ drop CHAR: x ] map
+    swap "" resize-string [ drop CHAR: \n ] map 
+    append text-dim ;
+
+: min-dim ( font editor -- dim )
+    [ min-rows>> 0 [ and ] most ]
+    [ min-cols>> 0 [ and ] most ] bi
+    row,col-dim ;
+    
+: max-dim ( font editor -- dim )
+    ! hopefully no one goes over 5000
+    [ max-rows>> 5000 [ and ] most ]
+    [ max-cols>> 5000 [ and ] most ] bi
+    row,col-dim ;
+    
+: txt-dim ( font editor -- dim )
+    control-value text-dim ;
+    
+PRIVATE>
 
 M: editor pref-dim*
     ! Add some space for the caret.
-    dup { [ min-cols>> ] [ min-rows>> ] [ max-cols>> ] [ max-rows>> ] } cleave and and and
-    [ dim-by-minmax ]
-    [ dim-by-text ]
-    if ;
+    ! Now respects min/max-row/col parameters
+    [ font>> ] keep
+    [ max-dim ]
+    [ txt-dim ]
+    [ min-dim ] 
+    2tri vmax vmin { 1 0 } v+ ;
 
 M: editor baseline font>> font-metrics ascent>> ;
 


### PR DESCRIPTION
This fixes issue #1697, so that the editor gadget now respects the min/max-row/col parameters when calculating its preferred size.

P.S. new to `git` - let me know if I screwed this up

