### PR TITLE
Editor Sizing

### DIFF
--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -215,25 +215,22 @@ M: editor draw-gadget*
 
 <PRIVATE
 
-: row,col-dim ( font r c -- dim )
-    CHAR: x <string> swap
-    CHAR: \n <string>
-    append text-dim ;
+: col,row-dim ( font c r -- dim )
+    2array swap "m" text-dim v* ;
 
 : min-dim ( font editor -- dim )
-    [ min-rows>> [ 0 ] unless* ]
-    [ min-cols>> [ 0 ] unless* ] bi
-    row,col-dim ;
-
+    [ min-cols>> [ 0 ] unless* ]
+    [ min-rows>> [ 0 ] unless* ] bi
+    col,row-dim ;
+    
 : max-dim ( font editor -- dim )
-    ! hopefully no one goes over 5000
-    [ max-rows>> [ 5000 ] unless* ]
-    [ max-cols>> [ 5000 ] unless* ] bi
-    row,col-dim ;
-
+    [ max-cols>> [ 1/0. ] unless* ]
+    [ max-rows>> [ 1/0. ] unless* ] bi
+    col,row-dim ;
+    
 : txt-dim ( font editor -- dim )
     control-value text-dim ;
-
+    
 PRIVATE>
 
 : editor-constrained-dim ( editor -- dim )

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -242,7 +242,7 @@ PRIVATE>
 
 M: editor pref-dim*
     ! Add some space for the caret.
-    [ font>> ] [ control-value ] bi text-dim { 1 0 } v+ ;
+    editor-constrained-dim ;
 
 M: editor baseline font>> font-metrics ascent>> ;
 


### PR DESCRIPTION
Hopefully the last pull request for issue #1697. The first commit shortens one of the helper functions for computing the dimension, fixes an error in computing the height. The second replaces the old `pref-dim*` with `editor-constrained-dim` so that by default editors obey their size restrictions - if it is decided that the original behavior is preferred, then this commit should be ignored. 
