### PR TITLE
vocabs.loader: prevent vocab-exists? from throwing bad-vocab-name

### DIFF
--- a/core/vocabs/loader/loader.factor
+++ b/core/vocabs/loader/loader.factor
@@ -56,7 +56,8 @@ PRIVATE>
     ] cache ;
 
 : vocab-exists? ( name -- ? )
-    dup lookup-vocab [ ] [ find-vocab-root ] ?if ;
+    [ dup lookup-vocab [ ] [ find-vocab-root ] ?if ]
+    [ dup bad-vocab-name? [ 2drop f ] [ rethrow ] if ] recover ;
 
 : vocab-append-path ( vocab path -- newpath )
     swap find-vocab-root [ prepend-path ] [ drop f ] if* ;


### PR DESCRIPTION
This fixes #1711.