### PR TITLE
interactor: fix issues with readln

### DIFF
--- a/basis/documents/documents.factor
+++ b/basis/documents/documents.factor
@@ -72,6 +72,9 @@ CONSTANT: doc-start { 0 0 }
 : doc-end ( document -- loc )
     [ last-line# ] keep line-end ;
 
+: doc-empty? ( document -- ? )
+    doc-end doc-start = ;
+
 <PRIVATE
 
 : (doc-range) ( from to line# document -- slice )

--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -127,9 +127,14 @@ M: word (print-input)
     [ model>> clear-undo drop ] 2tri ;
 
 : interactor-eof ( interactor -- )
-    dup interactor-busy? [
-        f over interactor-continue
-    ] unless drop ;
+    dup interactor-busy? [ drop ] [
+        [
+            [ model>> doc-empty? not ]
+            [ control-value ]
+            [ interactor-finish ]
+            tri f ?
+        ] keep interactor-continue
+    ] if ;
 
 : evaluate-input ( interactor -- )
     dup interactor-busy? [ drop ] [


### PR DESCRIPTION
This fixes one part of the issue #1281 where multiple `readln` discarded available user input. One drawback to this fix is that it introduces a change in behavior on the listener for the case where there are fewer `readln` invocations on the `interactor` being evaluated than the number of lines pasted into the listener. This behavior is similar to how `decoder` works outside the UI.

E.g. Enter on the listener `readln readln`, then paste the below input:

```
Line1
Line2
Line3
```

Then will cause an error to appear soon after due to the remaining extra input:

```
1: Line3
       ^
No word named “Line3” found in current vocabulary search path
```
