### PR TITLE
snake-game.*: fix name in the copyright

### DIFF
--- a/extra/snake-game/constants/constants.factor
+++ b/extra/snake-game/constants/constants.factor
@@ -1,4 +1,4 @@
-! Copyright (C) 2015 Your name.
+! Copyright (C) 2015 Sankaranarayanan Viswanathan.
 ! See http://factorcode.org/license.txt for BSD license.
 IN: snake-game.constants
 

--- a/extra/snake-game/game/game.factor
+++ b/extra/snake-game/game/game.factor
@@ -1,4 +1,4 @@
-! Copyright (C) 2015 Your name.
+! Copyright (C) 2015 Sankaranarayanan Viswanathan.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays combinators kernel make math random
 sequences sets snake-game.constants snake-game.util sorting ;

--- a/extra/snake-game/input/input.factor
+++ b/extra/snake-game/input/input.factor
@@ -1,4 +1,4 @@
-! Copyright (C) 2015 Your name.
+! Copyright (C) 2015 Sankaranarayanan Viswanathan.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: assocs sets snake-game.constants ;
 IN: snake-game.input

--- a/extra/snake-game/sprites/sprites.factor
+++ b/extra/snake-game/sprites/sprites.factor
@@ -1,4 +1,4 @@
-! Copyright (C) 2015 Your name.
+! Copyright (C) 2015 Sankaranarayanan Viswanathan.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs byte-vectors formatting fry
 images images.loader kernel locals make math math.vectors

--- a/extra/snake-game/ui/ui.factor
+++ b/extra/snake-game/ui/ui.factor
@@ -1,4 +1,4 @@
-! Copyright (C) 2015 Your name.
+! Copyright (C) 2015 Sankaranarayanan Viswanathan.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs calendar combinators destructors
 formatting kernel make math namespaces opengl opengl.textures

--- a/extra/snake-game/util/util.factor
+++ b/extra/snake-game/util/util.factor
@@ -1,4 +1,4 @@
-! Copyright (C) 2015 Your name.
+! Copyright (C) 2015 Sankaranarayanan Viswanathan.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: arrays assocs combinators kernel math sequences
 snake-game.constants ;


### PR DESCRIPTION
The author forgot to set his name before scaffolding the sources. In all files but the main one. I have copied the name from the main file to all the others.

I have searched the entire codebase for instances of "! Copyright.*Your " and these were the only ones I found.