### PR TITLE
Distributed messaging Fix

### DIFF
--- a/basis/concurrency/distributed/distributed-docs.factor
+++ b/basis/concurrency/distributed/distributed-docs.factor
@@ -1,5 +1,12 @@
-USING: help.markup help.syntax concurrency.messaging threads ;
+USING: help.markup help.syntax concurrency.messaging io.servers threads ;
 IN: concurrency.distributed
+
+HELP: local-node
+{ $var-description "A variable containing the " { $link threaded-server } " the current node is running on." } ;
+
+HELP: start-node
+{ $values { "addrspec" "an addrspec to listen on" } }
+{ $description "Starts a " { $link threaded-server } " for receiving messages from remote Factor instances." } ;
 
 ARTICLE: "concurrency.distributed.example" "Distributed Concurrency Example"
 "In this example the Factor instance associated with port 9000 will run "
@@ -11,7 +18,7 @@ ARTICLE: "concurrency.distributed.example" "Distributed Concurrency Example"
         "[ log-message ] \"logger\" spawn dup name>> register-remote-thread"
     }
 }
-"This spawns a thread waits for the messages. It registers that thread as a "
+"This spawns a thread waits for the messages. It registers that thread as "
 "able to be accessed remotely using " { $link register-remote-thread } "."
 $nl
 "The second Factor instance, the one associated with port 9001, can send "
@@ -38,7 +45,8 @@ $nl
 
 ARTICLE: "concurrency.distributed" "Distributed message passing"
 "The " { $vocab-link "concurrency.distributed" } " implements transparent distributed message passing, inspired by Erlang and Termite." $nl
-"Instances of " { $link thread } " can be sent to remote threads, at which point they are converted to objects holding the thread ID and the current node's host name:"
+{ $subsections local-node start-node }
+"Instances of " { $link thread } " can be sent to remote nodes, at which point they are converted to objects holding the thread ID and the current node's addrspec:"
 { $subsections remote-thread }
 "The " { $vocab-link "serialize" } " vocabulary is used to convert Factor objects to byte arrays for transfer over a socket."
 { $subsections "concurrency.distributed.example" } ;

--- a/basis/concurrency/distributed/distributed-tests.factor
+++ b/basis/concurrency/distributed/distributed-tests.factor
@@ -1,40 +1,26 @@
-USING: tools.test concurrency.distributed kernel io.files
-io.files.temp io.directories arrays io.sockets system calendar
-combinators threads math sequences concurrency.messaging
-continuations accessors prettyprint io.servers ;
+USING: arrays calendar concurrency.distributed
+concurrency.messaging io.sockets kernel math namespaces
+sequences threads tools.test ;
 FROM: concurrency.messaging => receive send ;
 IN: concurrency.distributed.tests
 
 CONSTANT: test-ip "127.0.0.1"
+CONSTANT: test-port 57234
 
-: test-node-server ( -- threaded-server )
-    {
-        { [ os unix? ] [ "distributed-concurrency-test" temp-file <local> ] }
-        { [ os windows? ] [ test-ip 0 <inet4> ] }
-    } cond <node-server> ;
-
-: test-node-client ( -- addrspec )
-    {
-        { [ os unix? ] [ "distributed-concurrency-test" temp-file <local> ] }
-        { [ os windows? ] [ insecure-addr ] }
-    } cond ;
-
-os unix? [
-    "distributed-concurrency-test" temp-file ?delete-file
-] when
-
-test-node-server [
-    [ ] [
+[ 8 ] [
+    local-node get
+    test-ip test-port <inet4> start-node
+    local-node get swap local-node set-global
+    local-node [
         [
             receive first2 [ 3 + ] dip send
             "thread-a" unregister-remote-thread
         ] "Thread A" spawn
         "thread-a" register-remote-thread
-    ] unit-test
-
-    [ 8 ] [
         5 self 2array
-        test-node-client "thread-a" <remote-thread> send
+        test-ip test-port <inet4> "thread-a" <remote-thread> send
         100 seconds receive-timeout
-    ] unit-test
-] with-threaded-server
+        stop-node
+    ] with-variable
+] unit-test
+

--- a/basis/concurrency/distributed/distributed.factor
+++ b/basis/concurrency/distributed/distributed.factor
@@ -22,6 +22,8 @@ PRIVATE>
 : get-remote-thread ( name -- thread )
     dup registered-remote-threads at [ ] [ threads at ] ?if ;
 
+SYMBOL: local-node
+
 : handle-node-client ( -- )
     deserialize
     [ first2 get-remote-thread send ] [ stop-this-server ] if* ;
@@ -31,6 +33,9 @@ PRIVATE>
         swap >>insecure
         "concurrency.distributed" >>name
         [ handle-node-client ] >>handler ;
+
+: start-node ( addrspec -- )
+    <node-server> start-server local-node set-global ;
 
 TUPLE: remote-thread node id ;
 
@@ -44,10 +49,10 @@ M: remote-thread send ( message thread -- )
     send-remote-message ;
 
 M: thread (serialize) ( obj -- )
-    id>> [ insecure-addr ] dip <remote-thread> (serialize) ;
+    id>> [ local-node get insecure>> ] dip <remote-thread> (serialize) ;
 
-: stop-node ( node -- )
-    f swap send-remote-message ;
+: stop-node ( -- )
+    local-node get insecure>> f swap send-remote-message ;
 
 [
     H{ } clone \ registered-remote-threads set-global


### PR DESCRIPTION
This fixes distributed messaging so that it works again. Changes in commit f20ee7a53b264fda515d2a55c8fbea26261de016 broke some use cases - in particular the remote channels functionality.

The test uses a hard coded port. I couldn't work out how to do a randomly generated port that worked with threaded-server. 