### PR TITLE
Avl

### DIFF
--- a/extra/trees/avl/avl-tests.factor
+++ b/extra/trees/avl/avl-tests.factor
@@ -3,7 +3,7 @@ assocs accessors trees.avl.private trees.private ;
 IN: trees.avl.tests
 
 { "key1" 0 "key2" 0 } [
-    T{ avl-node f "key1" f f T{ avl-node f "key2" f f 1 } 2 }
+    T{ avl-node f "key1" f f T{ avl-node f "key2" f f f 1 } 2 }
     [ single-rotate ] go-left
     [ left>> dup key>> swap balance>> ] keep
     dup key>> swap balance>>

--- a/extra/trees/avl/avl-tests.factor
+++ b/extra/trees/avl/avl-tests.factor
@@ -2,31 +2,35 @@ USING: kernel tools.test trees trees.avl math random sequences
 assocs accessors trees.avl.private trees.private ;
 IN: trees.avl.tests
 
-{ "key1" 0 "key2" 0 } [
-    T{ avl-node f "key1" f f T{ avl-node f "key2" f f f 1 } 2 }
+{ "key1" 0 "key3" "key2" 0 } [
+    T{ avl-node f "key1" f f T{ avl-node f "key2" f T{ avl-node f "key3" } f 1 } 2 }
     [ single-rotate ] go-left
     [ left>> dup key>> swap balance>> ] keep
+    [ left>> right>> key>> ] keep
     dup key>> swap balance>>
 ] unit-test
 
-{ "key1" 0 "key2" 0 } [
-    T{ avl-node f "key1" f f T{ avl-node f "key2" f f f 1 } 2 }
+{ "key1" 0 "key3" "key2" 0 } [
+    T{ avl-node f "key1" f f T{ avl-node f "key2" f T{ avl-node f "key3" } f 1 } 2 }
     [ select-rotate ] go-left
     [ left>> dup key>> swap balance>> ] keep
+    [ left>> right>> key>> ] keep
     dup key>> swap balance>>
 ] unit-test
 
-{ "key1" 0 "key2" 0 } [
-    T{ avl-node f "key1" f T{ avl-node f "key2" f f f -1 } f -2 }
+{ "key1" 0 "key3" "key2" 0 } [
+    T{ avl-node f "key1" f T{ avl-node f "key2" f f T{ avl-node f "key3" } -1 } f -2 }
     [ single-rotate ] go-right
     [ right>> dup key>> swap balance>> ] keep
+    [ right>> left>> key>> ] keep
     dup key>> swap balance>>
 ] unit-test
 
-{ "key1" 0 "key2" 0 } [
-    T{ avl-node f "key1" f T{ avl-node f "key2" f f f -1 } f -2 }
+{ "key1" 0 "key3" "key2" 0 } [
+    T{ avl-node f "key1" f T{ avl-node f "key2" f f T{ avl-node f "key3" } -1 } f -2 }
     [ select-rotate ] go-right
     [ right>> dup key>> swap balance>> ] keep
+    [ right>> left>> key>> ] keep
     dup key>> swap balance>>
 ] unit-test
 

--- a/extra/trees/avl/avl.factor
+++ b/extra/trees/avl/avl.factor
@@ -23,10 +23,9 @@ TUPLE: avl-node < node balance ;
     '[ _ + ] change-balance ;
 
 : rotate ( node -- node )
-    dup
-    [ node+link ]
-    [ node-link ]
-    [ set-node+link ] tri
+    dup node+link
+    dup node-link
+    pick set-node+link
     [ set-node-link ] keep ;
 
 : single-rotate ( node -- node )


### PR DESCRIPTION
Hi,
```factor
{
    { 0 0 }    { 1 1 }    { 3 3 }    { 4 4 }
    { 6 6 }    { 2 2 }    { 7 7 }    { 5 5 }
} >avl
```
throws retain-stack overflow. This is because ```rotate``` creates cycles in the tree and you get infinite recursion.

The error is actually visible with ```AVL{ { 0 0 } { 1 1 } { 2 2 } { 3 3 } { 4 4 } { 5 5 } } ...``` . This tree contains the node '0' twice and lost the node '2'.

This PR fixes it and improve the test coverage of rotate to avoid future regressions.

Note: for all the permutations of 0-8, the probability to throw is 0.7% ... Found the testcase by bruteforcing them. But as the tree gets bigger, the probability to throw increases exponentially. A random tree with 50 nodes is basically impossible to build..