### PR TITLE
Fix trails

### DIFF
--- a/extra/trails/trails.factor
+++ b/extra/trails/trails.factor
@@ -54,7 +54,7 @@ TUPLE: trails-gadget < gadget paused points ;
     ]
     loop
   ]
-  in-thread ;
+  "trails" spawn drop ;
 
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/extra/trails/trails.factor
+++ b/extra/trails/trails.factor
@@ -58,6 +58,10 @@ TUPLE: trails-gadget < gadget paused points ;
 
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+M: trails-gadget ungraft* ( trails-gadget -- ) t >>paused drop ;
+
+! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 M: trails-gadget pref-dim* ( trails-gadget -- dim ) drop { 500 500 } ;
 
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
I found that the `trails` vocab leaves its thread behind, and it eats 100% CPU in the background.
This fixes it.