### PR TITLE
Fix set-query-params usage

### DIFF
--- a/extra/google/charts/charts-tests.factor
+++ b/extra/google/charts/charts-tests.factor
@@ -1,0 +1,35 @@
+! Copyright (C) 2016 Alexander Ilin.
+! See http://factorcode.org/license.txt for BSD license.
+USING: accessors colors.constants google.charts
+google.charts.private kernel present sequences tools.test ;
+IN: google.charts.tests
+
+[ f ] [
+    { 0 0 } <line> COLOR: red >>background chart>url present length
+    { 0 0 } <line> chart>url present length =
+] unit-test
+
+[ f ] [
+    { 0 0 } <line> COLOR: red >>foreground chart>url present length
+    { 0 0 } <line> chart>url present length =
+] unit-test
+
+[ f ] [
+    "" <formula> t >>data-scale chart>url present length
+    "" <formula> chart>url present length =
+] unit-test
+
+[ f ] [
+    { 0 0 } <line> f >>width f >>height chart>url present length
+    { 0 0 } <line> chart>url present length =
+] unit-test
+
+[ f ] [
+    { 0 0 } <line> { 0 0 } >>margin chart>url present length
+    { 0 0 } <line> chart>url present length =
+] unit-test
+
+[ f ] [
+    { 0 0 } <line> 5 >>bar-width chart>url present length
+    { 0 0 } <line> chart>url present length =
+] unit-test

--- a/extra/google/charts/charts.factor
+++ b/extra/google/charts/charts.factor
@@ -71,7 +71,7 @@ PRIVATE>
 <PRIVATE
 
 : chart>url ( chart -- url )
-    [ URL" http://chart.googleapis.com/chart" ] dip {
+    [ URL" http://chart.googleapis.com/chart" clone ] dip {
         [ type>> "cht" set-query-param ]
         [
             [ width>> ] [ height>> ] bi 2dup and [

--- a/extra/google/search/search.factor
+++ b/extra/google/search/search.factor
@@ -10,7 +10,7 @@ IN: google.search
 <PRIVATE
 
 : search-url ( query -- url )
-    URL" http://ajax.googleapis.com/ajax/services/search/web"
+    URL" http://ajax.googleapis.com/ajax/services/search/web" clone
         "1.0" "v" set-query-param
         swap "q" set-query-param
         "8" "rsz" set-query-param

--- a/extra/webapps/calculator/calculator.factor
+++ b/extra/webapps/calculator/calculator.factor
@@ -22,7 +22,7 @@ TUPLE: calculator < dispatcher ;
             { "y" [ v-number ] }
         } validate-params
 
-        URL" $calculator" "x" value "y" value + "z" set-query-param
+        URL" $calculator" clone "x" value "y" value + "z" set-query-param
         <redirect>
     ] >>submit ;
 

--- a/extra/webapps/mason/report/report.factor
+++ b/extra/webapps/mason/report/report.factor
@@ -17,7 +17,7 @@ IN: webapps.mason.report
         [ build-report ] >>display ;
 
 : report-link ( builder -- xml )
-    [ URL" report" ] dip
+    [ URL" report" clone ] dip
     [ os>> "os" set-query-param ]
     [ cpu>> "cpu" set-query-param ] bi
     [XML <a href=<->>Latest build report</a> XML] ;

--- a/extra/webapps/mason/utils/utils.factor
+++ b/extra/webapps/mason/utils/utils.factor
@@ -46,15 +46,15 @@ IN: webapps.mason.utils
     adjust-url ;
 
 : package-url ( builder -- url )
-    [ URL" http://builds.factorcode.org/package" ] dip
+    [ URL" http://builds.factorcode.org/package" clone ] dip
     platform-url ;
 
 : report-url ( builder -- url )
-    [ URL" http://builds.factorcode.org/report" ] dip
+    [ URL" http://builds.factorcode.org/report" clone ] dip
     platform-url ;
 
 : release-url ( builder -- url )
-    [ URL" http://builds.factorcode.org/release" ] dip
+    [ URL" http://builds.factorcode.org/release" clone ] dip
     platform-url ;
 
 : validate-secret ( -- )


### PR DESCRIPTION
The first commit here fixes an actual issue with `google.charts`, the second one sort of proactively tries to do the right thing elsewhere.