### PR TITLE
vocabs.loader: stop add-vocab-root spawning extra monitoring threads

### DIFF
--- a/core/vocabs/loader/loader.factor
+++ b/core/vocabs/loader/loader.factor
@@ -21,9 +21,8 @@ SYMBOL: add-vocab-root-hook
 ] "vocabs.loader" add-startup-hook
 
 : add-vocab-root ( root -- )
-    trim-tail-separators
-    [ vocab-roots get adjoin ]
-    [ add-vocab-root-hook get-global call( root -- ) ] bi ;
+    trim-tail-separators dup vocab-roots get ?adjoin
+    [ add-vocab-root-hook get-global call( root -- ) ] [ drop ] if ;
 
 SYMBOL: root-cache
 root-cache [ H{ } clone ] initialize


### PR DESCRIPTION
This fixes issue #1758.