### PR TITLE
grouping-docs: add wrap-around note

### DIFF
--- a/basis/grouping/grouping-docs.factor
+++ b/basis/grouping/grouping-docs.factor
@@ -12,7 +12,7 @@ ARTICLE: "grouping" "Groups and clumps"
 { $subsections circular-clump }
 "A virtual sequence for splitting a sequence into overlapping, fixed-length subsequences:"
 { $subsections clumps <clumps> }
-"A virtual sequence for splitting a sequence into overlapping, fixed-length subsequences:"
+"A virtual sequence for splitting a sequence into overlapping, fixed-length subsequences, wrapping around the end of the sequence:"
 { $subsections circular-clumps <circular-clumps> }
 "The difference can be summarized as the following:"
 { $list


### PR DESCRIPTION
Added "wrapping around the end of the sequence" to the description of <circular-clumps>, for consistency with the description of circular-clump.