### PR TITLE
compiler.cfg: add peephole opt to never untag the input of ##bit-coun…

### DIFF
--- a/basis/compiler/cfg/representations/peephole/peephole.factor
+++ b/basis/compiler/cfg/representations/peephole/peephole.factor
@@ -281,3 +281,6 @@ M: ##not optimize-insn
         }
         [ call-next-method ]
     } cond ;
+
+M: ##bit-count optimize-insn
+    [ no-use-conversion ] [ finish ] [ emit-def-conversion ] tri ;

--- a/basis/compiler/cfg/representations/representations-tests.factor
+++ b/basis/compiler/cfg/representations/representations-tests.factor
@@ -897,3 +897,21 @@ cpu x86.64? [
         T{ ##replace f 1 D: 0 }
     } test-peephole
 ] unit-test
+
+! untag elimination for ##bit-count
+2 vreg-counter set-global
+
+{
+    V{
+        T{ ##peek f 0 D: 0 }
+        T{ ##bit-count f 3 0 }
+        T{ ##shl-imm f 1 3 $[ tag-bits get ] }
+        T{ ##replace f 1 D: 0 }
+    }
+} [
+    V{
+        T{ ##peek f 0 D: 0 }
+        T{ ##bit-count f 1 0 }
+        T{ ##replace f 1 D: 0 }
+    } test-peephole
+] unit-test

--- a/basis/compiler/cfg/representations/selection/selection.factor
+++ b/basis/compiler/cfg/representations/selection/selection.factor
@@ -109,7 +109,8 @@ UNION: peephole-optimizable
     ##test-imm
     ##test
     ##test-imm-branch
-    ##test-branch ;
+    ##test-branch
+    ##bit-count ;
 
 GENERIC: compute-insn-costs ( insn -- )
 


### PR DESCRIPTION
…t. fixes #1764

I'm not sure how the value of vreg-counter is chosen in the test.. I know it will be used to generate a unique vreg for the newly created untag instruction, but the file has values like 5, 3, 6 etc. What's going on ??