### PR TITLE
Doctype

### DIFF
--- a/basis/furnace/recaptcha/example/example.xml
+++ b/basis/furnace/recaptcha/example/example.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' ?>
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 <html><body><t:form t:action=""><t:recaptcha/></t:form></body></html>
 </t:chloe>

--- a/basis/furnace/recaptcha/recaptcha.xml
+++ b/basis/furnace/recaptcha/recaptcha.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' ?>
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 <html>
 	<body><t:recaptcha/>

--- a/basis/html/components/components-tests.factor
+++ b/basis/html/components/components-tests.factor
@@ -145,10 +145,10 @@ M: link-test link-href drop "http://www.apple.com/foo&bar" ;
 ] unit-test
 
 { } [
-    "<html>arbitrary <b>markup</b> for the win!</html>" "html" set-value
+    "<!DOCTYPE html><html>arbitrary <b>markup</b> for the win!</html>" "html" set-value
 ] unit-test
 
-{ "<html>arbitrary <b>markup</b> for the win!</html>" } [
+{ "<!DOCTYPE html><html>arbitrary <b>markup</b> for the win!</html>" } [
     [ "html" html render ] with-string-writer
 ] unit-test
 

--- a/basis/html/templates/chloe/chloe-tests.factor
+++ b/basis/html/templates/chloe/chloe-tests.factor
@@ -32,7 +32,7 @@ IN: html.templates.chloe.tests
     ] with-scope
 ] unit-test
 
-{ "<html><head><title>Hello world</title></head><body>Blah blah</body></html>" } [
+{ "<!DOCTYPE html><html><head><title>Hello world</title></head><body>Blah blah</body></html>" } [
     [
         [
             "test2" test-template call-template

--- a/basis/html/templates/chloe/test/test3.xml
+++ b/basis/html/templates/chloe/test/test3.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' ?>
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 	<html>
 		<head>

--- a/basis/html/templates/fhtml/test/example.fhtml
+++ b/basis/html/templates/fhtml/test/example.fhtml
@@ -1,5 +1,5 @@
 <% USING: math ; %>
-
+<!DOCTYPE html>
 <html>
     <head><title>Simple Embedded Factor Example</title></head>
     <body>

--- a/basis/html/templates/fhtml/test/example.html
+++ b/basis/html/templates/fhtml/test/example.html
@@ -1,5 +1,4 @@
-
-
+<!DOCTYPE html>
 <html>
     <head><title>Simple Embedded Factor Example</title></head>
     <body>

--- a/basis/http/http-tests.factor
+++ b/basis/http/http-tests.factor
@@ -345,7 +345,7 @@ SYMBOL: a
 <dispatcher>
     <action>
         [ a get-global "a" set-value ] >>init
-        [ [ "<html>" write "a" <field> render "</html>" write ] "text/html" <content> ] >>display
+        [ [ "<!DOCTYPE html><html>" write "a" <field> render "</html>" write ] "text/html" <content> ] >>display
         [ { { "a" [ v-integer ] } } validate-params ] >>validate
         [ "a" value a set-global URL" " <redirect> ] >>submit
     <conversations>

--- a/basis/http/server/responses/responses.factor
+++ b/basis/http/server/responses/responses.factor
@@ -20,6 +20,7 @@ IN: http.server.responses
 
 : trivial-response-body ( code message -- )
     <XML
+        <!DOCTYPE html>
         <html>
             <body>
                 <h1><-> <-></h1>

--- a/basis/http/test/foo.html
+++ b/basis/http/test/foo.html
@@ -1,1 +1,1 @@
-<html><head><title>Hello</title></head><body>HTTPd test</body></html>
+<!DOCTYPE html><html><head><title>Hello</title></head><body>HTTPd test</body></html>

--- a/basis/lists/lazy/old-doc.html
+++ b/basis/lists/lazy/old-doc.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Lazy Evaluation</title>

--- a/basis/xml/writer/writer-docs.factor
+++ b/basis/xml/writer/writer-docs.factor
@@ -56,10 +56,11 @@ HELP: indenter
 HELP: sensitive-tags
 { $var-description "Contains a sequence of " { $link name } "s where whitespace should be considered significant for prettyprinting purposes. The sequence can contain " { $link string } "s in place of names. For example, to preserve whitespace inside a " { $snippet "pre" } " tag:" }
 { $example "USING: xml.syntax xml.writer namespaces ;
-[XML <html> <head>   <title> something</title></head><body><pre>bing
+[XML <!DOCTYPE html> <html> <head>   <title> something</title></head><body><pre>bing
 bang
    bong</pre></body></html> XML] { \"pre\" } sensitive-tags [ pprint-xml ] with-variable"
 "
+<!DOCTYPE html>
 <html>
   <head>
     <title>

--- a/basis/xmode/code2html/code2html.factor
+++ b/basis/xmode/code2html/code2html.factor
@@ -28,7 +28,7 @@ IN: xmode.code2html
     [ "" ] [ path over first find-mode htmlize-lines ]
     if-empty :> input
     default-stylesheet :> stylesheet
-    <XML <html>
+    <XML <!DOCTYPE html> <html>
         <head>
             <-stylesheet->
             <title><-path-></title>

--- a/extra/codebook/codebook.factor
+++ b/extra/codebook/codebook.factor
@@ -96,7 +96,7 @@ TUPLE: code-file
     file mode>> load-mode :> rules
     f lines [| l i | l rules tokenize-line i 1 + line#len line#>string htmlize-tokens ]
     map-index concat nip :> html-lines
-    <XML <html>
+    <XML <!DOCTYPE html> <html>
         <head>
             <title><-name-></title>
             <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
@@ -116,7 +116,7 @@ TUPLE: code-file
     dir [
         files toc-list :> toc
 
-        <XML <html>
+        <XML <!DOCTYPE html> <html>
             <head>
                 <title><-name-></title>
                 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />

--- a/extra/html/parser/analyzer/analyzer-tests.factor
+++ b/extra/html/parser/analyzer/analyzer-tests.factor
@@ -32,7 +32,7 @@ IN: html.parser.analyzer.tests
     T{ tag f text f "foo" f }
 }
 } [
-    "<html><head><title>foo</title></head></html>" parse-html
+    "<!DOCTYPE html><html><head><title>foo</title></head></html>" parse-html
     "title" find-between-first
 ] unit-test
 

--- a/extra/mason/report/report-tests.factor
+++ b/extra/mason/report/report-tests.factor
@@ -10,6 +10,7 @@ mason.report mason.common mason.config namespaces tools.test xml xml.writer ;
      [ ] [ "report" delete-file ] unit-test ;
 
 "builds" temp-file builds-dir [
+    builds-dir get
     [
         "resource:extra/mason/report/fake-data/" "." copy-tree
 
@@ -29,5 +30,5 @@ mason.report mason.common mason.config namespaces tools.test xml xml.writer ;
         [ status-error ] [ 1236 test-failed ] unit-test
         verify-report
 
-    ] with-temp-directory
+    ] with-directory
 ] with-variable

--- a/extra/mason/report/report.factor
+++ b/extra/mason/report/report.factor
@@ -32,7 +32,7 @@ IN: mason.report
     '[
         common-report
         _ call( -- xml )
-        [XML <html><body><-><-></body></html> XML]
+        [XML <!DOCTYPE html><html><body><-><-></body></html> XML]
         write-xml
     ] with-file-writer ; inline
 

--- a/extra/mason/report/report.factor
+++ b/extra/mason/report/report.factor
@@ -32,7 +32,7 @@ IN: mason.report
     '[
         common-report
         _ call( -- xml )
-        [XML <!DOCTYPE html><html><body><-><-></body></html> XML]
+        [XML <div><-><-></div> XML]
         write-xml
     ] with-file-writer ; inline
 

--- a/extra/parser-combinators/parser-combinators.html
+++ b/extra/parser-combinators/parser-combinators.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Parser Combinators</title>

--- a/extra/webapps/imagebin/upload-image.xml
+++ b/extra/webapps/imagebin/upload-image.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' ?>
+<!DOCTYPE html>
 <html>
 <head><title>Upload</title></head>
 <body>

--- a/extra/webapps/imagebin/upload-image.xml
+++ b/extra/webapps/imagebin/upload-image.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' ?>
 <!DOCTYPE html>
 <html>
 <head><title>Upload</title></head>

--- a/extra/webapps/imagebin/uploaded-image.xml
+++ b/extra/webapps/imagebin/uploaded-image.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' ?>
 <!DOCTYPE html>
 <html>
 <head><title>Uploaded</title></head>

--- a/extra/webapps/imagebin/uploaded-image.xml
+++ b/extra/webapps/imagebin/uploaded-image.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' ?>
+<!DOCTYPE html>
 <html>
 <head><title>Uploaded</title></head>
 <body>

--- a/extra/webapps/mason/backend/watchdog/watchdog.factor
+++ b/extra/webapps/mason/backend/watchdog/watchdog.factor
@@ -7,6 +7,7 @@ IN: webapps.mason.backend.watchdog
 : crashed-builder-body ( crashed-builders -- string content-type )
     [ os/cpu [XML <li><-></li> XML] ] map
     <XML
+        <!DOCTYPE html>
         <html>
             <body>
                 <p>Machines which are not sending heartbeats:</p>

--- a/extra/webapps/site-watcher/common/site-watcher.xml
+++ b/extra/webapps/site-watcher/common/site-watcher.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' ?>
-
+<!DOCTYPE html>
 <t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
 
 <html>

--- a/unmaintained/tangle/resources/weave.html
+++ b/unmaintained/tangle/resources/weave.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <script type="text/javascript" src="jquery-1.2.3.min.js"></script>

--- a/unmaintained/webapps/numbers/numbers.factor
+++ b/unmaintained/webapps/numbers/numbers.factor
@@ -40,6 +40,7 @@ IN: webapps.numbers
   ! Display the string in a web page.
   [
     swap dup
+    "<!DOCTYPE html>" print
     <html>
       <head> <title> write </title> </head>
       <body>
@@ -51,6 +52,7 @@ IN: webapps.numbers
 
 : read-number ( -- )
   [
+    "<!DOCTYPE html>" print
     <html>
       <head> <title> "Enter a number" write </title> </head>
       <body>


### PR DESCRIPTION
The first commit adds DOCTYPE html everywhere where it made sense, continuing the work of 4ef4235

The second commit fixes the mason report page (eg http://builds.factorcode.org/report?os=linux&cpu=x86.64 ) , it has a spurious <html><body>  next to the report table.

The third commit fixes mason report unit tests. Does someone know if these tests are running on the build farm ? I'm not seeing the failures on the report. Or I misunderstood something and they somehow pass on the build-farm ??