### PR TITLE
French number>text modern usage + ratios

### DIFF
--- a/extra/math/text/french/french-tests.factor
+++ b/extra/math/text/french/french-tests.factor
@@ -1,19 +1,19 @@
 USING: math math.functions math.parser math.text.french sequences tools.test ;
 
 { "zéro" } [ 0 number>text ] unit-test
-{ "vingt et un" } [ 21 number>text ] unit-test
+{ "vingt-et-un" } [ 21 number>text ] unit-test
 { "vingt-deux" } [ 22 number>text ] unit-test
-{ "deux mille" } [ 2000 number>text ] unit-test
-{ "soixante et un" } [ 61 number>text ] unit-test
+{ "deux-mille" } [ 2000 number>text ] unit-test
+{ "soixante-et-un" } [ 61 number>text ] unit-test
 { "soixante-deux" } [ 62 number>text ] unit-test
 { "quatre-vingts" } [ 80 number>text ] unit-test
 { "quatre-vingt-un" } [ 81 number>text ] unit-test
 { "quatre-vingt-onze" } [ 91 number>text ] unit-test
-{ "deux cents" } [ 200 number>text ] unit-test
-{ "mille deux cents" } [ 1200 number>text ] unit-test
-{ "mille deux cent quatre-vingts" } [ 1280 number>text ] unit-test
-{ "mille deux cent quatre-vingt-un" } [ 1281 number>text ] unit-test
-{ "un billion deux cent vingt milliards quatre-vingts millions trois cent quatre-vingt mille deux cents" } [ 1220080380200 number>text ] unit-test
+{ "deux-cents" } [ 200 number>text ] unit-test
+{ "mille-deux-cents" } [ 1200 number>text ] unit-test
+{ "mille-deux-cent-quatre-vingts" } [ 1280 number>text ] unit-test
+{ "mille-deux-cent-quatre-vingt-un" } [ 1281 number>text ] unit-test
+{ "un billion deux-cent-vingt milliards quatre-vingts millions trois-cent-quatre-vingt-mille-deux-cents" } [ 1220080380200 number>text ] unit-test
 { "un million" } [ 1000000 number>text ] unit-test
 { "un million un" } [ 1000001 number>text ] unit-test
 { "moins vingt" } [ -20 number>text ] unit-test

--- a/extra/math/text/french/french-tests.factor
+++ b/extra/math/text/french/french-tests.factor
@@ -20,3 +20,15 @@ USING: math math.functions math.parser math.text.french sequences tools.test ;
 { 104 } [ -1 10 102 ^ - number>text length ] unit-test
 ! Check that we do not exhaust stack
 { 1484 } [ 10 100 ^ 1 - number>text length ] unit-test
+{ "un demi" } [ 1/2 number>text ] unit-test
+{ "trois demis" } [ 3/2 number>text ] unit-test
+{ "un tiers" } [ 1/3 number>text ] unit-test
+{ "deux tiers" } [ 2/3 number>text ] unit-test
+{ "un quart" } [ 1/4 number>text ] unit-test
+{ "un cinquième" } [ 1/5 number>text ] unit-test
+{ "un seizième" } [ 1/16 number>text ] unit-test
+{ "mille cent-vingt-septièmes" } [ 1000/127 number>text ] unit-test
+{ "mille-cent vingt-septièmes" } [ 1100/27 number>text ] unit-test
+{ "mille-cent-dix-neuf septièmes" } [ 1119/7 number>text ] unit-test
+{ "moins un quatre-vingtième" } [ -1/80 number>text ] unit-test
+{ "moins dix-neuf quatre-vingtièmes" } [ -19/80 number>text ] unit-test

--- a/extra/math/text/french/french.factor
+++ b/extra/math/text/french/french.factor
@@ -29,7 +29,7 @@ MEMO: units ( -- seq ) ! up to 10^99
 ! The only plurals we have to remove are "quatre-vingts" and "cents",
 ! which are also the only strings ending with "ts".
 : unpluralize ( str -- newstr ) dup "ts" tail? [ but-last ] when ;
-: pluralize ( str -- newstr ) CHAR: s suffix ;
+: pluralize ( str -- newstr ) dup "s" tail? [ CHAR: s suffix ] unless ;
 
 : space-append ( str1 str2 -- str ) " " glue ;
 
@@ -88,9 +88,28 @@ MEMO: units ( -- seq ) ! up to 10^99
         [ decompose ]
     } cond ;
 
+: ieme ( str -- str )
+    dup "ts" tail? [ but-last ] when
+    dup "e" tail? [ but-last ] when
+    dup "q" tail? [ CHAR: u suffix ] when
+    "ième" append ;
+
+: divisor ( n -- str )
+    {
+        { 2 [ "demi" ] }
+        { 3 [ "tiers" ] }
+        { 4 [ "quart" ] }
+        [ basic ieme ]
+    } case ;
+
 PRIVATE>
 
 GENERIC: number>text ( n -- str )
 
 M: integer number>text
     dup abs 102 10^ >= [ number>string ] [ basic ] if ;
+
+M: ratio number>text
+    >fraction [ [ number>text ] keep ] [ divisor ] bi*
+    swap abs 1 > [ pluralize ] when
+    space-append ;

--- a/extra/math/text/french/french.factor
+++ b/extra/math/text/french/french.factor
@@ -33,34 +33,33 @@ MEMO: units ( -- seq ) ! up to 10^99
 
 : space-append ( str1 str2 -- str ) " " glue ;
 
-! Small numbers (below 100) use dashes between them unless they are
-! separated with "et". Pluralized prefixes must be unpluralized.
-: complete-small ( str n -- str )
+: dash-append ( str1 str2 -- str ) "-" glue ;
+
+! Numbers below 1000000 use dashes between them. Pluralized prefixes
+! must be unpluralized.
+: complete ( str n -- str )
     { { 0 [ ] }
-      { 1 [ " et un" append ] }
+      { 1 [ "-et-un" append ] }
       [ [ unpluralize ] dip basic "-" glue ] } case ;
 
 : smaller-than-60 ( n -- str )
-    dup 10 mod [ - ] keep [ basic ] dip complete-small ;
+    dup 10 mod [ - ] keep [ basic ] dip complete ;
 
-: base-onto ( n b -- str ) [ nip literals at ] [ - ] 2bi complete-small ;
+: base-onto ( n b -- str ) [ nip literals at ] [ - ] 2bi complete ;
 
 : smaller-than-80 ( n -- str ) 60 base-onto ;
 
 : smaller-than-100 ( n -- str ) 80 base-onto ;
 
-: complete ( str n -- newstr )
-    [ basic space-append ] unless-zero ;
-
 : smaller-than-1000 ( n -- str )
     100 /mod
-    [ "cent" swap dup 1 = [ drop ] [ basic swap space-append ] if ]
-    [ [ pluralize ] [ basic space-append ] if-zero ] bi* ;
+    [ "cent" swap dup 1 = [ drop ] [ basic swap dash-append ] if ]
+    [ [ pluralize ] [ basic dash-append ] if-zero ] bi* ;
 
 : smaller-than-2000 ( n -- str ) "mille" swap 1000 - complete ;
 
 : smaller-than-1000000 ( n -- str )
-    1000 /mod [ basic unpluralize " mille" append ] dip complete ;
+    1000 /mod [ basic unpluralize "-mille" append ] dip complete ;
 
 : n-units ( n unit -- str/f )
     {
@@ -73,7 +72,8 @@ MEMO: units ( -- seq ) ! up to 10^99
     3 digit-groups [ 1 + units nth n-units ] map-index sift
     reverse " " join ;
 
-: decompose ( n -- str ) 1000000 /mod [ over-1000000 ] dip complete ;
+: decompose ( n -- str ) 1000000 /mod [ over-1000000 ] dip
+    dup 0 > [ basic space-append ] [ drop ] if ;
 
 : basic ( n -- str )
     {


### PR DESCRIPTION
When I originally wrote the `number>text` French implementation, I used an older form for formatting numbers. The new one is taught in France, Belgium, Quebec, Switzerland, etc.

Also, this adds support for ratios.