### PR TITLE
calendar.format: restore the deleted duration>hm

### DIFF
--- a/basis/calendar/format/format.factor
+++ b/basis/calendar/format/format.factor
@@ -187,10 +187,12 @@ TYPED: timestamp>ymdhms ( timestamp: timestamp -- str )
 M: timestamp present timestamp>string ;
 
 ! Duration formatting
-TYPED: duration>hms ( duration: duration -- str )
+TYPED: duration>hm ( duration: duration -- str )
     [ duration>hours >integer 24 mod pad-00 ]
-    [ duration>minutes >integer 60 mod pad-00 ]
-    [ second>> >integer 60 mod pad-00 ] tri 3array ":" join ;
+    [ duration>minutes >integer 60 mod pad-00 ] bi ":" glue ;
+
+TYPED: duration>hms ( duration: duration -- str )
+    [ duration>hm ] [ second>> >integer 60 mod pad-00 ] bi ":" glue ;
 
 TYPED: duration>human-readable ( duration: duration -- string )
     [


### PR DESCRIPTION
It was replaced with duration>hms, but the version without the seconds is also useful.
https://github.com/factor/factor/commit/b17590db24219f6110928a1059b144d03c120668