### PR TITLE
slides: map 'b' key to previous slide (like unix less)

### DIFF
--- a/extra/slides/slides.factor
+++ b/extra/slides/slides.factor
@@ -120,6 +120,7 @@ SYNTAX: STRIP-TEASE:
     { T{ button-down } [ request-focus ] }
     { T{ key-down f f " " } [ next-page ] }
     { T{ key-down f f "DOWN" } [ next-page ] }
+    { T{ key-down f f "b" } [ prev-page ] }
     { T{ key-down f f "UP" } [ prev-page ] }
     { T{ key-down f f "q" } [ close-window ] }
     { T{ key-down f f "ESC" } [ close-window ] }


### PR DESCRIPTION
'space' and 'b' are close together and make slide navigation similar to unix less.