### PR TITLE
`Save As` Operation for the `byte-array`s

### DIFF
--- a/extra/file-picker/authors.txt
+++ b/extra/file-picker/authors.txt
@@ -1,0 +1,1 @@
+John Benediktsson

--- a/extra/file-picker/file-picker.factor
+++ b/extra/file-picker/file-picker.factor
@@ -1,3 +1,5 @@
+! Copyright (C) 2014 John Benediktsson.
+! See http://factorcode.org/license.txt for BSD license.
 USING: accessors sequences system vocabs ;
 IN: file-picker
 

--- a/extra/file-picker/linux/authors.txt
+++ b/extra/file-picker/linux/authors.txt
@@ -1,0 +1,1 @@
+John Benediktsson

--- a/extra/file-picker/linux/linux.factor
+++ b/extra/file-picker/linux/linux.factor
@@ -1,3 +1,5 @@
+! Copyright (C) 2014, 2015 John Benediktsson.
+! See http://factorcode.org/license.txt for BSD license.
 USING: alien.c-types alien.data alien.strings alien.syntax
 destructors file-picker gobject-introspection.standard-types
 gtk.ffi io.encodings.string io.encodings.utf8 kernel system ;

--- a/extra/file-picker/macosx/authors.txt
+++ b/extra/file-picker/macosx/authors.txt
@@ -1,0 +1,1 @@
+John Benediktsson

--- a/extra/file-picker/macosx/macosx.factor
+++ b/extra/file-picker/macosx/macosx.factor
@@ -1,3 +1,5 @@
+! Copyright (C) 2014 John Benediktsson.
+! See http://factorcode.org/license.txt for BSD license.
 USING: cocoa.dialogs file-picker system ;
 IN: file-picker.macosx
 

--- a/extra/file-picker/operations/authors.txt
+++ b/extra/file-picker/operations/authors.txt
@@ -1,0 +1,1 @@
+Alexander Ilin

--- a/extra/file-picker/operations/operations.factor
+++ b/extra/file-picker/operations/operations.factor
@@ -1,0 +1,13 @@
+! Copyright (C) 2017 Alexander Ilin.
+! See http://factorcode.org/license.txt for BSD license.
+USING: byte-arrays file-picker io io.encodings.binary io.files
+kernel locals ui.commands ui.operations ;
+IN: file-picker.operations
+
+:: save-as ( data -- )
+    "" save-file-dialog [ binary [ data write ] with-file-writer ] when* ;
+
+! Right-click a byte-array presentation to open the Save As window.
+[ byte-array? ] \ save-as H{
+    { +description+ "Save the binary data to a file" }
+} define-operation

--- a/extra/file-picker/windows/authors.txt
+++ b/extra/file-picker/windows/authors.txt
@@ -1,0 +1,3 @@
+John Benediktsson
+Doug Coleman
+Alexander Ilin

--- a/extra/file-picker/windows/windows.factor
+++ b/extra/file-picker/windows/windows.factor
@@ -1,8 +1,8 @@
 USING: accessors alien.c-types alien.data alien.strings
 alien.syntax classes.struct destructors file-picker
 io.encodings.string io.encodings.utf8 kernel libc literals math
-system windows windows.kernel32 windows.shell32 windows.types
-windows.user32 ;
+system windows windows.comdlg32 windows.kernel32 windows.shell32
+windows.types windows.user32 ;
 IN: file-picker.windows
 LIBRARY: shell32
 
@@ -70,4 +70,11 @@ M: windows open-file-dialog
         ] if*
     ] with-destructors ;
 
-M: windows save-file-dialog ;
+M: windows save-file-dialog
+    [
+        drop ! TODO: support supplying a suggested file name or path
+        OPENFILENAME [ malloc-struct &free ] [ heap-size ] bi >>lStructSize
+            MAX_UNICODE_PATH [ 2 calloc &free >>lpstrFile ] [ >>nMaxFile ] bi
+            OFN_OVERWRITEPROMPT >>Flags
+        dup GetSaveFileName zero? [ drop f ] [ lpstrFile>> ] if
+    ] with-destructors ;

--- a/extra/file-picker/windows/windows.factor
+++ b/extra/file-picker/windows/windows.factor
@@ -1,3 +1,6 @@
+! Copyright (C) 2014 John Benediktsson, Doug Coleman.
+! Copyright (C) 2017 Alexander Ilin.
+! See http://factorcode.org/license.txt for BSD license.
 USING: accessors alien.c-types alien.data alien.strings
 alien.syntax classes.struct destructors file-picker
 io.encodings.string io.encodings.utf8 kernel libc literals math

--- a/extra/windows/comdlg32/authors.txt
+++ b/extra/windows/comdlg32/authors.txt
@@ -1,0 +1,1 @@
+Alexander Ilin

--- a/extra/windows/comdlg32/comdlg32.factor
+++ b/extra/windows/comdlg32/comdlg32.factor
@@ -1,0 +1,40 @@
+! Copyright (C) 2017 Alexander Ilin.
+! See http://factorcode.org/license.txt for BSD license.
+USING: accessors alien alien.c-types alien.libraries
+alien.syntax classes.struct destructors kernel libc math
+sequences strings windows windows.types ;
+
+IN: windows.comdlg32
+
+<< "comdlg32" "comdlg32.dll" stdcall add-library >>
+
+LIBRARY: comdlg32
+
+CONSTANT: OFN_OVERWRITEPROMPT 2
+
+STRUCT: OPENFILENAME
+    { lStructSize DWORD }
+    { hwndOwner HWND }
+    { hInstance HINSTANCE }
+    { lpstrFilter LPCTSTR }
+    { lpstrCustomFilter LPTSTR }
+    { nMaxCustFilter DWORD }
+    { nFilterIndex DWORD }
+    { lpstrFile LPTSTR }
+    { nMaxFile DWORD }
+    { lpstrFileTitle LPTSTR }
+    { nMaxFileTitle DWORD }
+    { lpstrInitialDir LPCTSTR }
+    { lpstrTitle LPCTSTR }
+    { Flags DWORD }
+    { nFileOffset WORD }
+    { nFileExtension WORD }
+    { lpstrDefExt LPCTSTR }
+    { lCustData LPARAM }
+    { lpfnHook PVOID }
+    { lpTemplateName LPCTSTR } ;
+
+TYPEDEF: OPENFILENAME* LPOPENFILENAME
+
+FUNCTION: BOOL GetSaveFileNameW ( LPOPENFILENAME lpofn )
+ALIAS: GetSaveFileName GetSaveFileNameW

--- a/extra/windows/comdlg32/platforms.txt
+++ b/extra/windows/comdlg32/platforms.txt
@@ -1,0 +1,1 @@
+windows


### PR DESCRIPTION
As I mentioned in the mailing list, I've added the possibility to right-click on a `byte-array` and - with the help of the standard Save As dialog - store its contents into a file. This PR also does a bit of metadata maintenance in the entire `file-picker` subtree by adding authors files and copyright headers.

To enable the new context menu operation, do `USE: file-picker.operations`.