### PR TITLE
file-picker.operations: fix invalid parameter order in save-as

### DIFF
--- a/extra/file-picker/operations/operations.factor
+++ b/extra/file-picker/operations/operations.factor
@@ -1,11 +1,11 @@
 ! Copyright (C) 2017 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: byte-arrays file-picker io io.encodings.binary io.files
-kernel locals ui.commands ui.operations ;
+kernel ui.commands ui.operations ;
 IN: file-picker.operations
 
-:: save-as ( data -- )
-    "" save-file-dialog [ data binary set-file-contents ] when* ;
+: save-as ( seq -- )
+    "" save-file-dialog [ binary set-file-contents ] [ drop ] if* ;
 
 ! Right-click a byte-array presentation to open the Save As window.
 [ byte-array? ] \ save-as H{


### PR DESCRIPTION
`set-file-contents ( seq path encoding -- )`