### PR TITLE
cocoa: Allow ?-> syntax for methods that might not exist.

### DIFF
--- a/basis/cocoa/cocoa.factor
+++ b/basis/cocoa/cocoa.factor
@@ -14,6 +14,8 @@ SYMBOL: sent-messages
 
 SYNTAX: -> scan-token dup remember-send suffix! \ send suffix! ;
 
+SYNTAX: ?-> scan-token dup remember-send suffix! \ ?send suffix! ;
+
 SYNTAX: SEL:
     scan-token
     [ remember-send ]

--- a/basis/cocoa/messages/messages.factor
+++ b/basis/cocoa/messages/messages.factor
@@ -86,6 +86,14 @@ MACRO: (send) ( selector super? -- quot )
 
 : send ( receiver args... selector -- return... ) f (send) ; inline
 
+MACRO:: (?send) ( effect selector super? -- quot )
+    selector dup ?lookup-method effect or super?
+    [ make-prepare-send ] 2keep
+    super-message-senders message-senders ? get at
+    [ 1quotation append ] [ effect selector sender-stub 1quotation append ] if* ;
+
+: ?send ( receiver args... selector effect -- return... ) f (?send) ; inline
+
 : super-send ( receiver args... selector -- return... ) t (send) ; inline
 
 ! Runtime introspection

--- a/basis/cocoa/touchbar/touchbar.factor
+++ b/basis/cocoa/touchbar/touchbar.factor
@@ -1,8 +1,8 @@
 ! Copyright (C) 2017 Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors alien.enums alien.syntax cocoa cocoa.classes
-cocoa.messages combinators core-foundation.strings kernel locals
-namespaces sequences words ;
+USING: accessors alien.c-types alien.enums alien.syntax cocoa
+cocoa.classes cocoa.messages cocoa.runtime combinators
+core-foundation.strings kernel locals namespaces sequences words ;
 IN: cocoa.touchbar
 
 ! ui.backend.cocoa.views creates buttons for each of these actions
@@ -15,17 +15,17 @@ ENUM: default-touchbar refresh-all-action auto-use-action ;
 
 : make-touchbar ( enum self -- touchbar )
     [ NSTouchBar -> alloc -> init dup ] dip -> setDelegate: {
-        [ swap enum>CFStringArray -> setDefaultItemIdentifiers: ]
-        [ swap enum>CFStringArray -> setCustomizationAllowedItemIdentifiers: ]
+        [ swap enum>CFStringArray { void { id SEL id } } ?-> setDefaultItemIdentifiers: ]
+        [ swap enum>CFStringArray { void { id SEL id } } ?-> setCustomizationAllowedItemIdentifiers: ]
         [ nip ]
     } 2cleave ;
 
 :: make-NSTouchBar-button ( self identifier label-string action-string -- button )
     NSCustomTouchBarItem -> alloc
-        identifier <CFString> -> initWithIdentifier: :> item
+        identifier <CFString> { id { id SEL id } } ?-> initWithIdentifier: :> item
         NSButton
             label-string <CFString>
             self
-            action-string lookup-selector -> buttonWithTitle:target:action: :> button
+            action-string lookup-selector { id { id SEL id id SEL } } ?-> buttonWithTitle:target:action: :> button
         item button -> setView:
         item ;

--- a/basis/ui/backend/cocoa/views/views.factor
+++ b/basis/ui/backend/cocoa/views/views.factor
@@ -438,9 +438,7 @@ CLASS: FactorWindowDelegate < NSObject
 
         notification -> object dup SEL: backingScaleFactor
         -> respondsToSelector: c-bool> [
-
-            SEL: backingScaleFactor
-            double f "objc_msgSend" { id SEL } f alien-invoke
+            { double { id SEL } } ?-> backingScaleFactor
 
             [ [ 1.0 > ] keep f ? gl-scale-factor set-global ]
             [ 1.0 > retina? set-global ] bi


### PR DESCRIPTION
If a method doesn't exist we need to provide a signature so the stack is balanced. This should also allow deploying from macOS versions that do not contain methods to ones that do. This is an alternative to asking a class if it provides a selector.