### PR TITLE
Nmakefile: add the /largeaddressaware linker option for 32-bit builds

### DIFF
--- a/Nmakefile
+++ b/Nmakefile
@@ -13,13 +13,13 @@ CL_FLAGS = /nologo /O2 /WX /W3 /D_CRT_SECURE_NO_WARNINGS /DFACTOR_VERSION=$(VERS
 CL_FLAGS_VISTA = /D_WIN32_WINNT=0x0600
 
 !IF "$(PLATFORM)" == "x86-32"
-LINK_FLAGS = $(LINK_FLAGS) /safeseh
+LINK_FLAGS = $(LINK_FLAGS) /safeseh /largeaddressaware
 PLAF_DLL_OBJS = vm\os-windows-x86.32.obj vm\safeseh.obj vm\cpu-x86.obj
 SUBSYSTEM_COM_FLAGS = console,"5.01"
 SUBSYSTEM_EXE_FLAGS = windows,"5.01"
 
 !ELSEIF "$(PLATFORM)" == "x86-32-vista"
-LINK_FLAGS = $(LINK_FLAGS) /safeseh
+LINK_FLAGS = $(LINK_FLAGS) /safeseh /largeaddressaware
 CL_FLAGS = $(CL_FLAGS) $(CL_FLAGS_VISTA)
 PLAF_DLL_OBJS = vm\os-windows-x86.32.obj vm\safeseh.obj vm\cpu-x86.obj
 SUBSYSTEM_COM_FLAGS = console


### PR DESCRIPTION
This somewhat mitigates issue #1828 by allowing more memory to be allocated for the 32-bit apps on some systems. Has no effect on 32-bit Windows XP.