### PR TITLE
io.directories: add size slot to directory-entry tuple

### DIFF
--- a/basis/io/directories/windows/windows.factor
+++ b/basis/io/directories/windows/windows.factor
@@ -4,7 +4,7 @@ USING: system io.directories alien.strings
 io.pathnames io.backend io.files.windows destructors
 kernel accessors calendar windows windows.errors
 windows.kernel32 alien.c-types sequences splitting
-fry continuations classes.struct ;
+fry continuations classes.struct windows.time ;
 IN: io.directories.windows
 
 M: windows touch-file ( path -- )
@@ -58,7 +58,7 @@ M: windows delete-directory ( path -- )
         ] unless drop f
     ] when ;
 
-TUPLE: windows-directory-entry < directory-entry attributes ;
+TUPLE: windows-directory-entry < directory-entry attributes size ;
 
 C: <windows-directory-entry> windows-directory-entry
 
@@ -67,8 +67,10 @@ C: <windows-directory-entry> windows-directory-entry
     [
         dwFileAttributes>>
         [ win32-file-type ] [ win32-file-attributes ] bi
-    ] bi
-    dupd remove <windows-directory-entry> ; inline
+        dupd remove
+    ]
+    [ [ nFileSizeLow>> ] [ nFileSizeHigh>> ] bi >64bit ] tri
+    <windows-directory-entry> ; inline
 
 M: windows (directory-entries) ( path -- seq )
     "\\" ?tail drop "\\*" append


### PR DESCRIPTION
This adds the file size slot to the basic tuple, and its implementation on Windows. I don't know anything about Unix systems, but I left a TODO-comment if someone wants to contribute to the Unix backend.

I'm creating a file management system, and I want to scan an entire 2 Tb drive worth of files once in a while (currently about 290'000 files). When I traverse directory entries, I always want the file size information, and it seems wasteful to make a second pass over the data set, especially since I know that the data are available from WinAPI during the first pass, and merely not published by Factor.