### PR TITLE
Add .gitattributes to enforce EOL policy for factor sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.factor text eol=lf


### PR DESCRIPTION
There were times when I committed files with Windows EOL by mistake. This file would have prevented the history rewrites that I had to do.