### PR TITLE
Improve Inspector performance

### DIFF
--- a/basis/ui/gadgets/tables/tables.factor
+++ b/basis/ui/gadgets/tables/tables.factor
@@ -39,6 +39,7 @@ single-click?
 { hook initial: [ drop ] }
 { gap initial: 2 }
 column-widths total-width
+fixed-column-widths
 focus-border-color
 mouse-color
 column-line-color
@@ -101,8 +102,12 @@ M: image-name draw-cell nip draw-image ;
 
 : compute-column-widths ( table -- total widths )
     dup rows>> [ drop 0 { } ] [
-        [ drop gap>> ] [ initial-widths ] [ ] 2tri
-        [ row-column-widths vmax ] with each
+        over fixed-column-widths>> [
+            nip [ gap>> ] dip
+        ] [
+            [ drop gap>> ] [ initial-widths ] [ ] 2tri
+            [ row-column-widths vmax ] with each
+        ] if*
         [ compute-total-width ] keep
     ] if-empty ;
 

--- a/basis/ui/tools/inspector/inspector.factor
+++ b/basis/ui/tools/inspector/inspector.factor
@@ -109,7 +109,8 @@ M: inspector-gadget focusable-child*
     table>> ;
 
 : com-refresh ( inspector -- )
-    model>> notify-connections ;
+    [ model>> notify-connections ] keep
+    [ table>> ] [ model>> ] bi fix-column-widths drop ;
 
 : com-push ( inspector -- obj )
     control-value ;

--- a/basis/ui/tools/inspector/inspector.factor
+++ b/basis/ui/tools/inspector/inspector.factor
@@ -72,17 +72,13 @@ M: object make-slot-descriptions
 M: hashtable make-slot-descriptions
     call-next-method [ key-string>> ] sort-with ;
 
-! If model is a sequence, get its maximum index, measure its width
-! and use that as the first column width (or the first column title
-! width, whichever is greater). This improves performance when
-! inspecting big arrays.
+! If model is an enum, get its maximum index, measure its width
+! rendered in the table, and use that as the first column width (or
+! the first column title width, whichever is greater). This
+! improves performance when inspecting big arrays.
 : first-column-width ( table model -- width )
-    value>> dup sequence? [
-        length 1 - 1array
-    ] [
-        make-mirror keys
-    ] if [ unparse-short ] map
-    over renderer>> column-titles first suffix
+    value>> make-mirror dup enum? [ length 1 - 1array ] [ keys ] if
+    [ unparse-short ] map over renderer>> column-titles first suffix
     row-column-widths supremum ;
 
 : <inspector-table> ( model -- table )

--- a/basis/ui/tools/inspector/inspector.factor
+++ b/basis/ui/tools/inspector/inspector.factor
@@ -81,6 +81,9 @@ M: hashtable make-slot-descriptions
     [ unparse-short ] map over renderer>> column-titles first suffix
     row-column-widths supremum ;
 
+: fix-column-widths ( table model -- table )
+    dupd first-column-width 0 2array >>fixed-column-widths ;
+
 : <inspector-table> ( model -- table )
     [
         [ make-slot-descriptions ] <arrow> inspector-renderer <table>
@@ -92,8 +95,7 @@ M: hashtable make-slot-descriptions
             40 >>min-cols
             40 >>max-cols
             monospace-font >>font
-            dup
-    ] keep first-column-width 0 2array >>fixed-column-widths ;
+    ] keep fix-column-widths ;
 
 : <inspector-gadget> ( model -- gadget )
     vertical inspector-gadget new-track with-lines


### PR DESCRIPTION
Given the code `200000 0 <array> ui.tools.inspector:inspector`, this patch improves the time it takes to open the Inspector window from over 6 seconds (5-11 seconds was the range of measurements) down to about 1 second.

The main bottleneck was the run through all the rows in a table to measure the maximum width for the Key column. This was especially useless when inspecting arrays and other sequences, where the Key is always the item index. The time was proportional to the sequence length.

With this patch it takes O(1) to measure the Key column width, and then the fixed value is used. Also, for some reason, the rendering of the mouse-over highlight becomes instantaneous instead of sluggish. Same for scrolling and general redrawing of the table.

I do have some questions left over. To measure the column width I have used the `text-dim` word, but conceptually it would be better to use `row-column-widths`. The latter considers the padding returned by the `cell-dim`, while the former does not. The only reason I didn't go with the `row-column-widths` was that it's in the private section of the `ui.gadgets.tables` vocab, and I wanted to respect the interface boundaries. What shall we do? Shall we make `row-column-widths` a part of the public interface? Shall we make the text padding value (currently zero) externally available in some way, like store it in a `SYMBOL`? Or shall we just assume that it will never be anything other than zero for the text strings? I can implement whichever you think is best.