### PR TITLE
Supremum infimum

### DIFF
--- a/basis/ui/baseline-alignment/baseline-alignment.factor
+++ b/basis/ui/baseline-alignment/baseline-alignment.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2009 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors combinators kernel locals math math.functions
-math.order sequences ui.gadgets ;
+math.order sequences sequences.extras ui.gadgets ;
 IN: ui.baseline-alignment
 
 SYMBOL: +baseline+
@@ -43,9 +43,6 @@ TUPLE: gadget-metrics height ascent descent cap-height ;
     second swap [ baseline ] [ cap-height ] bi
     [ dup [ 2dup - ] [ f ] if ] dip
     gadget-metrics boa ; inline
-
-: ?supremum ( seq -- n/f )
-    sift [ f ] [ supremum ] if-empty ;
 
 : max-ascent ( seq -- n )
     [ ascent>> ] map ?supremum ;

--- a/basis/ui/gadgets/packs/packs.factor
+++ b/basis/ui/gadgets/packs/packs.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2005, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays combinators fry kernel math math.order
-math.vectors sequences ui.baseline-alignment
+math.vectors sequences sequences.extras ui.baseline-alignment
 ui.baseline-alignment.private ui.gadgets ;
 IN: ui.gadgets.packs
 

--- a/extra/compiler/cfg/gvn/avail/avail.factor
+++ b/extra/compiler/cfg/gvn/avail/avail.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2011 Alex Vondrak.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors assocs hashtables kernel namespaces sequences
-sets
+sequences.extras sets
 compiler.cfg
 compiler.cfg.dataflow-analysis
 compiler.cfg.def-use
@@ -24,12 +24,9 @@ M: avail transfer-set drop defined assoc-union ;
 
 : available? ( vn -- ? ) basic-block get avail-in key? ;
 
-: best-vreg ( available-vregs -- vreg )
-    [ f ] [ infimum ] if-empty ;
-
 : >avail-vreg ( vreg -- vreg/f )
     final-iteration? get [
-        congruence-class [ available? ] filter best-vreg
+        congruence-class [ available? ] filter ?infimum
     ] when ;
 
 : available-uses? ( insn -- ? )

--- a/extra/sequences/extras/extras-docs.factor
+++ b/extra/sequences/extras/extras-docs.factor
@@ -1,6 +1,32 @@
 USING: help.markup help.syntax kernel math sequences ;
 IN: sequences.extras
 
+HELP: ?supremum
+{ $values
+    { "seq/f" { $maybe sequence } }
+    { "elt/f" { $maybe object } }
+}
+{ $description "Outputs the greatest element of " { $snippet "seq" } ", ignoring any " { $link POSTPONE: f } " elements in it. If " { $snippet "seq" } " is empty or " { $link POSTPONE: f } ", returns " { $link POSTPONE: f } "." }
+{ $examples
+    { $example "USING: prettyprint sequences.extras ;"
+    "{ 1 f 3 2 } ?supremum ."
+    "3" }
+} ;
+
+HELP: ?infimum
+{ $values
+    { "seq/f" { $maybe sequence } }
+    { "elt/f" { $maybe object } }
+}
+{ $description "Outputs the least element of " { $snippet "seq" } ", ignoring any " { $link POSTPONE: f } " elements in it. If " { $snippet "seq" } " is empty or " { $link POSTPONE: f } ", returns " { $link POSTPONE: f } "." }
+{ $examples
+    { $example "USING: prettyprint sequences.extras ;"
+    "{ 1 f 3 2 } ?infimum ."
+    "1" }
+} ;
+
+{ ?supremum ?infimum } related-words
+
 HELP: 2count
 { $values
     { "seq1" sequence }

--- a/extra/sequences/extras/extras-tests.factor
+++ b/extra/sequences/extras/extras-tests.factor
@@ -223,6 +223,16 @@ IN: sequences.extras.tests
 { 1 "beef" } [ { "chicken" "beef" "moose" } [ length ] infimum-by* ] unit-test
 { 0 "chicken" } [ { "chicken" "beef" "moose" } [ length ] supremum-by* ] unit-test
 { 2 "moose" } [ { "chicken" "beef" "moose" } [ first ] supremum-by* ] unit-test
+{ f } [ f ?supremum ] unit-test
+{ f } [ { } ?supremum ] unit-test
+{ f } [ { f } ?supremum ] unit-test
+{ 3 } [ { 1 f 3 2 } ?supremum ] unit-test
+{ 3 } [ { 1 3 2 } ?supremum ] unit-test
+{ f } [ f ?infimum ] unit-test
+{ f } [ { } ?infimum ] unit-test
+{ f } [ { f } ?infimum ] unit-test
+{ 1 } [ { 1 f 3 2 } ?infimum ] unit-test
+{ 1 } [ { 1 3 2 } ?infimum ] unit-test
 
 { 3/10 } [ 10 <iota> [ 3 < ] count* ] unit-test
 

--- a/extra/sequences/extras/extras.factor
+++ b/extra/sequences/extras/extras.factor
@@ -559,6 +559,16 @@ PRIVATE>
 : infimum-by* ( ... seq quot: ( ... elt -- ... x ) -- ... i elt )
     [ before? ] select-by* ; inline
 
+: ?supremum ( seq/f -- elt/f )
+    [ f ] [
+        [ ] [ 2dup and [ max ] [ dupd ? ] if ] map-reduce
+    ] if-empty ;
+
+: ?infimum ( seq/f -- elt/f )
+    [ f ] [
+        [ ] [ 2dup and [ min ] [ dupd ? ] if ] map-reduce
+    ] if-empty ;
+
 : change-last ( seq quot -- )
     [ drop length 1 - ] [ change-nth ] 2bi ; inline
 


### PR DESCRIPTION
As discussed in the mailing list, here they are: `?infimum` and `?supremum`, complete with tests and documentation.

I'm not sure about the last commit, because it introduces dependency from `basis` on `extra`, so feel free to skip it.