### PR TITLE
io.stream.limited: swap limit-stream parameters

### DIFF
--- a/basis/io/streams/limited/limited-docs.factor
+++ b/basis/io/streams/limited/limited-docs.factor
@@ -5,14 +5,14 @@ IN: io.streams.limited
 
 HELP: <limited-stream>
 { $values
-     { "stream" "an input stream" } { "limit" integer }
+     { "limit" integer } { "stream" "an input stream" }
      { "stream'" "an input stream" }
 }
 { $description "Constructs a new " { $link limited-stream } " from an existing stream. User code should use " { $link limit-stream } " or " { $link limited-input } "." } ;
 
 HELP: limit-stream
 { $values
-     { "stream" "an input stream" } { "limit" integer }
+     { "limit" integer } { "stream" "an input stream" }
      { "stream'" "a stream" }
 }
 { $description "Changes a decoder's stream to be a limited stream, or wraps " { $snippet "stream" } " in a " { $link limited-stream } "." }
@@ -21,7 +21,7 @@ HELP: limit-stream
     { $example
         "USING: accessors continuations io io.streams.limited"
         "io.streams.string kernel prettyprint ;"
-        "\"123456\" <string-reader> 3 limit-stream"
+        3 "\"123456\" <string-reader> limit-stream"
         "100 swap stream-read ."
         "\"123\""
     }

--- a/basis/io/streams/limited/limited-tests.factor
+++ b/basis/io/streams/limited/limited-tests.factor
@@ -86,21 +86,21 @@ IN: io.streams.limited.tests
 
 { t }
 [
-    "abc" <string-reader> 3 limit-stream unlimit-stream
+    3 "abc" <string-reader> limit-stream unlimit-stream
     "abc" <string-reader> =
 ] unit-test
 
 { t }
 [
-    "abc" <string-reader> 3 limit-stream unlimit-stream
+    3 "abc" <string-reader> limit-stream unlimit-stream
     "abc" <string-reader> =
 ] unit-test
 
 { t }
 [
     [
-        "resource:LICENSE.txt" utf8 <file-reader> &dispose
-        3 limit-stream unlimit-stream
+        3 "resource:LICENSE.txt" utf8 <file-reader> &dispose
+        limit-stream unlimit-stream
         "resource:LICENSE.txt" utf8 <file-reader> &dispose
         [ decoder? ] both?
     ] with-destructors

--- a/basis/io/streams/limited/limited.factor
+++ b/basis/io/streams/limited/limited.factor
@@ -9,34 +9,33 @@ IN: io.streams.limited
 TUPLE: limited-stream stream count limit current start stop ;
 INSTANCE: limited-stream input-stream
 
-: <limited-stream> ( stream limit -- stream' )
+: <limited-stream> ( limit stream -- stream' )
     limited-stream new
-        swap >>limit
         swap >>stream
+        swap >>limit
         0 >>count ;
 
 : <limited-file-reader> ( path encoding -- stream' )
-    [ <file-reader> ]
-    [ drop file-info size>> ] 2bi
+    [ drop file-info size>> ] [ <file-reader> ] 2bi
     <limited-stream> ;
 
-GENERIC#: limit-stream 1 ( stream limit -- stream' )
+GENERIC: limit-stream ( limit stream -- stream' )
 
-M: decoder limit-stream ( stream limit -- stream' )
-    '[ stream>> _ limit-stream ] [ code>> ] [ cr>> ] tri
+M: decoder limit-stream ( limit stream -- stream' )
+    [ stream>> limit-stream ] [ code>> ] [ cr>> ] tri
     decoder boa ; inline
 
-M: object limit-stream ( stream limit -- stream' )
+M: object limit-stream ( limit stream -- stream' )
     <limited-stream> ;
 
 : limited-input ( limit -- )
-    [ input-stream ] dip '[ _ limit-stream ] change ;
+    input-stream [ limit-stream ] change ;
 
-: with-limited-stream ( stream limit quot -- )
+: with-limited-stream ( limit stream quot -- )
     [ limit-stream ] dip call ; inline
 
 : with-limited-input ( limit quot -- )
-    [ [ input-stream get ] dip limit-stream input-stream ] dip
+    [ input-stream get limit-stream input-stream ] dip
     with-variable ; inline
 
 ERROR: limit-exceeded n stream ;

--- a/extra/io/streams/random/random.factor
+++ b/extra/io/streams/random/random.factor
@@ -23,5 +23,5 @@ M: random-stream dispose drop ;
 INSTANCE: random-stream input-stream
 
 : random-file ( n path -- )
-    [ <random-stream> swap limit-stream ]
+    [ <random-stream> limit-stream ]
     [ binary <file-writer> ] bi* stream-copy ;


### PR DESCRIPTION
This order of the `limit-stream` parameters (i.e. `limit` then `stream`) seems more logical and simplifies code.