### PR TITLE
use lists vocab in factor handbook

### DIFF
--- a/basis/help/handbook/handbook.factor
+++ b/basis/help/handbook/handbook.factor
@@ -5,7 +5,7 @@ math system strings sbufs vectors byte-arrays quotations
 io.streams.byte-array classes.builtin parser lexer
 classes.predicate classes.union classes.intersection
 classes.singleton classes.tuple help.vocabs math.parser
-accessors definitions sets ;
+accessors definitions sets lists ;
 IN: help.handbook
 
 ARTICLE: "conventions" "Conventions"


### PR DESCRIPTION
Without the `lists` vocabulary being used, the help page causes a traceback.

`help-lint-all` caught this error, for what it's worth.