### PR TITLE
ui.backend.x11, implement (fullscreen?)

### DIFF
--- a/basis/ui/backend/x11/x11.factor
+++ b/basis/ui/backend/x11/x11.factor
@@ -28,12 +28,12 @@ CONSTANT: _NET_WM_STATE_TOGGLE 2
 : XA_NET_WM_STATE_FULLSCREEN ( -- atom ) "_NET_WM_STATE_FULLSCREEN" x-atom ;
 : XA_NET_ACTIVE_WINDOW ( -- atom ) "_NET_ACTIVE_WINDOW" x-atom ;
 
-: supported-net-wm-hints ( -- seq )
+:: get-atom-properties ( window name -- seq )
     { Atom int ulong ulong pointer: Atom }
     [| type format n-atoms bytes-after atoms |
         dpy get
-        root get
-        XA_NET_SUPPORTED
+        window
+        name
         0
         ulong c-type-interval nip
         0
@@ -51,6 +51,9 @@ CONSTANT: _NET_WM_STATE_TOGGLE 2
         atoms n-atoms ulong <c-direct-array> >array
         atoms XFree
     ] call ;
+
+: supported-net-wm-hints ( -- seq )
+    root get XA_NET_SUPPORTED get-atom-properties ;
 
 : net-wm-hint-supported? ( atom -- ? )
     supported-net-wm-hints member? ;
@@ -270,6 +273,10 @@ M: x11-ui-backend set-title ( string world -- )
 
 M: x11-ui-backend (set-fullscreen) ( world ? -- )
     [ handle>> window>> ] dip make-fullscreen-msg send-event ;
+
+M: x11-ui-backend (fullscreen?) ( world -- ? )
+    handle>> window>> XA_NET_WM_STATE get-atom-properties
+    XA_NET_WM_STATE_FULLSCREEN swap member? ;
 
 M: x11-ui-backend (open-window) ( world -- )
     dup gadget-window handle>> window>>


### PR DESCRIPTION
I noticed this because the game vocabs use toggle-fullscreen and it wouldn't work on x11. Apparently it was just never implemented...

So this was crashing only for the toggle-fullscreen from the game vocab.
But then I rebased on the current master and it crashes every window !

(fullscreen?) is required for every window since
```
commit b90f37b13eeaaec45246dbc2591adf4f9a5459c2
Author: John Benediktsson <mrjbq7@gmail.com>
Date:   Wed Oct 25 16:16:53 2017 -0700

    ui.tools.common: only save tool-dim when not fullscreen.
```
