### PR TITLE
extra/cap: fix a bug where screenshots were incorrectly downscaled

### DIFF
--- a/extra/cap/cap-docs.factor
+++ b/extra/cap/cap-docs.factor
@@ -1,0 +1,15 @@
+USING: cap help.markup help.syntax images opengl ui.gadgets.worlds ;
+IN: cap
+
+HELP: screenshot.
+  { $values { "window" world } }
+  { $description
+    "Opens a window with a screenshot of the currently active window."
+  } ;
+
+HELP: screenshot
+  { $values { "window" world } { "bitmap" image } }
+  { $description
+    "Creates a bitmap image of a UI window."
+  }
+  { $notes "If the current " { $link gl-scale-factor } " is " { $snippet "2.0" } ", then the " { $snippet "2x" } " slot in the resulting " { $link image } " will be " { $link t } "." } ;

--- a/extra/cap/cap.factor
+++ b/extra/cap/cap.factor
@@ -6,6 +6,8 @@ models namespaces opengl opengl.gl sequences ui ui.gadgets
 ui.gadgets.worlds ;
 IN: cap
 
+<PRIVATE
+
 : screenshot-array ( world -- byte-array )
     dim>> [ first 4 * ] [ second ] bi
     [ gl-scale ] bi@ * >fixnum <byte-array> ;
@@ -23,10 +25,11 @@ IN: cap
     [ screenshot-array ] bi
     [ glReadPixels ] keep ;
 
+PRIVATE>
+
 : screenshot ( window -- bitmap )
     [ <image>
-        gl-scale-factor get-global
-        [ >integer 2 = [ >>2x? ] when* ] when*
+        gl-scale-factor get-global [ 2.0 = >>2x? ] when*
     ] dip
     [ gl-screenshot >>bitmap ]
     [ dim>> [ gl-scale >fixnum ] map >>dim ] bi

--- a/extra/cap/cap.factor
+++ b/extra/cap/cap.factor
@@ -24,7 +24,7 @@ IN: cap
     [ glReadPixels ] keep ;
 
 : screenshot ( window -- bitmap )
-    [ <image> ] dip
+    [ <image> gl-scale-factor get-global [ >>2x? ] when* ] dip
     [ gl-screenshot >>bitmap ]
     [ dim>> [ gl-scale >fixnum ] map >>dim ] bi
     ubyte-components >>component-type

--- a/extra/cap/cap.factor
+++ b/extra/cap/cap.factor
@@ -24,7 +24,7 @@ IN: cap
     [ glReadPixels ] keep ;
 
 : screenshot ( window -- bitmap )
-    [ <image> t >>2x? ] dip
+    [ <image> ] dip
     [ gl-screenshot >>bitmap ]
     [ dim>> [ gl-scale >fixnum ] map >>dim ] bi
     ubyte-components >>component-type

--- a/extra/cap/cap.factor
+++ b/extra/cap/cap.factor
@@ -24,7 +24,10 @@ IN: cap
     [ glReadPixels ] keep ;
 
 : screenshot ( window -- bitmap )
-    [ <image> gl-scale-factor get-global [ >>2x? ] when* ] dip
+    [ <image>
+        gl-scale-factor get-global
+        [ >integer 2 = [ >>2x? ] when* ] when*
+    ] dip
     [ gl-screenshot >>bitmap ]
     [ dim>> [ gl-scale >fixnum ] map >>dim ] bi
     ubyte-components >>component-type

--- a/extra/cap/summary.txt
+++ b/extra/cap/summary.txt
@@ -1,0 +1,1 @@
+Creating and displaying screenshots of Factor


### PR DESCRIPTION
closes #1888, screenshots are the native resolution now
![cap](https://user-images.githubusercontent.com/3238748/34582744-05cf2586-f163-11e7-8c02-e8c565061131.png)

  