### PR TITLE
concurrency.distributed: with-connection

### DIFF
--- a/basis/concurrency/distributed/authors.txt
+++ b/basis/concurrency/distributed/authors.txt
@@ -1,1 +1,2 @@
 Chris Double
+Alexander Ilin

--- a/basis/concurrency/distributed/distributed.factor
+++ b/basis/concurrency/distributed/distributed.factor
@@ -1,4 +1,5 @@
 ! Copyright (C) 2005 Chris Double. All Rights Reserved.
+! Copyright (C) 2018 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs concurrency.messaging
 continuations destructors fry init io io.encodings.binary

--- a/basis/concurrency/distributed/distributed.factor
+++ b/basis/concurrency/distributed/distributed.factor
@@ -52,7 +52,7 @@ M: thread (serialize) ( obj -- )
     id>> [ local-node get insecure>> ] dip <remote-thread> (serialize) ;
 
 : stop-node ( -- )
-    local-node get insecure>> f swap send-remote-message ;
+    f local-node get insecure>> send-remote-message ;
 
 [
     H{ } clone \ registered-remote-threads set-global


### PR DESCRIPTION
Please, have a look at this implementation. It allows a client to send multiple messages to the server in a single socket connection (as opposed to opening a connection per message). The implementation sends a special symbol `keep-connection` as the first message to make sever enter a receiving loop until the `terminate-connection` symbol is received. All messages between the two symbols are forwarded to the destination thread. Both client and server need to support the new mode of operation: the client remembers its connection stream in the new `connection` slot of the `remote-thread` tuple; the server's thread (spawned to handle the client connection) optionally enters a `loop`, which has the stream in its stack until the `loop` is terminated.

**Interoperability:** the new mode of operation is enabled by using the new `with-connection` combinator at the client end. If the combinator is not used, the implementation works as before (with per-message connections). Old client implementations can work with new server implementations without issues (the server implementation is fully backwards-compatible). New clients can work with old servers as before if the `with-connection` combinator is not used. If new clients use `with-connection` while connecting to old servers, the server's target thread will receive the `keep-connection` symbol **instead of** the intended message, and the socket connection will be terminated by the old server before the intended message can be sent by the client.
There is no possibility to overcome the interoperability limitations within the `concurrency.distributed` vocab itself, because there is no protocol versioning mechanism implemented in the vocab.

If you have any suggestions on how this implementation can be improved, I'd like to hear your feedback.

A further improvement to the vocab could be allowing *bidirectional* communication between a client and a server over the long-lived socket connection. For example, currently to do `send-synchronous`/`reply-synchronous` we need to open a server socket at the client side, which is completely unnecessary from the TCP viewpoint, as any established connection is inherently a `duplex-stream`. If you can suggest a way to implement that, or even contribute code, please do.

Another improvement could be replacing the initial `keep-connection` symbol with a tuple describing the required minimum version of the server implementation along with the desired connection options. I have little experience designing such protocols, so I would appreciate it if you point me to the relevant reading material.

PS: this implementation perfectly solves my particular use case, which is to start a client worker process, and send a bunch of data back to the server asynchronously. My test case sends almost 63500 messages over the single socket connection without breaking a sweat, whereas the previous implementation choked on a fraction of that number due to port number exhaustion and was completely CPU-bound, having to bring up and tear down TCP connections per each message. This means two things. One - it works, which is good; two - without your help I may leave this alone and not take it any further, which is not so good. So, if you have any interest in this topic, please voice it.

Also, I only tested it on Windows, so YMMV, although the code is pretty high-level so I don't expect any issues on other platforms.