### PR TITLE
Fix the IN: for test vocabs to include the ".tests" suffix

### DIFF
--- a/basis/concurrency/count-downs/count-downs-tests.factor
+++ b/basis/concurrency/count-downs/count-downs-tests.factor
@@ -1,5 +1,5 @@
 USING: concurrency.count-downs threads kernel tools.test ;
-IN: concurrency.count-downs.tests`
+IN: concurrency.count-downs.tests
 
 { } [ 0 <count-down> await ] unit-test
 

--- a/basis/interval-maps/interval-maps-tests.factor
+++ b/basis/interval-maps/interval-maps-tests.factor
@@ -1,5 +1,5 @@
 USING: kernel namespaces interval-maps tools.test ;
-IN: interval-maps.test
+IN: interval-maps.tests
 
 SYMBOL: test
 

--- a/basis/inverse/inverse-tests.factor
+++ b/basis/inverse/inverse-tests.factor
@@ -2,7 +2,7 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: inverse tools.test arrays math kernel sequences
 math.functions math.constants continuations combinators.smart ;
-IN: inverse-tests
+IN: inverse.tests
 
 { 2 } [ { 3 2 } [ 3 swap 2array ] undo ] unit-test
 [ { 3 4 } [ dup 2array ] undo ] must-fail

--- a/basis/io/encodings/strict/strict-tests.factor
+++ b/basis/io/encodings/strict/strict-tests.factor
@@ -1,6 +1,6 @@
 USING: io.encodings.strict io.encodings.ascii tools.test
 arrays io.encodings.string ;
-IN: io.encodings.strict.test
+IN: io.encodings.strict.tests
 
 { { 0xfffd } } [ { 128 } ascii decode >array ] unit-test
 [ { 128 } ascii strict decode ] must-fail

--- a/basis/linked-assocs/linked-assocs-tests.factor
+++ b/basis/linked-assocs/linked-assocs-tests.factor
@@ -2,7 +2,7 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors assocs kernel linked-assocs math sequences
 tools.test ;
-IN: linked-assocs.test
+IN: linked-assocs.tests
 
 { { 1 2 3 } } [
     <linked-hash> 1 "b" pick set-at

--- a/basis/locals/types/types-tests.factor
+++ b/basis/locals/types/types-tests.factor
@@ -1,5 +1,5 @@
 USING: accessors compiler.units kernel locals.types tools.test words ;
-IN: locals.types.test
+IN: locals.types.tests
 
 { t } [
     [ "hello" <local> ] with-compilation-unit "local?" word-prop

--- a/basis/regexp/regexp-tests.factor
+++ b/basis/regexp/regexp-tests.factor
@@ -1,6 +1,6 @@
 USING: arrays regexp tools.test kernel sequences regexp.parser
 regexp.private eval strings multiline accessors ;
-IN: regexp-tests
+IN: regexp.tests
 
 { f } [ "b" "a*" <regexp> matches? ] unit-test
 { t } [ "" "a*" <regexp> matches? ] unit-test

--- a/extra/calendar/elapsed/elapsed-tests.factor
+++ b/extra/calendar/elapsed/elapsed-tests.factor
@@ -3,7 +3,7 @@
 
 USING: calendar calendar.elapsed kernel tools.test ;
 
-IN: calendar.elapsed.test
+IN: calendar.elapsed.tests
 
 [ -1 elapsed-time ] [ "negative seconds" = ] must-fail-with
 

--- a/extra/jamshred/oint/oint-tests.factor
+++ b/extra/jamshred/oint/oint-tests.factor
@@ -1,5 +1,5 @@
 USING: jamshred.oint tools.test ;
-IN: jamshred.oint-tests
+IN: jamshred.oint.tests
 
 { { 0 -1 -1 } } [ { 0 1 -1 } { 0 -1 0 } reflect ] unit-test
 { { 0 1 0 } } [ { 1 1 0 } { 1 0 0 } proj-perp ] unit-test

--- a/extra/math/extras/extras-tests.factor
+++ b/extra/math/extras/extras-tests.factor
@@ -4,7 +4,7 @@
 USING: arrays kernel math math.extras math.ranges sequences
 tools.test ;
 
-IN: math.extras.test
+IN: math.extras.tests
 
 { { 1 -1/2 1/6 0 -1/30 0 1/42 0 -1/30 0 } }
 [ 10 <iota> [ bernoulli ] map ] unit-test


### PR DESCRIPTION
Change some existing suffixes from "-tests" or ".test" to ".tests".

Inspired by @bjourne's commit 2424a77507408d382eddd3ca6395b4b0664ac98c.

Most of the work was done by the following script, but manual adjustments were also necessary.
```
! Copyright (C) 2018 Alexander Ilin.
! See http://factorcode.org/license.txt for BSD license.
USING: io.directories.search io.encodings.utf8 io.files kernel
sequences ;
IN: tests-fix-in

: ensure-tail ( str tail -- str' )
    2dup tail? [ drop ] [ append ] if ;

: fix-tests-IN: ( lines -- lines' )
    dup [ "IN: " head? ] find [ ! lines i str
        over [ ".tests" ensure-tail ] change-nth
    ] [ drop ] if ;

: fix-tests ( -- )
    "." "-tests.factor" find-files-by-extension
    [ utf8 [ fix-tests-IN: ] change-file-lines ] each ;

MAIN: fix-tests
```