### PR TITLE
cast fixes undefined behaviour; closes #1919 in upstream

### DIFF
--- a/vm/layouts.hpp
+++ b/vm/layouts.hpp
@@ -104,7 +104,7 @@ inline static fixnum untag_fixnum(cell tagged) {
 }
 
 inline static cell tag_fixnum(fixnum untagged) {
-  return (untagged << TAG_BITS) | FIXNUM_TYPE;
+  return ( (cell)untagged << TAG_BITS) | FIXNUM_TYPE;
 }
 
 #define NO_TYPE_CHECK static const cell type_number = TYPE_COUNT


### PR DESCRIPTION
Factor compiles and runs all the tests as normal with this change, but it eliminates the undefined behaviour warnings given to us by ASan. 

Bootstrap took 7 minutes 11 seconds on this machine, which is a little below the average for me.

closes #1919