### PR TITLE
refactor help.lint.coverage with complete docs and tests

### DIFF
--- a/extra/help/lint/coverage/coverage-docs.factor
+++ b/extra/help/lint/coverage/coverage-docs.factor
@@ -1,5 +1,5 @@
-USING: help help.lint.coverage help.lint.coverage.private help.markup help.syntax kernel
-sequences strings vocabs words ;
+USING: help help.lint.coverage help.lint.coverage.private
+help.markup help.syntax io kernel sequences strings vocabs words ;
 IN: help.lint.coverage
 
 <PRIVATE
@@ -19,31 +19,84 @@ $nl
 $nl
 "These words are provided to aid in writing more complete documentation:"
 { $related-subsections
+    word-help-coverage.
+    vocab-help-coverage.
+    prefix-help-coverage.
+}
+
+"Coverage report objects:"
+{ $related-subsections
+    word-help-coverage
+    help-coverage.
+}
+
+"Raw report generation:"
+{ $related-subsections
     <word-help-coverage>
     <vocab-help-coverage>
     <prefix-help-coverage>
-}
-
-"Coverage reports:"
-{ $related-subsections
-    word-help-coverage
-    print-coverage
 } ;
 
-{ <word-help-coverage> <vocab-help-coverage> <prefix-help-coverage> word-help-coverage }
+{ word-help-coverage word-help-coverage. <word-help-coverage> <vocab-help-coverage> <prefix-help-coverage> }
 related-words
 
 HELP: word-help-coverage
 { $class-description "A documentation coverage report for a single word." } ;
 
-HELP: print-coverage
+HELP: help-coverage.
 { $values { "coverage" word-help-coverage } }
 { $contract "Displays a coverage object." }
 { $examples
     { $example
-        "USING: help.lint.coverage io ;"
-        "\\ <word-help-coverage> <word-help-coverage> print-coverage"
-        "Word '<word-help-coverage>' has 100% help coverage"
+        "USING: help.lint.coverage ;"
+        "\\ <word-help-coverage> <word-help-coverage> help-coverage."
+        "[help.lint.coverage] <word-help-coverage>: full help coverage"
+    }
+} ;
+
+HELP: word-help-coverage.
+{ $values { "word-spec" { $or word string } } }
+{ $description "Prettyprints a help coverage report of " { $snippet "word-spec" } " to " { $link output-stream } "." }
+{ $examples
+    { $example
+        "USING: sequences help.lint.coverage ;"
+        "\\ map word-help-coverage."
+        "[sequences] map: needs help section: $examples"
+    }
+} ;
+
+HELP: vocab-help-coverage.
+{ $values { "vocab-spec" { $or vocab string } } }
+{ $description "Prettyprints a help coverage report of " { $snippet "vocab-spec" } " to " { $link output-stream } "." }
+{ $examples
+    { $example
+        "USING: help.lint.coverage ;"
+        "\"english\" vocab-help-coverage."
+"[english] a10n: needs help sections: $description $examples
+[english] count-of-things: needs help sections: $description $examples
+[english] pluralize: needs help sections: $description $examples
+[english] singularize: needs help sections: $description $examples
+
+0.0% of words have complete documentation"
+    }
+} ;
+
+HELP: prefix-help-coverage.
+{ $values { "prefix-spec" { $or vocab string } } { "private?" boolean } }
+{ $description "Prettyprints a help coverage report of " { $snippet "prefix-spec" } " to " { $link output-stream } "." }
+{ $examples
+    { $example
+        "USING: help.lint.coverage ;"
+        "\"english\" t prefix-help-coverage."
+"[english] a10n: needs help sections: $description $examples
+[english] count-of-things: needs help sections: $description $examples
+[english] pluralize: needs help sections: $description $examples
+[english] singularize: needs help sections: $description $examples
+[english.private] match-case: needs help sections: $description $examples
+[english.private] plural-to-singular: needs help sections: $description $examples
+[english.private] singular-to-plural: needs help sections: $description $examples
+
+0.0% of words have complete documentation"
     }
 } ;
 
@@ -53,35 +106,36 @@ HELP: <prefix-help-coverage>
 { $examples
     { $example
         "USING: help.lint.coverage prettyprint ;"
-        "\"help.lint.coverage\" f <prefix-help-coverage> ."
+        "\"english\" t <prefix-help-coverage> ."
 "{
-    {
-        T{ word-help-coverage
-            { word-name <prefix-help-coverage> }
-            { 100%-coverage? t }
-        }
-        T{ word-help-coverage
-            { word-name <vocab-help-coverage> }
-            { 100%-coverage? t }
-        }
-        T{ word-help-coverage
-            { word-name <word-help-coverage> }
-            { 100%-coverage? t }
-        }
-        T{ word-help-coverage
-            { word-name print-coverage }
-            { 100%-coverage? t }
-        }
-        T{ word-help-coverage
-            { word-name word-help-coverage }
-            { 100%-coverage? t }
-        }
-        T{ word-help-coverage
-            { word-name word-help-coverage? }
-            { 100%-coverage? t }
-        }
+    T{ word-help-coverage
+        { word-name a10n }
+        { omitted-sections { $description $examples } }
     }
-    { }
+    T{ word-help-coverage
+        { word-name count-of-things }
+        { omitted-sections { $description $examples } }
+    }
+    T{ word-help-coverage
+        { word-name pluralize }
+        { omitted-sections { $description $examples } }
+    }
+    T{ word-help-coverage
+        { word-name singularize }
+        { omitted-sections { $description $examples } }
+    }
+    T{ word-help-coverage
+        { word-name match-case }
+        { omitted-sections { $description $examples } }
+    }
+    T{ word-help-coverage
+        { word-name plural-to-singular }
+        { omitted-sections { $description $examples } }
+    }
+    T{ word-help-coverage
+        { word-name singular-to-plural }
+        { omitted-sections { $description $examples } }
+    }
 }"
     }
 } ;
@@ -106,31 +160,23 @@ HELP: <vocab-help-coverage>
 { $examples
     { $example
         "USING: help.lint.coverage prettyprint ;"
-        "\"help.lint.coverage\" <vocab-help-coverage> ."
+        "\"english\" <vocab-help-coverage> ."
 "{
     T{ word-help-coverage
-        { word-name <prefix-help-coverage> }
-        { 100%-coverage? t }
+        { word-name a10n }
+        { omitted-sections { $description $examples } }
     }
     T{ word-help-coverage
-        { word-name <vocab-help-coverage> }
-        { 100%-coverage? t }
+        { word-name count-of-things }
+        { omitted-sections { $description $examples } }
     }
     T{ word-help-coverage
-        { word-name <word-help-coverage> }
-        { 100%-coverage? t }
+        { word-name pluralize }
+        { omitted-sections { $description $examples } }
     }
     T{ word-help-coverage
-        { word-name print-coverage }
-        { 100%-coverage? t }
-    }
-    T{ word-help-coverage
-        { word-name word-help-coverage }
-        { 100%-coverage? t }
-    }
-    T{ word-help-coverage
-        { word-name word-help-coverage? }
-        { 100%-coverage? t }
+        { word-name singularize }
+        { omitted-sections { $description $examples } }
     }
 }"
     }

--- a/extra/help/lint/coverage/coverage-tests.factor
+++ b/extra/help/lint/coverage/coverage-tests.factor
@@ -1,5 +1,6 @@
-USING: help.lint.coverage help.lint.coverage.private help.markup
-help.syntax kernel math.matrices sorting tools.test vocabs ;
+USING: accessors fuel.help.private help.lint.coverage
+help.lint.coverage.private help.markup help.syntax kernel
+literals math math.matrices sorting tools.test vocabs ;
 IN: help.lint.coverage.tests
 
 <PRIVATE
@@ -9,7 +10,7 @@ IN: help.lint.coverage.tests
 
 HELP: empty { $examples } ;
 HELP: nonexistent ;
-HELP: defined { $examples { $example "USING: x ;" "blah" "hahaha" } } ;
+HELP: defined { $examples { $example "USING: prettyprint ; ""1 ." "1" } } ;
 PRIVATE>
 
 { t } [ \ empty empty-examples? ] unit-test
@@ -33,4 +34,35 @@ PRIVATE>
 { { $values $description $examples } } [ \ keep word-defines-sections ] unit-test
 { { $values $contract $examples } } [ \ <word-help-coverage> word-defines-sections ] unit-test
 
-{ eye } [ "eye" loaded-vocab-names resolve-name-in ] unit-test
+{ eye } [ "eye" find-word ] unit-test
+
+{
+  V{ "[" { $[ "math" dup lookup-vocab ] } "] " { "zero?" zero? } ": " }
+} [
+  V{ } clone \ zero? (assemble-word-metadata)
+] unit-test
+{
+  V{ "empty " { "$examples" $examples } "; " }
+} [
+  V{ } clone word-help-coverage new t >>empty-examples? (assemble-empty-examples)
+] unit-test
+
+{
+  V{ "needs help " "sections: " { { "$description" $description } { "$examples" $examples } } }
+} [
+  V{ } clone word-help-coverage new { $description $examples } >>omitted-sections (assemble-omitted-sections)
+] unit-test
+{
+  V{ "needs help " "section: " { { "$description" $description } } }
+} [
+  V{ } clone word-help-coverage new { $description } >>omitted-sections (assemble-omitted-sections)
+] unit-test
+{
+  V{ "full help coverage" }
+} [
+  V{ } clone word-help-coverage new t >>100%-coverage? (assemble-full-coverage)
+] unit-test
+
+! make sure this doesn't throw an error (would signify an issue with ignored-words)
+! the contents of all-words is not important
+{ } [ all-words [ <word-help-coverage> ] map drop ] unit-test


### PR DESCRIPTION
follow-on to #1927 
this will un-break the build and provide a more clear API with better tests too.