### PR TITLE
add $related-subsections to minimise docs duplication

### DIFF
--- a/basis/help/help-docs.factor
+++ b/basis/help/help-docs.factor
@@ -195,7 +195,14 @@ HELP: $subsections
     { $markup-example { $subsections "sequences" nth each } }
 } ;
 
-{ $subsection $subsections $link } related-words
+HELP: $related-subsections 
+{ $values { "children" "a " { $link sequence } " of one or more " { $link topic } "s" } }
+{ $description "A version of " { $link $subsections } " which also calls " { $link related-words } " on " { $snippet "children" } ", relating its contents together." }
+{ $examples
+    { $markup-example { $related-subsections keep + } }
+} ; 
+
+{ $subsection $subsections $related-subsections $link $vocab-subsection } related-words
 
 HELP: $vocab-subsection
 { $values { "element" "a markup element of the form " { $snippet "{ title vocab }" } } }

--- a/basis/help/markup/markup.factor
+++ b/basis/help/markup/markup.factor
@@ -251,6 +251,11 @@ PRIVATE>
 : $subsections ( children -- )
     [ $subsection* ] each ($blank-line) ;
 
+DEFER: related-words
+
+: $related-subsections ( children -- ) 
+    [ related-words ] [ $subsections ] bi ; 
+
 : $subsection ( element -- )
     check-first $subsection* ;
 


### PR DESCRIPTION
very often there are some words in a `{ $subsectoions a b c d }` and then later on in the docs `{ a b c d } related-words`, but it is duplicate-y and you have to change the list in 2 places every time you add a word. :( 

I have found this incredibly useful for documenting vocabs with lots of similar words like math.matrices' new documentation (https://github.com/catb0t/factor/commit/662e6f855ea6a5f5b86632e70a6e0472b80ffd1f); I've used this in a couple other places and I think it would fit in the distribution
