### PR TITLE
fix a typo in compiler.tree.propagation.constraints documentation

### DIFF
--- a/basis/compiler/tree/propagation/constraints/constraints-docs.factor
+++ b/basis/compiler/tree/propagation/constraints/constraints-docs.factor
@@ -17,18 +17,19 @@ HELP: interval-constraint
 { $class-description "An interval constraint." } ;
 
 HELP: literal-constraint
-{ $class-description "A literal constraint" } ;
+{ $class-description "A literal constraint." } ;
 
 HELP: satisfied?
 { $values { "constraint" "a constraint" } { "?" boolean } }
-{ $description "satisfied? is inaccurate. It's just used to prevent infinite loops so its only implemented for true-constraints and false-constraints." } ;
+{ $description "The name " { $snippet "satisfied?" } " is imprecise. This word is used to prevent infinite loops, so it is only implemented for " { $link true-constraint } " and " { $link false-constraint } "." } ;
 
 ARTICLE: "compiler.tree.propagation.constraints" "Support for predicated value info"
-"A constraint is a statement about a value."
+"A constraint is a statement about a value. The " { $vocab-link "compiler.tree.propagation.constraints" } " vocabulary implements these constraints for propagation of values through the compilation process."
 $nl
 "Boolean constraints:"
-{ $subsections true-constraint true-constraint }
+{ $subsections true-constraint false-constraint }
 "Utilities:"
 { $subsections t--> f--> } ;
 
 ABOUT: "compiler.tree.propagation.constraints"
+


### PR DESCRIPTION
i fixed up some documentation i stumbled across.