### PR TITLE
db.tuples improvement

### DIFF
--- a/basis/db/tuples/tuples-docs.factor
+++ b/basis/db/tuples/tuples-docs.factor
@@ -122,13 +122,23 @@ HELP: update-tuple
      { "tuple" tuple } }
 { $description "Updates a tuple that has already been inserted into a database. The tuple must have a primary key that has been set by " { $link insert-tuple } " or that is user-defined." } ;
 
+HELP: update-tuples
+{ $values
+     { "query/tuple" tuple }
+     { "quot" { $quotation ( tuple -- tuple'/f ) } } }
+{ $description "An SQL query is constructed from the slots of the exemplar tuple that are not " { $link f } ". The " { $snippet "quot" } " is applied to each tuple from the database that matches the query, and the changed tuple is stored back to the database. If the " { $snippet "quot" } " returns " { $link f } ", the tuple is dropped, and its data remains unmodified in the database."
+$nl
+"The word is equivalent to the following code:"
+{ $code "query/tuple select-tuples quot map sift [ update-tuple ] each" }
+"The difference is that " { $snippet "update-tuples" } " handles query results one by one, thus avoiding the overhead of allocating the intermediate array of tuples, which " { $link select-tuples } " would do. This is important when processing large amounts of data in limited memory." } ;
+
 HELP: delete-tuples
 { $values
      { "tuple" tuple } }
 { $description "Uses the " { $snippet "tuple" } " as an exemplar object and deletes any objects that have the same slots set. If a slot is not " { $link f } ", then it is used to generate an SQL statement that deletes tuples." }
 { $warning "This word will delete your data." } ;
 
-{ insert-tuple update-tuple delete-tuples } related-words
+{ insert-tuple update-tuple update-tuples delete-tuples } related-words
 
 HELP: each-tuple
 { $values
@@ -183,8 +193,11 @@ ARTICLE: "db-tuples-words" "High-level tuple/database words"
 { $subsections drop-table }
 "Inserting a tuple:"
 { $subsections insert-tuple }
-"Updating a tuple:"
-{ $subsections update-tuple }
+"Updating tuples:"
+{ $subsections
+    update-tuple
+    update-tuples
+}
 "Deleting tuples:"
 { $subsections delete-tuples }
 "Querying tuples:"

--- a/basis/db/tuples/tuples-docs.factor
+++ b/basis/db/tuples/tuples-docs.factor
@@ -130,6 +130,12 @@ HELP: delete-tuples
 
 { insert-tuple update-tuple delete-tuples } related-words
 
+HELP: each-tuple
+{ $values
+     { "query/tuple" tuple }
+     { "quot" { $quotation ( tuple -- ) } } }
+{ $description "An SQL query is constructed from the slots of the exemplar tuple that are not " { $link f } ". The " { $snippet "quot" } " is applied to each tuple from the database that matches the query constructed from the exemplar tuple." } ;
+
 HELP: select-tuple
 { $values
      { "query/tuple" tuple }
@@ -148,7 +154,7 @@ HELP: count-tuples
      { "n" integer } }
 { $description "Returns the number of items that would be returned if the query were a select query. Counting the tuples with this word is more efficient than calling " { $link length } " on the result of " { $link select-tuples } "." } ;
 
-{ select-tuple select-tuples count-tuples } related-words
+{ each-tuple select-tuple select-tuples count-tuples } related-words
 
 
 
@@ -183,6 +189,7 @@ ARTICLE: "db-tuples-words" "High-level tuple/database words"
 { $subsections delete-tuples }
 "Querying tuples:"
 { $subsections
+    each-tuple
     select-tuple
     select-tuples
     count-tuples

--- a/basis/db/tuples/tuples-docs.factor
+++ b/basis/db/tuples/tuples-docs.factor
@@ -134,13 +134,13 @@ HELP: select-tuple
 { $values
      { "query/tuple" tuple }
      { "tuple/f" { $maybe tuple } } }
-{ $description "A SQL query is constructed from the slots of the exemplar tuple that are not " { $link f } ". Returns a single tuple from the database if it matches the query constructed from the exemplar tuple." } ;
+{ $description "An SQL query is constructed from the slots of the exemplar tuple that are not " { $link f } ". Returns a single tuple from the database if it matches the query constructed from the exemplar tuple." } ;
 
 HELP: select-tuples
 { $values
      { "query/tuple" tuple }
      { "tuples" "an array of tuples" } }
-{ $description "A SQL query is constructed from the slots of the exemplar tuple that are not " { $link f } ". Returns an array of multiple tuples from the database that match the query constructed from the exemplar tuple." } ;
+{ $description "An SQL query is constructed from the slots of the exemplar tuple that are not " { $link f } ". Returns an array of multiple tuples from the database that match the query constructed from the exemplar tuple." } ;
 
 HELP: count-tuples
 { $values

--- a/basis/db/tuples/tuples-docs.factor
+++ b/basis/db/tuples/tuples-docs.factor
@@ -1,4 +1,5 @@
 ! Copyright (C) 2008 Doug Coleman.
+! Copyright (C) 2018 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: classes help.markup help.syntax io.streams.string kernel
 quotations sequences strings math db.types db.tuples.private db ;

--- a/basis/db/tuples/tuples.factor
+++ b/basis/db/tuples/tuples.factor
@@ -166,3 +166,6 @@ ERROR: no-defined-persistent object ;
 : each-tuple ( query/tuple quot: ( tuple -- ) -- )
     [ >query [ tuple>> ] [ query>statement ] bi ] dip do-each-tuple
     ; inline
+
+: update-tuples ( query/tuple quot: ( tuple -- tuple'/f ) -- )
+    '[ @ [ update-tuple ] when* ] each-tuple ; inline

--- a/basis/db/tuples/tuples.factor
+++ b/basis/db/tuples/tuples.factor
@@ -1,4 +1,5 @@
 ! Copyright (C) 2008 Doug Coleman.
+! Copyright (C) 2018 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: arrays assocs classes db kernel namespaces
 classes.tuple words sequences slots math accessors

--- a/basis/db/types/types-docs.factor
+++ b/basis/db/types/types-docs.factor
@@ -97,12 +97,12 @@ HELP: user-assigned-id-spec?
 
 HELP: bind#
 { $values
-     { "spec" "a SQL spec" } { "obj" object } }
+     { "spec" "an SQL spec" } { "obj" object } }
 { $description "A generic word that lets a database construct a literal binding." } ;
 
 HELP: bind%
 { $values
-     { "spec" "a SQL spec" } }
+     { "spec" "an SQL spec" } }
 { $description "A generic word that lets a database output a binding." } ;
 
 HELP: db-assigned-id-spec?
@@ -120,23 +120,23 @@ HELP: find-primary-key
 
 HELP: no-sql-type
 { $values
-     { "type" "a SQL type" } }
+     { "type" "an SQL type" } }
 { $description "Throws an error containing an SQL type that is unsupported or the result of a typo." } ;
 
 HELP: normalize-spec
 { $values
-     { "spec" "a SQL spec" } }
+     { "spec" "an SQL spec" } }
 { $description "Normalizes an SQL spec." } ;
 
 HELP: primary-key?
 { $values
-     { "spec" "a SQL spec" }
+     { "spec" "an SQL spec" }
      { "?" boolean } }
 { $description "Returns true if an SQL spec is a primary key." } ;
 
 HELP: relation?
 { $values
-     { "spec" "a SQL spec" }
+     { "spec" "an SQL spec" }
      { "?" boolean } }
 { $description "Returns true if an SQL spec is a relation." } ;
 


### PR DESCRIPTION
Hey, guys! I'm very excited about these changes. Was pretty surprised that this functionality wasn't there in the first place, and I'm glad I was able to contribute it with only half a day's worth of effort.

Basically, in this PR I add two new words to `db.tuples`: `each-tuple` and `map-tuples`. These words allow one to stream and handle really big amounts of data one tuple at a time without creating the intermediate array in memory. The old `query-tuples` word is now implemented using the new `query-tuples-each`, so there is no code duplication.

A lot of words had to be declared `inline` because of the quotations now being passed through the stack. I hope that's not a big issue.

The new words have been tested by me with an SQLite DB, but I didn't have time yet to add new unit-tests. I want you to take a look and make some comments before I finalize this PR by adding the tests. If you think documentation needs improvement or some words may have better names, please suggest.