### PR TITLE
extra/pairs: 2 new words and tests

### DIFF
--- a/extra/pairs/pairs-tests.factor
+++ b/extra/pairs/pairs-tests.factor
@@ -21,3 +21,6 @@ SYMBOL: blah
 { f f } [ "fdaf" "b" get at* ] unit-test
 { 2 } [ "b" get assoc-size ] unit-test
 { { { 2 1 } { blah "bleah" } } } [ "b" get >alist ] unit-test
+{ V{ 1 2 } } [ 1 2 <pair> V{ } >sequence ] unit-test
+{ { 1 2 } } [ 1 2 <pair> >array ] unit-test
+

--- a/extra/pairs/pairs.factor
+++ b/extra/pairs/pairs.factor
@@ -38,4 +38,11 @@ M: pair delete-at
 M: pair >alist
     [ hash>> >alist ] [ [ key>> ] [ value>> ] bi 2array ] bi suffix ; inline
 
+: >sequence ( pair exemplar -- seq )
+    [ [ value>> ] [ key>> ] bi 2array ] dip like ;
+
+: >array ( pair -- array )
+    { } >sequence ;
+
 INSTANCE: pair assoc
+


### PR DESCRIPTION
tiny changes to make it easier to use pairs. `>sequence` outputs the slots in the same order they were put in, rather than in `key value` order.

I considered implementing all of the sequence protocol so that you can say `1 2 <pair> [ 2 + ] map` and have it output a real sequence `{ 3 4 }`, but it seems overkill when all I want is a 2-element box that I can easily convert to an array.

I also considered moving the vocab to `basis` because I think it's useful enough to not be in `extra` but again, it's more than I want to bother with right now.