### PR TITLE
.gitattributes: add the eol=lf attribute to html-files (fixes #1916)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.factor text eol=lf
+*.html text eol=lf


### PR DESCRIPTION
For some reason that issue never got the (easy) patch it deserved.