### PR TITLE
make the caret color themeable

### DIFF
--- a/basis/ui/gadgets/editors/editors-docs.factor
+++ b/basis/ui/gadgets/editors/editors-docs.factor
@@ -12,7 +12,6 @@ HELP: editor
 $nl
 "Editors have the following slots:"
 { $list
-    { { $snippet "caret-color" } " - a " { $link color } "." }
     { { $snippet "caret" } " - a " { $link model } " storing a line/column pair." }
     { { $snippet "mark" } " - a " { $link model } " storing a line/column pair. If there is no selection, the mark is equal to the caret, otherwise the mark is located at the opposite end of the selection from the caret." }
     { { $snippet "focused?" } " - a boolean." }

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -25,7 +25,6 @@ TUPLE: editor < line-gadget
     <loc> >>mark ; inline
 
 : editor-theme ( editor -- editor )
-    COLOR: red >>caret-color
     monospace-font >>font ; inline
 
 PRIVATE>
@@ -158,11 +157,9 @@ M: editor ungraft*
 
 : draw-caret ( editor -- )
     dup draw-caret? [
-        [ caret-color>> gl-color ]
-        [
-            [ caret-loc ] [ caret-dim ] bi
-            over v+ gl-line
-        ] bi
+        [ editor-caret-color gl-color ] dip
+        [ caret-loc ] [ caret-dim ] bi
+        over v+ gl-line
     ] [ drop ] if ;
 
 : selection-start/end ( editor -- start end )

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -11,7 +11,6 @@ ui.render ui.text ui.theme unicode ;
 IN: ui.gadgets.editors
 
 TUPLE: editor < line-gadget
-    caret-color
     caret mark
     focused? blink blink-timer
     default-text ;

--- a/basis/ui/theme/theme.factor
+++ b/basis/ui/theme/theme.factor
@@ -262,7 +262,7 @@ M: dark-theme vocab-border-color COLOR: solarized-base01 ;
 
 M: dark-theme field-border-color COLOR: solarized-base01 ;
 
-M: dark-theme editor-caret-color COLOR: red ;
+M: dark-theme editor-caret-color COLOR: DeepPink2 ;
 M: dark-theme selection-color COLOR: solarized-base01 ;
 M: dark-theme panel-background-color T{ rgba f 0.7843 0.7686 0.7176 1.0 } ;
 M: dark-theme focus-border-color COLOR: solarized-base01 ;

--- a/basis/ui/theme/theme.factor
+++ b/basis/ui/theme/theme.factor
@@ -83,6 +83,7 @@ HOOK: vocab-border-color theme ( -- color )
 
 HOOK: field-border-color theme ( -- color )
 
+HOOK: editor-caret-color theme ( -- color )
 HOOK: selection-color theme ( -- color )
 HOOK: panel-background-color theme ( -- color )
 HOOK: focus-border-color theme ( -- color )
@@ -172,6 +173,7 @@ M: light-theme vocab-border-color COLOR: FactorDarkTan ;
 
 M: light-theme field-border-color COLOR: gray ;
 
+M: light-theme editor-caret-color COLOR: red ;
 M: light-theme selection-color T{ rgba f 0.8 0.8 1.0 1.0 } ;
 M: light-theme panel-background-color T{ rgba f 0.7843 0.7686 0.7176 1.0 } ;
 M: light-theme focus-border-color COLOR: dark-gray ;
@@ -260,6 +262,7 @@ M: dark-theme vocab-border-color COLOR: solarized-base01 ;
 
 M: dark-theme field-border-color COLOR: solarized-base01 ;
 
+M: dark-theme editor-caret-color COLOR: red ;
 M: dark-theme selection-color COLOR: solarized-base01 ;
 M: dark-theme panel-background-color T{ rgba f 0.7843 0.7686 0.7176 1.0 } ;
 M: dark-theme focus-border-color COLOR: solarized-base01 ;


### PR DESCRIPTION
Move the editor caret color into a theme hook instead of delegating it to each editor instance.