### PR TITLE
math.functions docs: add logn to "powers and logarithms" article

### DIFF
--- a/basis/math/functions/functions-docs.factor
+++ b/basis/math/functions/functions-docs.factor
@@ -51,7 +51,7 @@ ARTICLE: "power-functions" "Powers and logarithms"
 "Exponential and natural logarithm:"
 { $subsections e^ cis log }
 "Other logarithms:"
-{ $subsections log1+ log10 }
+{ $subsections log1+ log10 logn }
 "Raising a number to a power:"
 { $subsections ^ e^ 10^ }
 "Logistics functions:"


### PR DESCRIPTION
logn function was omitted from the subsections in "powers and logarithms"