### PR TITLE
splitting.extras[-docs|-tests]: add split-lengths

### DIFF
--- a/extra/splitting/extras/extras-docs.factor
+++ b/extra/splitting/extras/extras-docs.factor
@@ -20,3 +20,7 @@ HELP: split-find
 { $description "Splits a sequence into slices using the provided quotation to find split points." } ;
 
 { split-when-harvest split-when-slice-harvest } related-words
+
+HELP: split-lengths
+{ $values { "seq" sequence } { "lengths" sequence } { "pieces" "a new array" } }
+{ $description "Splits a sequence into slices of the given lengths." } ;

--- a/extra/splitting/extras/extras-tests.factor
+++ b/extra/splitting/extras/extras-tests.factor
@@ -37,3 +37,8 @@ tools.test ;
 { { "a" "b" "c" } } [ "a  b  c" " " split-harvest ] unit-test
 { { "a" "b" "c" } } [ " a  b  c" " " split-harvest ] unit-test
 { { "a" "b" "c" } } [ " a  b  c " " " split-harvest ] unit-test
+
+{ { { } } } [ { } { } split-lengths ] unit-test
+{ { { } { } } } [ { } { 0 } split-lengths ] unit-test
+[ { } { 1 } split-lengths ] must-fail
+{ { { } { 0 } { } { 1 2 } { 3 4 5 } { 6 7 8 9 } } } [ 10 <iota> { 0 1 0 2 3 } split-lengths ] unit-test

--- a/extra/splitting/extras/extras.factor
+++ b/extra/splitting/extras/extras.factor
@@ -1,4 +1,4 @@
-USING: hints kernel math sequences strings ;
+USING: hints kernel math sequences splitting strings ;
 
 IN: splitting.extras
 
@@ -62,3 +62,6 @@ PRIVATE>
 
 { split* split*-slice split-harvest }
 [ { string string } set-specializer ] each
+
+: split-lengths ( seq lengths -- pieces )
+    0 swap [ + dup ] map nip split-indices ;


### PR DESCRIPTION
`split-lengths` is a new word that I could not find anywhere. It can be useful to split streams into chunks, for example when interpreting things like [AUTHENTICATE_MESSAGE](https://msdn.microsoft.com/en-us/library/cc236643.aspx).