### PR TITLE
furnance.auth: fix documentation

### DIFF
--- a/basis/furnace/auth/auth-docs.factor
+++ b/basis/furnace/auth/auth-docs.factor
@@ -121,7 +121,6 @@ $nl
     "furnace.auth.providers.null"
     "furnace.auth.providers.assoc"
     "furnace.auth.providers.db"
-    "furnace.auth.providers.couchdb"
 } ;
 
 ARTICLE: "furnace.auth.features" "Optional authentication features"

--- a/basis/furnace/auth/providers/couchdb/couchdb-docs.factor
+++ b/basis/furnace/auth/providers/couchdb/couchdb-docs.factor
@@ -25,12 +25,12 @@ HELP: couchdb-auth-provider
 
 ARTICLE: "furnace.auth.providers.couchdb" "CouchDB Authentication Provider"
     "The " { $vocab-link "furnace.auth.providers.couchdb" } " vocabulary implements an authentication provider "
-    "which looks up authentication requests in a CouchDB. It is necessary to create a view "
+    "which looks up authentication requests in CouchDB. It is necessary to create a view "
     "associating usernames with user documents before using this vocabulary; see documentation "
     "for " { $link couchdb-auth-provider } "."
     $nl
     "Although this implementation guarantees that users with duplicate IDs/emails"
-    " cannot be created in a single CouchDB database, it provides so such guarentee if you are clustering "
+    " cannot be created in a single CouchDB database, it provides no such guarantee if you are clustering "
     "multiple DBs. In this case, you are responsible for ensuring the uniqueness of users across "
     "databases."
     $nl


### PR DESCRIPTION
The docs were attempting to reference the CouchDB auth provider, but that fails, because the help vocab didn't include `furnance.auth.couchdb`.

That said, the CouchDB auth provider has such major caveats with it (see the docs) that I think I personally might prefer axing the reference entirely. Thoughts?