### PR TITLE
add a FreeDesktop Desktop Entry file that users may customise and use

### DIFF
--- a/misc/Factor.desktop
+++ b/misc/Factor.desktop
@@ -1,0 +1,14 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Factor IDE
+Comment=Factor Programming Environment (Development Mode)
+Icon=/path/to/factor-folder/misc/icons/Factor_512x512@2x.png
+Exec="/path/to/factor-folder/factor"
+Path=/path/to/factor-folder/
+Terminal=false
+Categories=Development;IDE;
+Keywords=Programming;
+StartupWMClass=Listener
+


### PR DESCRIPTION
This is an executable text file which tells FreeDesktop-compliant desktop environments information about the Factor program, so that it can be included in menus and other application launchers (mostly in BSD/Linux desktops). 

`Version` refers to the .desktop spec version, not the program version.

to use this file as a launcher, it should be copied to a location like `/home/$USER/.local/share/applications/` and the paths should be changed to real ones.

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html