### PR TITLE
build.sh: correctness / safety and fixups

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -681,7 +681,7 @@ install_deps_apt() {
 }
 
 install_deps_pacman() {
-    sudo pacman --noconfirm -S gcc clang make rlwrap git wget pango glibc gtk2 gtk3 gtkglext gtk-engines gdk-pixbuf2 libx11 screen tmux
+    sudo pacman --noconfirm -Syu gcc clang make rlwrap git wget pango glibc gtk2 gtk3 gtkglext gtk-engines gdk-pixbuf2 libx11 screen tmux
     check_ret sudo
 }
 

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ test_program_installed() {
 
 # return 1 on found
 test_programs_installed() {
-    installed=0;
+    local installed=0;
     $ECHO -n "Checking for all($*)..."
     for i in "$@" ;
     do
@@ -54,7 +54,7 @@ exit_script() {
 }
 
 ensure_program_installed() {
-    installed=0;
+    local installed=0;
     $ECHO -n "Checking for any($*)..."
     for i in "$@" ;
     do
@@ -243,7 +243,7 @@ check_factor_exists() {
 find_os() {
     if [[ -n $OS ]] ; then return; fi
     $ECHO "Finding OS..."
-    uname_s=$(uname -s)
+    local uname_s=$(uname -s)
     check_ret uname
     case $uname_s in
         CYGWIN_NT-5.2-WOW64) OS=windows;;
@@ -550,7 +550,7 @@ check_url() {
             return 1
         fi
     elif [[ $DOWNLOADER_NAME == 'curl' ]]; then
-        code=$(curl -sL -w "%{http_code}\\n" "$1" -o /dev/null)
+        local code=$(curl -sL -w "%{http_code}\\n" "$1" -o /dev/null)
         if [[ $code -eq 200 ]]; then return 0; else return 1; fi
     else
         $ECHO "error: wget or curl required in check_url"
@@ -562,10 +562,10 @@ check_url() {
 # Otherwise, just use `master`
 set_boot_image_vars() {
     set_current_branch
-    url="http://downloads.factorcode.org/images/${CURRENT_BRANCH}/checksums.txt"
+    local url="http://downloads.factorcode.org/images/${CURRENT_BRANCH}/checksums.txt"
     check_url $url
     if [[ $? -eq 0 ]]; then
-        CHECKSUM_URL="http://downloads.factorcode.org/images/${CURRENT_BRANCH}/checksums.txt"
+        CHECKSUM_URL="$url"
         BOOT_IMAGE_URL="http://downloads.factorcode.org/images/${CURRENT_BRANCH}/${BOOT_IMAGE}"
     else
         CHECKSUM_URL="http://downloads.factorcode.org/images/master/checksums.txt"

--- a/build.sh
+++ b/build.sh
@@ -590,9 +590,9 @@ update_boot_image() {
     $DELETE temp/staging.*.image > /dev/null 2>&1
     if [[ -f $BOOT_IMAGE ]] ; then
         get_url $CHECKSUM_URL
-        factorcode_md5=$(cat checksums.txt | grep $BOOT_IMAGE | cut -f2 -d' ')
+        local factorcode_md5=$(cat checksums.txt | grep $BOOT_IMAGE | cut -f2 -d' ')
         set_md5sum
-        disk_md5=$($MD5SUM $BOOT_IMAGE | cut -f1 -d' ')
+        local disk_md5=$($MD5SUM $BOOT_IMAGE | cut -f1 -d' ')
         $ECHO "Factorcode md5: $factorcode_md5";
         $ECHO "Disk md5: $disk_md5";
         if [[ "$factorcode_md5" == "$disk_md5" ]] ; then

--- a/build.sh
+++ b/build.sh
@@ -15,9 +15,11 @@ GIT_PROTOCOL=${GIT_PROTOCOL:="git"}
 GIT_URL=${GIT_URL:=$GIT_PROTOCOL"://factorcode.org/git/factor.git"}
 SCRIPT_ARGS="$*"
 
+REQUIRE_CLANG_VERSION=3.1
+
 # return 1 on found
 test_program_installed() {
-    if ! [[ -n `type -p $1` ]] ; then
+    if ! [[ -n $(type -p $1) ]] ; then
         return 0;
     fi
     return 1;
@@ -27,7 +29,7 @@ test_program_installed() {
 test_programs_installed() {
     installed=0;
     $ECHO -n "Checking for all($*)..."
-    for i in $* ;
+    for i in "$@" ;
     do
         test_program_installed $i
         if [[ $? -eq 1 ]]; then
@@ -54,7 +56,7 @@ exit_script() {
 ensure_program_installed() {
     installed=0;
     $ECHO -n "Checking for any($*)..."
-    for i in $* ;
+    for i in "$@" ;
     do
         test_program_installed $i
         if [[ $? -eq 1 ]]; then
@@ -133,16 +135,16 @@ semver_into() {
 }
 
 clang_version_ok() {
-    CLANG_VERSION=`clang --version | head -n1`
+    CLANG_VERSION=$(clang --version | head -n1)
     CLANG_VERSION_RE='^[a-zA-Z0-9 ]* version (.*)$' # 3.3-5
     if [[ $CLANG_VERSION =~ $CLANG_VERSION_RE ]] ; then
         export "CLANG_VERSION=${BASH_REMATCH[1]}"
-        local CLANG_MAJOR local CLANG_MINOR local CLANG_PATCH local CLANG_SPECIAL
+        local CLANG_MAJOR CLANG_MINOR CLANG_PATCH CLANG_SPECIAL
         semver_into "$CLANG_VERSION" CLANG_MAJOR CLANG_MINOR CLANG_PATCH CLANG_SPECIAL
         if [[ $CLANG_MAJOR -lt 3
             || ( $CLANG_MAJOR -eq 3 && $CLANG_MINOR -le 1 )
             ]] ; then
-            echo "clang version required >= 3.1, got $CLANG_VERSION"
+            echo "clang version required >= $REQUIRE_CLANG_VERSION, got $CLANG_VERSION"
             return 1
         fi
     else
@@ -241,7 +243,7 @@ check_factor_exists() {
 find_os() {
     if [[ -n $OS ]] ; then return; fi
     $ECHO "Finding OS..."
-    uname_s=`uname -s`
+    uname_s=$(uname -s)
     check_ret uname
     case $uname_s in
         CYGWIN_NT-5.2-WOW64) OS=windows;;
@@ -258,7 +260,7 @@ find_os() {
 find_architecture() {
     if [[ -n $ARCH ]] ; then return; fi
     $ECHO "Finding ARCH..."
-    uname_m=`uname -m`
+    uname_m=$(uname -m)
     check_ret uname
     case $uname_m in
        i386) ARCH=x86;;
@@ -275,7 +277,7 @@ find_architecture() {
 find_num_cores() {
     $ECHO "Finding num cores..."
     NUM_CORES=7ZZ
-    uname_s=`uname -s`
+    uname_s=$(uname -s)
     check_ret uname
     case $uname_s in
         CYGWIN_NT-5.2-WOW64 | *CYGWIN_NT* | *CYGWIN* | MINGW32*) NUM_CORES=$NUMBER_OF_PROCESSORS;;
@@ -283,20 +285,19 @@ find_num_cores() {
     esac
 }
 
-write_test_program() {
+echo_test_program() {
     #! Must be 'echo'
-    echo "#include <stdio.h>" > $C_WORD.c
-    echo "int main(){printf(\"%ld\", (long)(8*sizeof(void*))); return 0; }" >> $C_WORD.c
+    echo -e "int main(){ return (long)(8*sizeof(void*)); }"
 }
 
 c_find_word_size() {
     $ECHO "Finding WORD..."
-    C_WORD=factor-word-size
-    write_test_program
-    $CC -o $C_WORD $C_WORD.c
-    WORD=$(./$C_WORD)
-    check_ret $C_WORD
-    $DELETE -f $C_WORD*
+    C_WORD="factor-word-size"
+    echo_test_program | $CC -o $C_WORD -xc -
+    check_ret $CC
+    ./$C_WORD
+    WORD=$?
+    $DELETE -f $C_WORD
 }
 
 intel_macosx_word_size() {
@@ -403,9 +404,9 @@ set_build_info() {
 parse_build_info() {
     ensure_program_installed cut
     $ECHO "Parsing make target from command line: $1"
-    OS=`echo $1 | cut -d '-' -f 1`
-    ARCH=`echo $1 | cut -d '-' -f 2`
-    WORD=`echo $1 | cut -d '-' -f 3`
+    OS=$(echo $1 | cut -d '-' -f 1)
+    ARCH=$(echo $1 | cut -d '-' -f 2)
+    WORD=$(echo $1 | cut -d '-' -f 3)
 
     if [[ $OS == linux && $ARCH == ppc ]] ; then WORD=32; fi
     if [[ $OS == linux && $ARCH == arm ]] ; then WORD=32; fi
@@ -433,7 +434,7 @@ find_build_info() {
 }
 
 invoke_git() {
-    git $*
+    git "$@"
     check_ret git
 }
 
@@ -443,12 +444,12 @@ git_clone() {
 }
 
 update_script_name() {
-    $ECHO `dirname $0`/_update.sh
+    $ECHO "$(dirname $0)/_update.sh"
 }
 
 update_script() {
-    update_script=`update_script_name`
-    bash_path=`which bash`
+    local -r update_script=$(update_script_name)
+    local -r bash_path=$(which bash)
     $ECHO "#!$bash_path" >"$update_script"
     $ECHO "git pull \"$GIT_URL\" master" >>"$update_script"
     $ECHO "if [[ \$? -eq 0 ]]; then exec \"$0\" $SCRIPT_ARGS; else echo \"git pull failed\"; exit 2; fi" \
@@ -460,13 +461,13 @@ update_script() {
 }
 
 update_script_changed() {
-    invoke_git diff --stat `invoke_git merge-base HEAD FETCH_HEAD` FETCH_HEAD | grep 'build\.sh' >/dev/null
+    invoke_git diff --stat "$(invoke_git merge-base HEAD FETCH_HEAD)" FETCH_HEAD | grep 'build\.sh' >/dev/null
 }
 
 git_fetch_factorcode() {
     $ECHO "Fetching the git repository from factorcode.org..."
 
-    rm -f `update_script_name`
+    rm -f "$(update_script_name)"
     invoke_git fetch "$GIT_URL" master
 
     if update_script_changed; then
@@ -479,7 +480,7 @@ git_fetch_factorcode() {
 }
 
 cd_factor() {
-    cd factor
+    cd "factor"
     check_ret cd
 }
 
@@ -519,7 +520,7 @@ check_makefile_exists() {
 
 invoke_make() {
     check_makefile_exists
-    $MAKE $MAKE_OPTS $*
+    $MAKE $MAKE_OPTS "$@"
     check_ret $MAKE
 }
 
@@ -543,13 +544,13 @@ current_git_branch() {
 
 check_url() {
     if [[ $DOWNLOADER_NAME == 'wget' ]]; then
-        if [[ `wget -S --spider $1 2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+        if [[ $(wget -S --spider $1 2>&1 | grep 'HTTP/1.1 200 OK') ]]; then
             return 0
         else
             return 1
         fi
     elif [[ $DOWNLOADER_NAME == 'curl' ]]; then
-        code=`curl -sL -w "%{http_code}\\n" "$1" -o /dev/null`
+        code=$(curl -sL -w "%{http_code}\\n" "$1" -o /dev/null)
         if [[ $code -eq 200 ]]; then return 0; else return 1; fi
     else
         $ECHO "error: wget or curl required in check_url"
@@ -589,9 +590,9 @@ update_boot_image() {
     $DELETE temp/staging.*.image > /dev/null 2>&1
     if [[ -f $BOOT_IMAGE ]] ; then
         get_url $CHECKSUM_URL
-        factorcode_md5=`cat checksums.txt|grep $BOOT_IMAGE|cut -f2 -d' '`
+        factorcode_md5=$(cat checksums.txt | grep $BOOT_IMAGE | cut -f2 -d' ')
         set_md5sum
-        disk_md5=`$MD5SUM $BOOT_IMAGE|cut -f1 -d' '`
+        disk_md5=$($MD5SUM $BOOT_IMAGE | cut -f1 -d' ')
         $ECHO "Factorcode md5: $factorcode_md5";
         $ECHO "Disk md5: $disk_md5";
         if [[ "$factorcode_md5" == "$disk_md5" ]] ; then
@@ -665,12 +666,12 @@ net_bootstrap_no_pull() {
 }
 
 refresh_image() {
-    ./$FACTOR_BINARY -script -e="USING: vocabs.loader vocabs.refresh system memory ; refresh-all save 0 exit"
+    ./$FACTOR_BINARY -e="USING: vocabs.loader vocabs.refresh system memory ; refresh-all save 0 exit"
     check_ret factor
 }
 
 make_boot_image() {
-    ./$FACTOR_BINARY -script -e="\"$MAKE_IMAGE_TARGET\" USING: system bootstrap.image memory ; make-image save 0 exit"
+    ./$FACTOR_BINARY -e="\"$MAKE_IMAGE_TARGET\" USING: system bootstrap.image memory ; make-image save 0 exit"
     check_ret factor
 }
 


### PR DESCRIPTION
i found some improvements to make to the build.sh buildscript. I don't know  `CMD` sowell anymore, but maybe I'll look at `build.cmd` sometime too.

* fixed: backtick substitition -> `$(...)` backticks are broken and old, and the form `$(...)` is preferred, safer, fewer bugs etc

* fixed: interpreting arrays as strings (`$*` where there should be `"$@"`)

* fixed: `local x local y` declares the local variables `x`, `local`, and `y` (don't do that)

* correctness: some arguments and substitutions need `"quoted"` to prevent word splitting 

* `CLANG_VERSION >= x` is now globally accessible as `$REQUIRED_CLANG_VERSION` rather than being a magic number hidden away in a function (perhaps we should get it from the Makefile instead??)

* `local -r` like `declare -r` declares `readonly` (const) variables, used where opportune 

* correctness / safety: Factor's `command-line.startup` doesn't have any `-script` argument anymore so i removed it from the invocations of `./$FACTOR_BINARY`, so that it doesn't do something un-expected 

* largest single change: performance improvement (especially if your L1 cache is about 80kb) in c_find_word size

  * make `$CC` compile STDIN
  * return the word size as an exit code instead of printing it
 
`WORD` will always be of the range 16 - 128, so it's a valid POSIX exit code. 

this means we don't have to include a header, and we don't have to call `printf`.

this also reduces the function's number of disk / cache writes, to just 1 per invocation (not including `$DELETE`).

then `check_ret` is used on `$CC` instead of on the executable itself. (`check_ret` on a program that always returns 0 is pretty pointless anyway)