### PR TITLE
fix absolute path on windows

### DIFF
--- a/extra/etc-hosts/etc-hosts.factor
+++ b/extra/etc-hosts/etc-hosts.factor
@@ -7,7 +7,7 @@ IN: etc-hosts
 HOOK: hosts-path os ( -- path )
 
 M: windows hosts-path
-    "SystemRoot" os-env "/System32/drivers/etc/hosts" append-path ;
+    "SystemRoot" os-env "System32/drivers/etc/hosts" append-path ;
 
 M: unix hosts-path "/etc/hosts" ;
 


### PR DESCRIPTION
append-path ignores the first argument if the second is an absolute path, breaks the vocab on windows