### PR TITLE
editors.visual-studio-code: search PATH on Windows

### DIFF
--- a/basis/editors/visual-studio-code/visual-studio-code.factor
+++ b/basis/editors/visual-studio-code/visual-studio-code.factor
@@ -40,6 +40,7 @@ M: linux find-visual-studio-code-invocation
 M: windows find-visual-studio-code-invocation
     {
         [ { "Microsoft VS Code" } "code.exe" find-in-applications ]
+        [ "code.cmd" ]
     } 0|| ;
 
 M: visual-studio-code editor-command ( file line -- command )


### PR DESCRIPTION
- A \\\\?\ prefixed path returned by 'which' will fail with a Windows
error when used to start the editor, so drop that prefix if present.