### PR TITLE
Heaps

### DIFF
--- a/basis/heaps/heaps-tests.factor
+++ b/basis/heaps/heaps-tests.factor
@@ -27,8 +27,24 @@ IN: heaps.tests
 { 0 } [ <max-heap> heap-size ] unit-test
 { 1 } [ <max-heap> t 1 pick heap-push heap-size ] unit-test
 
+DEFER: (assert-heap-invariant)
+
+: ((assert-heap-invariant)) ( parent child heap heap-size -- )
+    pick over < [
+        [ [ heapdata-compare f assert= ] 2keep ] dip
+        (assert-heap-invariant)
+    ] [ 4drop ] if ;
+
+: (assert-heap-invariant) ( n heap heap-size -- )
+    [ dup left dup 1 + ] 2dip
+    [ ((assert-heap-invariant)) ] 2curry bi-curry@ bi ;
+
+: assert-heap-invariant ( heap -- )
+    dup heap-empty? [ drop ]
+    [ 0 swap dup heap-size (assert-heap-invariant) ] if ;
+
 : heap-sort ( alist heap -- keys )
-    [ heap-push-all ] keep heap-pop-all ;
+    [ heap-push-all ] keep dup assert-heap-invariant heap-pop-all ;
 
 : random-alist ( n -- alist )
     <iota> [
@@ -57,6 +73,7 @@ IN: heaps.tests
 : test-entry-indices ( n -- ? )
     random-alist
     <min-heap> [ heap-push-all ] keep
+    dup assert-heap-invariant
     data>> dup length <iota> swap [ index>> ] map sequence= ;
 
 14 [
@@ -72,6 +89,7 @@ IN: heaps.tests
         <min-heap> [ heap-push-all ] keep
         dup data>> clone swap
     ] keep 3 /i [ 2dup [ delete-random ] dip heap-delete ] times
+    dup assert-heap-invariant
     data>>
     [ [ key>> ] map ] bi@
     [ natural-sort ] bi@ ;

--- a/basis/heaps/heaps-tests.factor
+++ b/basis/heaps/heaps-tests.factor
@@ -80,9 +80,6 @@ DEFER: (assert-heap-invariant)
     [ t ] swap [ 2^ test-entry-indices ] curry unit-test
 ] each-integer
 
-: sort-entries ( entries -- entries' )
-    [ key>> ] sort-with ;
-
 : delete-test ( n -- obj1 obj2 )
     [
         random-alist

--- a/basis/heaps/heaps.factor
+++ b/basis/heaps/heaps.factor
@@ -70,6 +70,12 @@ M: min-heap heap-compare
 M: max-heap heap-compare
     drop { entry entry } declare [ key>> ] bi@ before? ; inline
 
+: (heapdata-compare) ( m n data heap -- ? )
+    [ '[ _ data-nth ] bi@ ] [ heap-compare ] bi* ; inline
+
+: heapdata-compare ( m n heap -- ? )
+    [ data>> ] keep (heapdata-compare) ; inline
+
 PRIVATE>
 
 : >entry< ( entry -- value key )
@@ -117,7 +123,7 @@ M: heap heap-push*
     n dup left [ dup end < ] [
         dup 1 fixnum+fast
         dup end < [
-            2dup [ data data-nth ] bi@ heap heap-compare
+            2dup data heap (heapdata-compare)
         ] [ f ] if
         [ nip ] [ drop ] if
         [ data data-nth swap data data-set-nth ]

--- a/basis/heaps/heaps.factor
+++ b/basis/heaps/heaps.factor
@@ -6,6 +6,9 @@ kernel.private locals math math.order math.private sequences
 sequences.private summary vectors ;
 IN: heaps
 
+! names and optimizations copied from pypy's heapq.py,
+! refer to it from in depth explanations of the optimizations.
+
 GENERIC: heap-push* ( value key heap -- entry )
 GENERIC: heap-peek ( heap -- value key )
 GENERIC: heap-pop* ( heap -- )
@@ -86,6 +89,7 @@ M: heap heap-peek ( heap -- value key )
 
 <PRIVATE
 
+! called bubble-up in the litterature... but we keep pypy's name.
 :: sift-down ( heap from to -- )
     heap data>>      :> data
     to data data-nth :> tmp
@@ -115,6 +119,11 @@ M: heap heap-push*
 
 <PRIVATE
 
+! called bubble-down in the litterature... but we keep pypy's name.
+! A quote from pypy's implementation:
+! > We *could* break out of the loop as soon as we find a pos where newitem <=
+! > both its children, but turns out that's not a good idea [...]
+! Indeed the code is 33% slower if we remove this optmization.
 :: sift-up ( heap n -- )
     heap data>>     :> data
     data length     :> end


### PR DESCRIPTION
I implemented what I suggested in #2103 .

Then I saw that the you used the same names as pypy for sift-up and sift-down so I didn't rename them.

And then I saw that the benchmarks went from 0.6s to 0.8s consistently. It turns out bubbling down to the bottom and then back up is a known (but counter-intuitive..) optimization ! It was even explained in the link you provided (I missed it the first time because it's at line 260...) : 
> We *could* break out of the loop as soon as we find a pos where newitem <=
> both its children, but turns out that's not a good idea, ...

https://github.com/reingart/pypy/blob/9d6b4fb5eaabe6d2bbe63e063709d72d86f8b153/lib-python/2.7/heapq.py#L261

So now it's just tests, comments and the bubble up or down in heap-delete.

Also I found this https://stackoverflow.com/a/10163422 where it is suggested to do what I suggested in #2103 (using sift-up with 0 as a limit..) . I was wondering if this was another case of counter intuitive performance optimization, but this time I'd be really surprised if it was. A proper benchmark would be needed to be sure though.

Please review and merge !