### PR TITLE
ui.backend.windows: fix special treatment of the character keypresses

### DIFF
--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -323,13 +323,10 @@ CONSTANT: exclude-keys-wm-char
 
 : key-sym ( wParam -- string/f action? )
     {
-        {
-            [ dup LETTER? ]
-            [ shift? caps-lock? xor [ CHAR: a + CHAR: A - ] unless 1string f ]
-        }
-        { [ dup digit? ] [ 1string f ] }
-        [ wm-keydown-codes at t ]
-    } cond ;
+        { [ dup LETTER? ] [ CHAR: a + CHAR: A - 1string ] }
+        { [ dup digit? ] [ 1string ] }
+        [ wm-keydown-codes at ]
+    } cond t ;
 
 :: handle-wm-keydown ( hWnd uMsg wParam lParam -- )
     wParam exclude-key-wm-keydown? [
@@ -344,8 +341,7 @@ CONSTANT: exclude-keys-wm-char
     wParam exclude-key-wm-char? [
         ctrl? alt? xor [
             wParam 1string
-            [ f hWnd send-key-down ]
-            [ hWnd window user-input ] bi
+            hWnd window user-input
         ] unless
     ] unless ;
 

--- a/basis/ui/tools/browser/browser.factor
+++ b/basis/ui/tools/browser/browser.factor
@@ -195,7 +195,7 @@ M: browser-gadget focusable-child* search-field>> ;
 browser-gadget "toolbar" f {
     { T{ key-down f { A+ } "LEFT" } com-back }
     { T{ key-down f { A+ } "RIGHT" } com-forward }
-    { T{ key-down f { A+ } "H" } com-home }
+    { T{ key-down f { S+ A+ } "h" } com-home }
     { T{ key-down f f "F1" } browser-help }
     { T{ key-down f { A+ } "F1" } glossary }
 } define-command-map
@@ -217,7 +217,7 @@ browser-gadget "navigation" "Commands for navigating in the article hierarchy" {
     { T{ key-down f { A+ } "p" } com-prev }
     { T{ key-down f { A+ } "n" } com-next }
     { T{ key-down f { A+ } "k" } com-show-outgoing-links }
-    { T{ key-down f { A+ } "K" } com-show-incoming-links }
+    { T{ key-down f { S+ A+ } "k" } com-show-incoming-links }
 } define-command-map
 
 browser-gadget "multi-touch" f {

--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -452,7 +452,7 @@ listener-gadget "toolbar" f {
     { f restart-listener }
     { T{ key-down f { A+ } "u" } com-auto-use }
     { T{ key-down f { A+ } "k" } clear-output }
-    { T{ key-down f { A+ } "K" } clear-stack }
+    { T{ key-down f { S+ A+ } "k" } clear-stack }
     { T{ key-down f { C+ } "d" } com-end }
     { T{ key-down f f "F1" } com-help }
 } define-command-map

--- a/basis/ui/tools/tools.factor
+++ b/basis/ui/tools/tools.factor
@@ -15,14 +15,14 @@ IN: ui.tools
 
 tool "tool-switching" f {
     { T{ key-down f { A+ } "l" } show-listener }
-    { T{ key-down f { A+ } "L" } listener-window }
+    { T{ key-down f { S+ A+ } "l" } listener-window }
     { T{ key-down f { A+ } "b" } show-browser }
-    { T{ key-down f { A+ } "B" } browser-window }
+    { T{ key-down f { S+ A+ } "b" } browser-window }
 } define-command-map
 
 tool "common" f {
     { T{ key-down f { A+ } "w" } close-window }
-    { T{ key-down f { A+ } "F" } toggle-fullscreen }
+    { T{ key-down f { S+ A+ } "f" } toggle-fullscreen }
     { T{ key-down f { A+ } "q" } com-exit }
     { T{ key-down f f "F2" } refresh-all }
     { T{ key-down f f "F3" } show-error-list }

--- a/extra/game-of-life/game-of-life.factor
+++ b/extra/game-of-life/game-of-life.factor
@@ -188,7 +188,7 @@ grid-gadget "toolbar" f {
 
 grid-gadget "gestures" [
     {
-        { T{ key-down f { A+ } "F" } [ toggle-fullscreen ] }
+        { T{ key-down f { S+ A+ } "f" } [ toggle-fullscreen ] }
         { T{ button-down { # 1 } } [ on-click ] }
         { T{ drag { # 1 } } [ on-drag ] }
         { mouse-scroll [ on-scroll ] }


### PR DESCRIPTION
Without this fix, Caps Lock state interferes with the shortcuts like
Ctrl-a by registering them as Ctrl-A, and it is also impossible to create
shortcuts with the Shift key to be triggered only by the physical pressing
of the Shift key, and not the Caps Lock state.

With this fix, all the key-down events for characters have the lower case
letter, and the Shift state reported in the mods field.

This patch solves the issue for the Windows platform, not any others, but the UI shortcut definitions are updated globally, so other platforms will probably lose the functions like A+S+k to clear the stack in the listener.