### PR TITLE
sequences-docs: add a missing article

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,5 +135,7 @@ anything related to Factor or language design in general.
 
 * [Factor homepage](https://factorcode.org)
 * [Concatenative languages wiki](https://concatenative.org)
+* [Mailing list](factor-talk@lists.sourceforge.net)
+* Search for "factorcode" on [Gitter](https://gitter.im/)
 
 Have fun!

--- a/core/sequences/sequences-docs.factor
+++ b/core/sequences/sequences-docs.factor
@@ -632,7 +632,7 @@ HELP: member-eq?
 
 HELP: remove
 { $values { "elt" object } { "seq" sequence } { "newseq" "a new sequence" } }
-{ $description "Outputs a new sequence containing all elements of the input sequence except for given element." }
+{ $description "Outputs a new sequence containing all elements of the input sequence except for the given element." }
 { $notes "This word uses equality comparison (" { $link = } ")." } ;
 
 HELP: remove-eq


### PR DESCRIPTION
A small fix to the documentation, and an update to the Community section of the Readme file.