### PR TITLE
calendar[-docs]: add week-number

### DIFF
--- a/basis/calendar/calendar-docs.factor
+++ b/basis/calendar/calendar-docs.factor
@@ -401,6 +401,22 @@ HELP: day-of-year
     }
 } ;
 
+HELP: week-number
+{ $values { "timestamp" timestamp } { "[1,53]" integer } }
+{ $description "Calculates the ISO 8601 week number from 1 to 53 (leap years). See " { $snippet "https://en.wikipedia.org/wiki/ISO_week_date" } }
+{ $examples
+    "Last day of 2018 is already in the first week of 2019."
+    { $example "USING: calendar prettyprint ;"
+               "2018 12 31 <date> week-number ."
+               "1"
+    }
+    "2020 is a leap year with 53 weeks, and January 1st, 2021 is still in week 53 of 2020."
+    { $example "USING: calendar prettyprint ;"
+               "2021 1 1 <date> week-number ."
+               "53"
+    }
+} ;
+
 HELP: sunday
 { $values { "timestamp" timestamp } { "new-timestamp" timestamp } }
 { $description "Returns the Sunday from the current week, which starts on a Sunday." } ;
@@ -573,6 +589,7 @@ ARTICLE: "calendar-facts" "Calendar facts"
     days-in-month
     day-of-year
     day-of-week
+    week-number
 }
 "Calculating a Julian day number:"
 { $subsections julian-day-number }

--- a/basis/calendar/calendar-tests.factor
+++ b/basis/calendar/calendar-tests.factor
@@ -194,3 +194,9 @@ IN: calendar
 
 ! pm
 [ now 30 pm ] [ not-in-interval? ] must-fail-with
+
+{ 1 } [ 2018 12 31 <date> week-number ] unit-test
+
+{ 16 } [ 2019 4 17 <date> week-number ] unit-test
+
+{ 53 } [ 2021 1 1 <date> week-number ] unit-test

--- a/basis/calendar/calendar.factor
+++ b/basis/calendar/calendar.factor
@@ -538,6 +538,16 @@ M: integer end-of-year 12 31 <date> ;
 : unix-time>timestamp ( seconds -- timestamp )
     [ unix-1970 ] dip +second ; inline
 
+: (week-number) ( timestamp -- [0,53] )
+    [ day-of-year ] [ day-of-week [ 7 ] when-zero ] bi - 10 + 7 /i ;
+
+: week-number ( timestamp -- [1,53] )
+    dup (week-number) {
+        {  0 [ year>> 1 - end-of-year (week-number) ] }
+        { 53 [ year>> 1 + <year> (week-number) 1 = 1 53 ? ] }
+        [ nip ]
+    } case ;
+
 {
     { [ os unix? ] [ "calendar.unix" ] }
     { [ os windows? ] [ "calendar.windows" ] }


### PR DESCRIPTION
The new `week-number` word in the `calendar` vocab returns the week number of a `timestamp` according to ISO 8601 (https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date).

Should we maybe use this new word for the "W" format in `strftime`? This could make it compatible with [PHP date("W")](https://www.php.net/manual/en/function.date.php) and possibly other languages. Currently the `formatting` vocab uses its own `<PRIVATE` version of `week-of-year`, which prompted me to write the new `week-number` in the first place, when I needed to do `today week-number .`.

In any case, it seems like the `week-of-year` is something that should be in the `calendar` vocab (along with `day-of-week` and `day-of-year`), not in a private section of the `formatting` vocab.