### PR TITLE
Gtk key down up

### DIFF
--- a/basis/ui/backend/gtk/gtk.factor
+++ b/basis/ui/backend/gtk/gtk.factor
@@ -540,7 +540,7 @@ M: gtk-ui-backend (with-ui)
 M: gtk-ui-backend stop-event-loop
     gtk_main_quit ;
 
-os linux? [
+os { linux freebsd } member? [
     gtk-ui-backend ui-backend set-global
 ] when
 

--- a/basis/ui/backend/gtk/gtk.factor
+++ b/basis/ui/backend/gtk/gtk.factor
@@ -171,19 +171,23 @@ CONSTANT: events-mask
     event win [ key-event>gesture ] [ window ] bi*
     over :> gesture
     gesture sym>> length 1 = [
-        gesture sym>> first LETTER?
-        S+ event event-modifiers member? not and [
-            gesture [ >lower ] change-sym drop
-        ] when
+        { { [ gesture sym>> first LETTER?
+              S+ event event-modifiers member? not and ] 
+            [ gesture [ >lower ] change-sym drop ] }
+          { [ gesture sym>> first letter?
+              S+ event event-modifiers member? and ]
+            [ gesture [ >upper ] change-sym drop ] }
+          [ ]
+        } cond
     ] when
     event keyval>> shift-ignore-keys key? [
         gesture [ S+ swap remove ] change-mods drop
     ] when
     over sym>> "\0" =
     event keyval>> exclude-keys-keydown/up key? or [
-        2drop f
+        2drop t
     ] [
-        propagate-key-gesture f
+        propagate-key-gesture t
     ] if ;
  
 : on-focus-in ( win event user-data -- ? )

--- a/basis/ui/backend/gtk/gtk.factor
+++ b/basis/ui/backend/gtk/gtk.factor
@@ -9,7 +9,7 @@ math.vectors namespaces sequences strings system threads ui ui.backend
 ui.backend.gtk.input-methods ui.backend.gtk.io ui.backend.x11.keys
 ui.clipboards ui.event-loop ui.gadgets ui.gadgets.private
 ui.gadgets.worlds ui.gestures ui.pixel-formats
-ui.pixel-formats.private ui.private vocabs.loader ;
+ui.pixel-formats.private ui.private vocabs.loader unicode ;
 IN: ui.backend.gtk
 
 SINGLETON: gtk-ui-backend
@@ -157,14 +157,35 @@ CONSTANT: events-mask
 : key-sym ( keyval -- string/f action? )
     code>sym [ dup integer? [ gdk_keyval_to_unicode 1string ] when ] dip ;
 
-: key-event>gesture ( event -- key-gesture )
-    [ event-modifiers ] [ keyval>> key-sym ] [
-        type>> GDK_KEY_PRESS = [ <key-down> ] [ <key-up> ] if
-    ] tri ;
+:: key-event>gesture ( event -- key-gesture )
+    event event-modifiers
+    event keyval>> code>sym drop
+    dup integer? not [
+        drop event keyval>> key-sym
+    ] [
+        gdk_keyval_to_unicode 1string f
+    ] if
+    event type>> GDK_KEY_PRESS = [ <key-down> ] [ <key-up> ] if ;
 
-: on-key-press/release ( win event user-data -- ? )
-    drop swap [ key-event>gesture ] [ window ] bi* propagate-key-gesture t ;
-
+:: on-key-press/release ( win event user-data -- ? )
+    event win [ key-event>gesture ] [ window ] bi*
+    over :> gesture
+    gesture sym>> length 1 = [
+        gesture sym>> first LETTER?
+        S+ event event-modifiers member? not and [
+            gesture [ >lower ] change-sym drop
+        ] when
+    ] when
+    event keyval>> shift-ignore-keys key? [
+        gesture [ S+ swap remove ] change-mods drop
+    ] when
+    over sym>> "\0" =
+    event keyval>> exclude-keys-keydown/up key? or [
+        2drop f
+    ] [
+        propagate-key-gesture f
+    ] if ;
+ 
 : on-focus-in ( win event user-data -- ? )
     2drop window focus-world t ;
 
@@ -515,7 +536,7 @@ M: gtk-ui-backend (with-ui)
 M: gtk-ui-backend stop-event-loop
     gtk_main_quit ;
 
-os { linux freebsd } member? [
+os linux? [
     gtk-ui-backend ui-backend set-global
 ] when
 

--- a/basis/ui/backend/x11/keys/keys.factor
+++ b/basis/ui/backend/x11/keys/keys.factor
@@ -59,7 +59,48 @@ CONSTANT: codes
         { $ XK_Super_R f }
         { $ XK_Hyper_L f }
         { $ XK_Hyper_R f }
+
+        { $ XK_KP_Home "HOME" }
+        { $ XK_KP_Left "LEFT" }
+        { $ XK_KP_Up "UP" }
+        { $ XK_KP_Right "RIGHT" }
+        { $ XK_KP_Down "DOWN" }
+        { $ XK_KP_Page_Up "PAGE_UP" }
+        { $ XK_KP_Page_Down "PAGE_DOWN" }
+        { $ XK_KP_End "END" }
+        { $ XK_KP_Begin "BEGIN" }
+        { $ XK_KP_Insert "INSERT" }
+        { $ XK_KP_Delete "DELETE" }
     }
+
+CONSTANT: exclude-keys-keydown/up
+    H{
+        { $ XK_Shift_L f }
+        { $ XK_Shift_R f }
+        { $ XK_Control_L f }
+        { $ XK_Control_R f }
+        { $ XK_Caps_Lock f }
+        { $ XK_Shift_Lock f }
+        { $ XK_Super_L f }
+        { $ XK_Super_R f }
+        { $ XK_Alt_L f }
+        { $ XK_Alt_R f }
+    }
+
+CONSTANT: shift-ignore-keys
+    H{
+        { $ XK_KP_Home "HOME" }
+        { $ XK_KP_Left "LEFT" }
+        { $ XK_KP_Up "UP" }
+        { $ XK_KP_Right "RIGHT" }
+        { $ XK_KP_Down "DOWN" }
+        { $ XK_KP_Page_Up "PAGE_UP" }
+        { $ XK_KP_Page_Down "PAGE_DOWN" }
+        { $ XK_KP_End "END" }
+        { $ XK_KP_Begin "BEGIN" }
+        { $ XK_KP_Insert "INSERT" }
+        { $ XK_KP_Delete "DELETE" }
+    }    
 
 : code>sym ( code -- name/code/f action? )
     dup codes at* [ nip dup t and ] when ;


### PR DESCRIPTION
I wrote the cord which fixed key-down/up event issues on gtk backend Factor. It improves:
- events about numeric keys on the keypad with shift, 
- the influence by the state of caps-lock, 
- unnecessary event generation with an individual press of shift, control or alt keys 
- illegal "\0" event generation
on key-down/up events.