### PR TITLE
FUEL: make `fuel-refactor-inline-word` work with hyphenated words

### DIFF
--- a/misc/fuel/fuel-refactor.el
+++ b/misc/fuel/fuel-refactor.el
@@ -195,7 +195,7 @@ The word's body is put in a new method for the generic."
     (let ((code (fuel-refactor--word-def word)))
       (unless code (error "Word's definition not found"))
       (factor-beginning-of-symbol)
-      (kill-word 1)
+      (kill-sexp 1)
       (let ((start (point)))
         (insert code)
         (save-excursion (font-lock-fontify-region start (point)))


### PR DESCRIPTION
The emacs command `kill-word`, used by `fuel-factor-inline-word` does not
delete the complete word if that contains hyphens.  Using `kill-sexp` instead
exhibits correct behavior.

Reproduction:

1. Create some definitions:

```
: foo-bar ( x -- y )
    1 + dup . ;

: baz ( x -- y )
    foo-bar ;  ! place point on 'foo-bar' for step 3
```
2. Compile file
3. Place point  on `foo-bar` inside definition of `baz`
4. run `M-x fuel-refactor-inline-word`, notice that the `-bar` part is not removed before the definition of `foo-bar` is inserted