### PR TITLE
[RFC] Locals value info propagation

### DIFF
--- a/basis/compiler/tree/locals/locals-tests.factor
+++ b/basis/compiler/tree/locals/locals-tests.factor
@@ -1,0 +1,21 @@
+USING: compiler.tree.builder compiler.tree.locals compiler.tree.optimizer kernel
+kernel.private locals math namespaces prettyprint ;
+
+IN: compiler.tree.locals.tests
+
+! Running this should be able to infer output interval
+: test1. ( -- )
+t track-local-infos [
+        [let 45 :> x! [ { fixnum } declare x + dup x! ] ] build-tree optimize-tree ...
+        local-infos get . ] with-variable ;
+
+! Running this should show empty return type
+: test2. ( -- )
+    t track-local-infos [
+        [let t :> x! [ { fixnum } declare x + dup x! ] ] build-tree optimize-tree ...
+        local-infos get . ] with-variable ;
+
+: test3. ( -- )
+t track-local-infos [
+        [let t :> x! [ 42 x! x { fixnum fixnum } declare + dup x! ] ] build-tree optimize-tree ...
+        local-infos get . ] with-variable ;

--- a/basis/compiler/tree/locals/locals.factor
+++ b/basis/compiler/tree/locals/locals.factor
@@ -1,0 +1,57 @@
+USING: accessors assocs compiler.tree compiler.tree.combinators
+compiler.tree.propagation compiler.tree.propagation.info hashtables.identity io
+kernel namespaces prettyprint sequences words ;
+
+IN: compiler.tree.locals
+USE: locals.backend
+
+PREDICATE: local-writer-node < #call word>> \ set-local-value = ;
+
+SYMBOL: local-infos
+
+SYMBOL: track-local-infos
+: track-local-infos? ( -- ? ) track-local-infos get ;
+
+GENERIC: compute-box-info* ( node -- )
+
+M: object compute-box-info* drop ;
+M: local-writer-node compute-box-info*
+    "local-writer-compute-box-info" print
+    dup .
+    node-input-infos first2 literal>>
+    local-infos get push-at ;
+
+! This pass must run between two propagation passes
+: compute-local-boxes ( nodes -- nodes )
+    "local box compute ?" print
+    track-local-infos?
+    [
+        "local box compute" print
+        dup
+        [ compute-box-info* ] each-node
+    ] when ;
+
+: optimize-locals ( nodes -- nodes )
+    "optimize locals" print
+    IH{ } clone local-infos set
+    compute-local-boxes
+    local-infos get assoc-empty?
+    [ propagate ] unless ;
+
+! Info is a union type on all set locations including literal at call site
+: (local-value-info) ( box -- info' )
+    [ local-infos get at ] [ first clone <literal-info> ] bi
+    prefix value-infos-union dup . ;
+
+\ local-value [
+    "local-value-outputs" print
+    track-local-infos? [
+        literal>> (local-value-info)
+    ] [ drop object-info ] if
+] "outputs" set-word-prop
+
+
+! Hack inlining so loading this triggers the new behavior, this should obviously
+! be removed and local-value and set-local-value defined non-inline properly
+
+{ set-local-value local-value } [ f "inline" set-word-prop ] each

--- a/basis/compiler/tree/locals/locals.factor
+++ b/basis/compiler/tree/locals/locals.factor
@@ -16,23 +16,23 @@ GENERIC: compute-box-info* ( node -- )
 
 M: object compute-box-info* drop ;
 M: local-writer-node compute-box-info*
-    "local-writer-compute-box-info" print
+    ! "local-writer-compute-box-info" print
     dup .
     node-input-infos first2 literal>>
     local-infos get push-at ;
 
 ! This pass must run between two propagation passes
 : compute-local-boxes ( nodes -- nodes )
-    "local box compute ?" print
+    ! "local box compute ?" print
     track-local-infos?
     [
-        "local box compute" print
+        ! "local box compute" print
         dup
         [ compute-box-info* ] each-node
     ] when ;
 
 : optimize-locals ( nodes -- nodes )
-    "optimize locals" print
+    ! "optimize locals" print
     IH{ } clone local-infos set
     compute-local-boxes
     local-infos get assoc-empty?
@@ -41,10 +41,12 @@ M: local-writer-node compute-box-info*
 ! Info is a union type on all set locations including literal at call site
 : (local-value-info) ( box -- info' )
     [ local-infos get at ] [ first clone <literal-info> ] bi
-    prefix value-infos-union dup . ;
+    prefix value-infos-union
+    ! dup .
+    ;
 
 \ local-value [
-    "local-value-outputs" print
+    ! "local-value-outputs" print
     track-local-infos? [
         literal>> (local-value-info)
     ] [ drop object-info ] if

--- a/basis/compiler/tree/optimizer/optimizer.factor
+++ b/basis/compiler/tree/optimizer/optimizer.factor
@@ -7,6 +7,7 @@ compiler.tree.propagation
 compiler.tree.cleanup
 compiler.tree.escape-analysis
 compiler.tree.escape-analysis.check
+compiler.tree.locals
 compiler.tree.tuple-unboxing
 compiler.tree.identities
 compiler.tree.def-use
@@ -28,6 +29,7 @@ SYMBOL: check-optimizer?
         analyze-recursive
         normalize
         propagate
+        track-local-infos? [ optimize-locals ] when
         cleanup-tree
         dup run-escape-analysis? [
             escape-analysis

--- a/basis/locals/backend/backend.factor
+++ b/basis/locals/backend/backend.factor
@@ -8,6 +8,6 @@ PRIMITIVE: get-local ( n -- obj )
 PRIMITIVE: load-local ( obj -- )
 PRIMITIVE: load-locals ( ... n -- )
 
-: local-value ( box -- value ) 2 slot ; inline
+: local-value ( box -- value ) 2 slot ;
 
-: set-local-value ( value box -- ) 2 set-slot ; inline
+: set-local-value ( value box -- ) 2 set-slot ;


### PR DESCRIPTION
Adds an additional frontend pass to calculate possible value types at reader sites
of (mutable) local variables.

This is a proof-of-concept for tackling #2154. Probably fails in every case except the one I tested it with.  No idea if this is the correct place to implement this.  Should probably be integrated into the propagation pass.

Basic idea:
1. Record input value information for `set-local-value` calls, Assuming `local-value` calls return the initialization value
2. Traverse the tree again, annotating `local-value` outputs with the union type information of all `set-local-value` calls and the initial value

Has not been tested on branches, but keeping an assoc-stack, this should also work.  Currently every call to `set-local-value` is considered for all reader sites, which is probably wrong.

No idea what this does to overall compilation times.