### PR TITLE
 Inline input using input methods in Mac Factor

### DIFF
--- a/basis/documents/documents-docs.factor
+++ b/basis/documents/documents-docs.factor
@@ -59,6 +59,12 @@ HELP: set-doc-range
 { $errors "Throws an error if " { $snippet "from" } " or " { $snippet "to" } " is out of bounds." }
 { $side-effects "document" } ;
 
+HELP: set-doc-range*
+{ $values { "string" string } { "from" "a pair of integers" } { "to" "a pair of integers" } { "document" document } }
+{ $description "Replaces all text between two line/column number pairs with " { $snippet "string" } ". The string may use either " { $snippet "\\n" } ", " { $snippet "\\r\\n" } " or " { $snippet "\\r" } " line separators.\n\nThis word differs from " { $link set-doc-range } " in that it does not include changes in the Undo and Redo actions." }
+{ $errors "Throws an error if " { $snippet "from" } " or " { $snippet "to" } " is out of bounds." }
+{ $side-effects "document" } ;
+
 HELP: remove-doc-range
 { $values { "from" "a pair of integers" } { "to" "a pair of integers" } { "document" document } }
 { $description "Removes all text between two line/column number pairs." }

--- a/basis/documents/documents.factor
+++ b/basis/documents/documents.factor
@@ -135,6 +135,14 @@ PRIVATE>
         new-to document update-locs
     ] unless ;
 
+:: set-doc-range* ( string from to document -- )
+    from to = string empty? and [
+        string split-lines :> new-lines
+        new-lines from text+loc :> new-to
+        new-lines from to document [ (set-doc-range) ] models:change-model
+        new-to document update-locs
+    ] unless ;
+
 : change-doc-range ( from to document quot -- )
     '[ doc-range @ ] 3keep set-doc-range ; inline
 

--- a/basis/ui/backend/cocoa/input-methods/editors/editors.factor
+++ b/basis/ui/backend/cocoa/input-methods/editors/editors.factor
@@ -1,0 +1,6 @@
+! Copyright (C) 2019 KUSUMOTO Norio
+! See http://factorcode.org/license.txt for BSD license.
+USING: kernel ui.gadgets.editors ui.backend.cocoa.input-methods ;
+IN: ui.backend.cocoa.input-methods.editors
+
+M: editor support-input-methods? drop t ;

--- a/basis/ui/backend/cocoa/input-methods/input-methods.factor
+++ b/basis/ui/backend/cocoa/input-methods/input-methods.factor
@@ -1,0 +1,8 @@
+! Copyright (C) 2019 KUSUMOTO Norio
+! See http://factorcode.org/license.txt for BSD license.
+USING: kernel ui.gadgets ;
+IN: ui.backend.cocoa.input-methods
+
+GENERIC: support-input-methods? ( gadget -- ? )
+
+M: gadget support-input-methods? drop f ;

--- a/basis/ui/gadgets/editors/editors-docs.factor
+++ b/basis/ui/gadgets/editors/editors-docs.factor
@@ -15,7 +15,16 @@ $nl
     { { $snippet "caret" } " - a " { $link model } " storing a line/column pair." }
     { { $snippet "mark" } " - a " { $link model } " storing a line/column pair. If there is no selection, the mark is equal to the caret, otherwise the mark is located at the opposite end of the selection from the caret." }
     { { $snippet "focused?" } " - a boolean." }
-} }
+    { { $snippet "preedit-start" } " - a line/column pair or " { $link f } ". It represents the starting point of the string being edited by an input method." }
+    { { $snippet "preedit-end" } " - a line/column pair or " { $link f } ". It represents the end point of the string being edited by an input method." }
+    { { $snippet "preedit-selected-start" } " - a line/column pair or " { $link f } ". It represents the starting point of the string being selected by an input method." }
+    { { $snippet "preedit-selected-end" } " - a line/column pair or " { $link f } ". It represents the end point of the string being selected by an input method." }
+    { { $snippet "preedit-selection-mode?" } " - a boolean. It means the mode of selecting convertion canditate word. The caret in an editor is not drawn if it is true." }
+    { { $snippet "preedit-underlines" } " - an array or " { $link f } ". It stores underline attributes for its preedit area." }
+}
+$nl
+" Slots that are prefixed with \"preedit-\" should not be modified directly. They are changed by the platform-dependent backend."
+}
 { $see-also line-gadget } ;
 
 HELP: <editor>

--- a/basis/ui/gadgets/gadgets-docs.factor
+++ b/basis/ui/gadgets/gadgets-docs.factor
@@ -46,6 +46,10 @@ HELP: user-input*
 { $values { "str" string } { "gadget" gadget } { "?" boolean } }
 { $contract "Handle free-form textual input while the gadget has keyboard focus." } ;
 
+HELP: temp-im-input
+{ $values { "str" string } { "gadget" gadget } { "?" boolean } }
+{ $contract "Handle free-form textual input while the gadget has keyboard focus. This is used to display the string being preedited by an input method on the gadget. Input by this word is not include changes in the Undo and Redo actions." } ;
+
 HELP: pick-up
 { $values { "point" "a pair of integers" } { "gadget" gadget } { "child/f" { $maybe gadget } } }
 { $description "Outputs the child at a point in the gadget's co-ordinate system. This word recursively descends the gadget hierarchy, and so outputs the deepest child." } ;

--- a/basis/ui/gadgets/gadgets.factor
+++ b/basis/ui/gadgets/gadgets.factor
@@ -55,6 +55,10 @@ GENERIC: user-input* ( str gadget -- ? )
 
 M: gadget user-input* 2drop t ;
 
+GENERIC: temp-im-input ( str gadget -- ? )
+
+M: gadget temp-im-input 2drop t ;
+
 GENERIC: children-on ( rect gadget -- seq )
 
 M: gadget children-on nip children>> ;

--- a/basis/ui/gestures/gestures.factor
+++ b/basis/ui/gestures/gestures.factor
@@ -3,7 +3,7 @@
 USING: accessors arrays ascii assocs boxes calendar classes columns
 combinators combinators.short-circuit deques fry kernel make math
 math.order math.parser math.vectors namespaces sequences sets system
-timers ui.gadgets ui.gadgets.private words ;
+timers ui.gadgets ui.gadgets.private words locals ui.gadgets.editors ;
 IN: ui.gestures
 
 : get-gesture-handler ( gesture gadget -- quot )
@@ -63,8 +63,10 @@ M: propagate-key-gesture-tuple send-queued-gesture
     [ gesture>> ] [ world>> world-focus ] bi
     [ handle-gesture ] with each-parent drop ;
 
-: propagate-key-gesture ( gesture world -- )
-    \ propagate-key-gesture-tuple queue-gesture ;
+:: propagate-key-gesture ( gesture world -- )
+    world world-focus preedit? [
+        gesture world \ propagate-key-gesture-tuple queue-gesture
+    ] unless ;
 
 TUPLE: user-input-tuple string world ;
 


### PR DESCRIPTION
This PR provides inline input using input methods in Mac Factor.

To support this internationalization of text input, I have made changes to the editor gadget and the propagation mechanism for key gestures.

Input using Input methods are underlined until their input is confirmed. The editor gadgets changes for this feature are intended for future use with Windows Factor and GTK Factor.
During inline input using an input method, the key gesture is exclusively passed to it.

This PR supports the input of emojis using input methods. Therefore, this PR is for branch unicode-12.1.0.

The Mac Factor's text input protocol changes from NSTextInput to NSTextInputClient.
