### PR TITLE
Compute and use output type information when compiling words

### DIFF
--- a/basis/compiler/compiler.factor
+++ b/basis/compiler/compiler.factor
@@ -4,7 +4,10 @@ USING: accessors assocs classes classes.algebra combinators
 combinators.short-circuit compiler.cfg compiler.cfg.builder
 compiler.cfg.builder.alien compiler.cfg.finalization
 compiler.cfg.optimizer compiler.codegen compiler.crossref
-compiler.errors compiler.tree.builder compiler.tree.optimizer
+compiler.errors
+compiler.tree
+compiler.tree.propagation.output-infos
+compiler.tree.builder compiler.tree.optimizer
 compiler.units compiler.utilities continuations definitions fry
 generic generic.single io kernel macros make namespaces
 sequences sets stack-checker.dependencies stack-checker.errors
@@ -28,6 +31,7 @@ SYMBOL: compiled
     H{ } clone dependencies namespaces:set
     H{ } clone generic-dependencies namespaces:set
     HS{ } clone conditional-dependencies namespaces:set
+    dup word-being-compiled namespaces:set
     clear-compiler-error ;
 
 GENERIC: no-compile? ( word -- ? )
@@ -111,7 +115,9 @@ M: word combinator? inline? ;
     ! If the word contains breakpoints, don't optimize it, since
     ! the walker does not support this.
     dup optimize? [
-        [ [ build-tree ] [ deoptimize ] recover optimize-tree ] keep
+        [ [ build-tree ] [ deoptimize ] recover optimize-tree
+          [ update-output-infos ] keep
+        ] keep
         contains-breakpoints? [ nip deoptimize* ] [ drop ] if
     ] [ deoptimize* ] if ;
 

--- a/basis/compiler/tree/propagation/known-words/known-words.factor
+++ b/basis/compiler/tree/propagation/known-words/known-words.factor
@@ -1,15 +1,15 @@
 ! Copyright (C) 2008, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors alien alien.accessors alien.data.private arrays
-assocs byte-arrays byte-vectors classes classes.algebra classes.tuple
+USING: accessors alien alien.accessors alien.data.private arrays assocs
+byte-arrays byte-vectors classes classes.algebra classes.tuple
 classes.tuple.private combinators compiler.tree.comparisons
 compiler.tree.propagation.constraints compiler.tree.propagation.info
-compiler.tree.propagation.simple compiler.tree.propagation.slots fry
-generic.math hashtables kernel kernel.private layouts locals math
-math.floats.private math.functions math.integers.private
-math.intervals math.libm math.parser math.partial-dispatch
-math.private namespaces sbufs sequences slots.private splitting
-stack-checker.dependencies strings strings.private vectors words ;
+compiler.tree.propagation.simple compiler.tree.propagation.slots continuations
+continuations.private fry generic.math hashtables kernel kernel.private layouts
+locals math math.floats.private math.functions math.integers.private
+math.intervals math.libm math.parser math.partial-dispatch math.private
+namespaces sbufs sequences slots.private splitting stack-checker.dependencies
+strings strings.private vectors words ;
 FROM: alien.c-types => (signed-interval) (unsigned-interval) ;
 IN: compiler.tree.propagation.known-words
 
@@ -391,3 +391,9 @@ generic-comparison-ops [
 \ tag [
     drop fixnum 0 num-types get [a,b) <class/interval-info>
 ] "outputs" set-word-prop
+
+
+! If info from `current-continuation` and the dummies is used, `ifcc` breaks
+\ current-continuation [ object-info ] "outputs" set-word-prop
+\ dummy-1 [ object-info ] "outputs" set-word-prop
+\ dummy-2 [ drop object-info ] "outputs" set-word-prop

--- a/basis/compiler/tree/propagation/output-infos/output-infos.factor
+++ b/basis/compiler/tree/propagation/output-infos/output-infos.factor
@@ -1,0 +1,72 @@
+USING: accessors combinators combinators.short-circuit compiler.tree
+compiler.tree.propagation.info continuations io kernel math namespaces sequences
+words ;
+IN: compiler.tree.propagation.output-infos
+
+FROM: namespaces => set ;
+
+! * Using Stored Output Infos During Propagation
+ERROR: invalid-outputs #call infos ;
+
+: check-outputs ( #call infos -- infos )
+    over out-d>> over [ length ] bi@ =
+    [ nip ] [ invalid-outputs ] if ;
+
+: null-infos? ( infos -- ? )
+    [ null-info = ] any? ;
+
+: literal-infos? ( infos -- ? )
+    [ literal?>> ] any? ;
+
+: check-consistent-effects ( #call infos -- ? )
+    [ check-outputs ] [
+        dup invalid-outputs? [
+            2drop
+            "FIXME: Inconsistent stack effect output for compiled word: " write
+            word>> name>> print
+            f
+        ] [ rethrow ] if
+    ] recover
+    ;
+
+! This is quite verbose, mainly for catching things which indicate other problems.
+: check-copied-output-infos ( #call word -- ? )
+    "output-infos" word-prop
+    {
+        { [ 2dup check-consistent-effects not ] [ 2drop f ] }
+        { [ [ word>> name>> ] dip dup null-infos? ]
+          [ drop "WARNING: ignoring NULL infos from " prepend write nl f ] }
+        ! { [ dup literal-infos? ]
+        !   [ drop "WARNING: ignoring LITERAL infos from " prepend write nl f ] }
+        [ 2drop t ]
+    } cond
+    ;
+
+! * Storing Inferred Output Infos
+
+: should-store-output-infos? ( nodes -- infos/f )
+    [
+        { [ length 2 > ] [ but-last last ] } 1&&
+        #terminate? not
+    ]
+    [ last dup #return?
+      [ "STRANGE: last node not return, not storing outputs" print ] unless
+      node-input-infos
+    ]
+    bi and ;
+
+ERROR: duplicate-output-infos word infos ;
+
+: update-output-infos ( nodes -- )
+    word-being-compiled get [
+        ! dup "output-infos" word-prop [ duplicate-output-infos ] when*
+        swap should-store-output-infos?
+        [
+            [ drop ] [
+                [ clone f >>literal? ] map ! This line prevents literal propagation
+                "output-infos" set-word-prop
+            ] if-empty
+        ] [
+            drop
+        ] if*
+    ] [ drop ] if* ;

--- a/basis/compiler/tree/tree.factor
+++ b/basis/compiler/tree/tree.factor
@@ -4,6 +4,8 @@ USING: accessors arrays assocs kernel namespaces sequences
 stack-checker.visitor vectors ;
 IN: compiler.tree
 
+SYMBOL: word-being-compiled
+
 TUPLE: node < identity-tuple ;
 
 TUPLE: #introduce < node out-d ;

--- a/basis/tools/deploy/shaker/shaker.factor
+++ b/basis/tools/deploy/shaker/shaker.factor
@@ -182,6 +182,7 @@ IN: tools.deploy.shaker
                 "no-compile"
                 "owner-generic"
                 "outputs"
+                "output-infos"
                 "participants"
                 "predicate"
                 "predicate-definition"

--- a/core/words/words.factor
+++ b/core/words/words.factor
@@ -179,6 +179,7 @@ M: word reset-word
         "unannotated-def" "parsing" "inline" "recursive"
         "foldable" "flushable" "reading" "writing" "reader"
         "writer" "delimiter" "deprecated"
+        "output-infos"
     } remove-word-props ;
 
 : reset-generic ( word -- )


### PR DESCRIPTION
This is intended to fix #417.

When the frontend compiler arrives at the `#return` node during the propagation pass, that node's input value information corresponds to the return type of the word outputs.

The first commit basically does the following:
- When compiling, expose the word which is being compiled in a global variable (Couldn't find a better way to determine where to put the type information)
- At the end of the propagation pass, store output type information in the word's property `output-infos`
- During the propagation pass, when determining the initial types of a `#call` node's outputs, check whether the word has information in it's `output-infos` property, and use these

This breaks some unit test in the dead-code elimination pass, because when a word returns a literal, it's output type information also records that literal, and then when turning an optimized tree back into a quotation, the literal is inserted instead of the original word call.  One could argue that this is actually correct behavior of an optimizer, and that the unit tests should be fixed.  One could also argue that a word should not be inlined unless marked inline, regardless of what it returns.  The latter issue is addressed by the second commit, which removes the information whether a return value is a literal.

I don't know what the correct way is to test this, but I reran all tests in the `compiler.tree` test as well as reload a lot of vocabs, and it did not seem to break anything.

As I am mostly interested in words storing their compiled output types, I did not (and don't know how to) extensively test these changes regarding generated code speed/size or compile time differences.