### PR TITLE
math.intervals: Consistent handling of special intervals

### DIFF
--- a/basis/compiler/tree/propagation/info/info.factor
+++ b/basis/compiler/tree/propagation/info/info.factor
@@ -83,7 +83,7 @@ UNION: fixed-length array byte-array string ;
 : empty-set? ( info -- ? )
     {
         [ class>> null-class? ]
-        [ [ interval>> empty-interval eq? ] [ class>> real class<= ] bi and ]
+        [ [ interval>> empty-interval? ] [ class>> real class<= ] bi and ]
     } 1|| ;
 
 ! Hardcoding classes is kind of a hack.

--- a/basis/compiler/tree/propagation/recursive/recursive.factor
+++ b/basis/compiler/tree/propagation/recursive/recursive.factor
@@ -27,7 +27,7 @@ IN: compiler.tree.propagation.recursive
     interval class counter-class :> class
     {
         { [ interval initial-interval interval-subset? ] [ initial-interval ] }
-        { [ interval empty-interval eq? ] [ initial-interval ] }
+        { [ interval empty-interval? ] [ initial-interval ] }
         {
             [ interval initial-interval interval>= t eq? ]
             [ class max-value [a,a] initial-interval interval-union ]

--- a/basis/math/intervals/intervals-tests.factor
+++ b/basis/math/intervals/intervals-tests.factor
@@ -384,3 +384,16 @@ commutative-ops [
         ] all?
     ] unit-test
 ] each
+
+! Test singleton behavior
+{ f } [ full-interval interval-nonnegative? ] unit-test
+
+{ t } [ empty-interval interval-nonnegative? ] unit-test
+
+{ t } [ full-interval interval-zero? ] unit-test
+
+{ f } [ empty-interval interval-zero? ] unit-test
+
+{ f } [ -1/0. 1/0. [ empty-interval interval-contains? ] bi@ or ] unit-test
+
+{ t } [ -1/0. 1/0. [ full-interval interval-contains? ] bi@ and ] unit-test


### PR DESCRIPTION
Make both `empty-interval` and `full-interval` singletons, use generic functions
and methods where they are special-cased.

All words which work with interval points should also now work with the special
intervals.