### PR TITLE
Create shell.nix for building/running on NixOS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> {} }:
+(pkgs.buildFHSUserEnv {
+  name = "factor";
+  targetPkgs = pkgs: (with pkgs; [
+    # for running factor
+    gtk2-x11
+    glib
+    gdk_pixbuf
+    gnome2.pango
+    cairo
+    gnome2.gtkglext
+
+    # for building factor
+    clang
+    git
+    curl
+    binutils
+  ]);
+  runScript = "bash";
+}).env


### PR DESCRIPTION
NixOS uses different conventions for locating/loading dynamic libraries, which, by default, makes Factor unable to build or run (errors like `./factor: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory`).  

One workaround is to open a _Nix shell_ (conceptually similar to something like `pipenv shell`), which sets up some environment variables and builds a "conventional" environment that puts dynamic libraries in places where programs _like Factor_ normally expect to find them.  The `shell.nix` file added here defines the configuration for the Nix shell (dependencies, etc.) and makes it possible for a NixOS user to build and run Factor from source by doing
```bash
nix-shell
./build.sh update
./factor
```
