### PR TITLE
Simplify nix shell environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,20 +1,27 @@
 { pkgs ? import <nixpkgs> {} }:
-(pkgs.buildFHSUserEnv {
-  name = "factor";
-  targetPkgs = pkgs: (with pkgs; [
-    # for running factor
-    gtk2-x11
+with pkgs;
+let
+  mkClangShell = mkShell.override { stdenv = clangStdenv; };
+  runtimeLibs = with xorg; [
     glib
+    pango cairo
+    gtk2-x11
     gdk_pixbuf
-    gnome2.pango
-    cairo
     gnome2.gtkglext
-
+    pcre
+    mesa_glu
+    freealut
+    openssl
+    udis86 # available since NixOS 19.09
+    openal
+  ];
+in
+(mkClangShell {
+  name = "factor-shell-env";
+  LD_LIBRARY_PATH = "/run/opengl-driver/lib:${lib.makeLibraryPath runtimeLibs}" ;
+  buildInputs = runtimeLibs ++ [
     # for building factor
-    clang
     git
     curl
-    binutils
-  ]);
-  runScript = "bash";
-}).env
+  ];
+})


### PR DESCRIPTION
`buildFHSUserEnv` uses `chroot` to create a kind of sandbox environment.  This
change uses a simpler mechanism, and also provides the necessary libraries for
running all the demos.

Tested (on NixOS):
- check out master
- run `nix shell`
- in the shell:
  - run `./build.sh net-bootstrap`
  - run `./factor -i=factor.image`
  - enter `USE: demos demos`
  - play around with the demos

Not Tested:
- core unit tests (likely to fail until the corresponding issues in #2180 are addressed)
