### PR TITLE
cache: Don't use in-place filter

### DIFF
--- a/basis/cache/cache.factor
+++ b/basis/cache/cache.factor
@@ -38,9 +38,9 @@ M: cache-assoc dispose* clear-assoc ;
 PRIVATE>
 
 : purge-cache ( cache -- )
-    [ assoc>> ] [ max-age>> ] bi V{ } clone [
+    dup [ assoc>> ] [ max-age>> ] bi V{ } clone [
         '[
             nip dup age>> 1 + [ >>age ] keep
             _ < [ drop t ] [ _ dispose-to f ] if
-        ] assoc-filter! drop
+        ] assoc-filter >>assoc drop 
     ] keep [ last rethrow ] unless-empty ;


### PR DESCRIPTION
This solves a UI corruption problem by not reusing the hashtable when
purging the cache. The root cause of why the hashtable gets corrupted
when filtering in place hasn't been found.

Fixes #1978.