### PR TITLE
Linux kernel 5 is released

### DIFF
--- a/basis/system-info/linux/linux-tests.factor
+++ b/basis/system-info/linux/linux-tests.factor
@@ -11,5 +11,5 @@ tools.test kernel ;
 [ t ] [ domainname string? ] unit-test
 
 { t } [
-    release "." split1 drop { "2" "3" "4" } member?
+    release "." split1 drop { "2" "3" "4" "5" } member?
 ] unit-test


### PR DESCRIPTION
The test failed on e.g. `Linux $hostname 5.3.0-20-generic`