### PR TITLE
Feature commandline help

### DIFF
--- a/vm/factor.cpp
+++ b/vm/factor.cpp
@@ -154,7 +154,7 @@ void factor_vm::factor_sleep(long us) {
 
 void factor_vm::start_standalone_factor(int argc, vm_char** argv) {
   vm_parameters p;
-  p.init_from_args(argc, argv);
+  if (!p.init_from_args(argc, argv)) return;
   init_factor(&p);
   pass_args_to_factor(argc, argv);
 

--- a/vm/factor.cpp
+++ b/vm/factor.cpp
@@ -154,7 +154,7 @@ void factor_vm::factor_sleep(long us) {
 
 void factor_vm::start_standalone_factor(int argc, vm_char** argv) {
   vm_parameters p;
-  if (!p.init_from_args(argc, argv)) return;
+  if (!p.init_from_args(argc, argv)) exit (0);
   init_factor(&p);
   pass_args_to_factor(argc, argv);
 

--- a/vm/image.cpp
+++ b/vm/image.cpp
@@ -49,7 +49,7 @@ vm_parameters::~vm_parameters() {
   free((vm_char *)executable_path);
 }
 
-void vm_parameters::init_from_args(int argc, vm_char** argv) {
+bool vm_parameters::init_from_args(int argc, vm_char** argv) {
   int i = 0;
 
   for (i = 1; i < argc; i++) {
@@ -96,7 +96,13 @@ void vm_parameters::init_from_args(int argc, vm_char** argv) {
       signals = false;
     else if (STRCMP(arg, STRING_LITERAL("-console")) == 0)
       console = true;
+    else if (STRCMP(arg, STRING_LITERAL("--help")) == 0) {
+      puts ("help for factor");
+      return false;
+    }
   }
+
+  return true;
 }
 
 void factor_vm::load_data_heap(FILE* file, image_header* h, vm_parameters* p) {

--- a/vm/image.cpp
+++ b/vm/image.cpp
@@ -97,7 +97,9 @@ bool vm_parameters::init_from_args(int argc, vm_char** argv) {
     else if (STRCMP(arg, STRING_LITERAL("-console")) == 0)
       console = true;
     else if (STRCMP(arg, STRING_LITERAL("--help")) == 0) {
-      puts ("help for factor");
+      puts ("Usage: factor [options] [script [args]|-run=<vocab>]\n"
+            "       to get full help on commandline options, run factor without arguments,\n"
+            "       then in the Listener type '\"command-line\" help'");
       return false;
     }
   }

--- a/vm/image.hpp
+++ b/vm/image.hpp
@@ -46,7 +46,7 @@ struct vm_parameters {
 
   vm_parameters();
   ~vm_parameters();
-  void init_from_args(int argc, vm_char** argv);
+  bool init_from_args(int argc, vm_char** argv);
 };
 
 }


### PR DESCRIPTION
Proof of concept of adding '--help' to commandline. Full help text to be supplied, see #2206.

Note that 'exit()' is required because the destructors assume malloc has already been called, which is not true when '--help' is finished.