### PR TITLE
help.lint.coverage: fix for shadowing "empty" word; prevent the other…

### DIFF
--- a/extra/help/lint/coverage/coverage-docs.factor
+++ b/extra/help/lint/coverage/coverage-docs.factor
@@ -10,7 +10,7 @@ PRIVATE>
 ABOUT: "help.lint.coverage"
 
 ARTICLE: "help.lint.coverage" "Help coverage linting"
-"The " { $vocab-link "help.lint.coverage" } " vocabulary implements a very picky documentation completeness checker."
+"The " { $vocab-link "help.lint.coverage" } " vocabulary implements a very pedantic documentation completeness checker."
 $nl
 "The documentation coverage linter requires most words to have " { $link POSTPONE: HELP: } " declarations defining some of the "
 { $links $values $description $error-description $class-description $examples } " sections (see " { $links "element-types" } ")."

--- a/extra/help/lint/coverage/coverage-tests.factor
+++ b/extra/help/lint/coverage/coverage-tests.factor
@@ -5,22 +5,22 @@ tools.test vocabs ;
 IN: help.lint.coverage.tests
 
 <PRIVATE
-: empty ( a v -- x y ) ;
-: nonexistent ( a v -- x y ) ;
-: defined ( x -- x ) ;
+: an-empty-word-with-a-unique-name ( a v -- x y ) ;
+: a-nonexistent-word ( a v -- x y ) ;
+: a-defined-word ( x -- x ) ;
 
-HELP: empty { $examples } ;
-HELP: nonexistent ;
-HELP: defined { $examples { $example "USING: prettyprint ; " "1 ." "1" } } ;
+HELP: an-empty-word-with-a-unique-name { $examples } ;
+HELP: a-nonexistent-word ;
+HELP: a-defined-word { $examples { $example "USING: prettyprint ; " "1 ." "1" } } ;
 PRIVATE>
 
-{ t } [ \ empty empty-examples? ] unit-test
-{ f } [ \ nonexistent empty-examples? ] unit-test
-{ f } [ \ defined empty-examples? ] unit-test
+{ t } [ \ an-empty-word-with-a-unique-name empty-examples? ] unit-test
+{ f } [ \ a-nonexistent-word empty-examples? ] unit-test
+{ f } [ \ a-defined-word empty-examples? ] unit-test
 { f } [ \ keep empty-examples? ] unit-test
 
-{ { $description $values } } [ \ empty missing-sections natural-sort ] unit-test
-{ { $description $values } } [ \ defined missing-sections natural-sort ] unit-test
+{ { $description $values } } [ \ an-empty-word-with-a-unique-name missing-sections natural-sort ] unit-test
+{ { $description $values } } [ \ a-defined-word missing-sections natural-sort ] unit-test
 { { } } [ \ keep missing-sections ] unit-test
 
 { { "a.b" "a.b.c" } } [ { "a.b" "a.b.private" "a.b.c.private" "a.b.c" } filter-private ] unit-test
@@ -29,13 +29,13 @@ PRIVATE>
 { "section" } [ 1 "section" ?pluralize ] unit-test
 { "sections" } [ 10 "section" ?pluralize ] unit-test
 
-{ { $examples } } [ \ empty word-defines-sections ] unit-test
-{ { $examples } } [ \ defined word-defines-sections ] unit-test
-{ { } } [ \ nonexistent word-defines-sections ] unit-test
+{ { $examples } } [ \ an-empty-word-with-a-unique-name word-defines-sections ] unit-test
+{ { $examples } } [ \ a-defined-word word-defines-sections ] unit-test
+{ { } } [ \ a-nonexistent-word word-defines-sections ] unit-test
 { { $values $description $examples } } [ \ keep word-defines-sections ] unit-test
 { { $values $contract $examples } } [ \ <word-help-coverage> word-defines-sections ] unit-test
 
-{ empty } [ "empty" find-word ] unit-test
+{ an-empty-word-with-a-unique-name } [ "an-empty-word-with-a-unique-name" find-word ] unit-test
 
 {
   V{ "[" { $[ "math" dup lookup-vocab ] } "] " { "zero?" zero? } ": " }
@@ -101,8 +101,8 @@ PRIVATE>
   USING: definitions compiler.units ;
   IN: help.lint.coverage.tests.private
 [
-    \ empty forget
-    \ nonexistent forget
-    \ defined forget
+    \ an-empty-word-with-a-unique-name forget
+    \ a-nonexistent-word forget
+    \ a-defined-word forget
 ] with-compilation-unit
 ]] eval( -- )


### PR DESCRIPTION
… test-only words from being shadowed too

When `load-all test-all`ing, there would be at least 3 `empty` words in scope, and then the `help.lint.coverage` test fails as intended because of an `ambiguous-use-error`. This change makes them all more unique.

I could also have forced the test-only words to be used namespaced-only which would be much more robust, but getting `find-word` to work with namespaced words (like `a:b`) would be complicated for little benefit (right now). 