### PR TITLE
Fix linux find-so failure if no old ld entries exist

### DIFF
--- a/extra/ldcache/ldcache.factor
+++ b/extra/ldcache/ldcache.factor
@@ -1,8 +1,9 @@
 ! Copyright (C) 2017 Björn Lindqvist.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors alien.c-types alien.strings assocs byte-arrays
-classes.struct fry io io.encodings.binary io.encodings.string io.files
-kernel math math.bitwise sequences system ;
+classes.struct continuations fry io io.encodings.binary
+io.encodings.string io.files kernel math math.bitwise sequences
+system ;
 IN: ldcache
 
 ! General util
@@ -75,8 +76,10 @@ STRUCT: EntryNew
 : parse ( -- entries  )
     ! Read the old header and jump past it.
     HeaderOld read-struct
-    [ HEADER_MAGIC_OLD check-ldcache-magic ]
-    [ nlibs>> EntryOld struct-size * seek-relative seek-input ] bi
+    [
+        [ HEADER_MAGIC_OLD check-ldcache-magic ]
+        [ nlibs>> EntryOld struct-size * seek-relative seek-input ] bi
+    ] [ 2drop HeaderOld struct-size neg seek-relative seek-input ] recover
     HeaderNew read-struct
     [ HEADER_MAGIC_NEW check-ldcache-magic ] keep
     [ parse-new-entries ]


### PR DESCRIPTION
If '/etc/ld.so.cache' does not contain any old entries
using the 'HeaderOld' struct then it fails with a bad-magic
error before looking for the HeaderNew entries.

My Ubuntu 19.10 system doesn't have any old entries so always
fails here when using 'load-all', which results in the
'extra/llvm' vocab failing due to using 'find-so'.

The fix implemented here is to catch the error and recover from
it by seeking back to the start of the header before looking for
the new header entries.