### PR TITLE
Dotted pair notation

### DIFF
--- a/basis/lists/lists.factor
+++ b/basis/lists/lists.factor
@@ -105,4 +105,23 @@ M: list >list ;
 
 M: sequence >list sequence>list ;
 
-SYNTAX: L{ \ } [ sequence>list ] parse-literal ;
+: items>list ( seq -- cons-pair )
+    dup empty? [ drop +nil+ ] [
+        reverse unclip swap [ swap cons ] each
+    ] if ;
+
+:: (parse-list-literal) ( accum right-of-dot? -- accum )
+    accum scan-token {
+        { "}" [ +nil+ , ] }
+        { "rest:" [ t (parse-list-literal) ] }
+        [
+            parse-datum dup parsing-word? [
+                V{ } clone swap execute-parsing first
+            ] when
+            , right-of-dot? [ "}" expect ] [ f (parse-list-literal) ] if ]
+    } case ;
+
+: parse-list-literal ( accum -- accum object )
+    [ f (parse-list-literal) ] { } make items>list ;
+
+SYNTAX: L{ parse-list-literal suffix! ;

--- a/basis/lists/lists.factor
+++ b/basis/lists/lists.factor
@@ -113,7 +113,7 @@ M: sequence >list sequence>list ;
 :: (parse-list-literal) ( accum right-of-dot? -- accum )
     accum scan-token {
         { "}" [ +nil+ , ] }
-        { "rest:" [ t (parse-list-literal) ] }
+        { "." [ t (parse-list-literal) ] }
         [
             parse-datum dup parsing-word? [
                 V{ } clone swap execute-parsing first

--- a/basis/lists/lists.factor
+++ b/basis/lists/lists.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2008 James Cash, Daniel Ehrenberg, Chris Double.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors combinators.short-circuit kernel locals math
-parser sequences ;
+USING: accessors combinators combinators.short-circuit kernel
+lexer locals make math parser sequences words ;
 IN: lists
 
 ! List Protocol

--- a/basis/prettyprint/backend/backend.factor
+++ b/basis/prettyprint/backend/backend.factor
@@ -277,7 +277,12 @@ M: cons-state pprint*
                 '[ dup cons-state? _ length _ < and ]
                 [ uncons swap , ] while
             ] { } make
-            [ pprint* ] each nil? [ "~more~" text ] unless
+            [ pprint* ] each
+            dup list? [
+                nil? [ "~more~" text ] unless
+            ] [
+                "." text pprint*
+            ] if
             block>
         ] dip pprint-word block>
     ] check-recursion ;


### PR DESCRIPTION
I want to be able to use the equivalent of the Lisp's list dotted notation for the Factor list.

The PR allows for the following:
```Factor
IN: scratchpad USE: lists
IN: scratchpad L{ 1 2 . 3 } .
L{ 1 2 . 3 }
IN: scratchpad "a" "b" cons "c" cons .
L{ L{ "a" . "b" } . "c" }
IN: scratchpad L{ 1 . L{ 2 . L{ 3 . L{ 4 . L{ 5 . L{ } } } } } } .
L{ 1 2 3 4 5 }
```

This change also allows dots to be elements of lists.
```Factor
IN: scratchpad L{ \ . . \ . } [ car ] [ cdr ]  bi . .
\ .
\ .
```

