### PR TITLE
rosetta-code.multisplit: reduce memory usage

### DIFF
--- a/extra/rosetta-code/multisplit/multisplit.factor
+++ b/extra/rosetta-code/multisplit/multisplit.factor
@@ -8,7 +8,7 @@ IN: rosetta-code.multisplit
     over [ 2array ] [ 2drop f ] if ;
 
 : best-separator ( seq -- pos index )
-    dup [ first ] map infimum '[ first _ = ] filter first first2 ;
+    dup [ first ] map infimum '[ first _ = ] find nip first2 ;
 
 : first-subseq ( separators seq -- n separator )
     dupd [ swap [ subseq-start ] dip ?pair ] curry map-index sift


### PR DESCRIPTION
Avoid creating a filtered sequence when all we need is its first element.