### PR TITLE
io.standard-paths: fix standard-login-paths for fish shell

### DIFF
--- a/basis/io/standard-paths/unix/unix-tests.factor
+++ b/basis/io/standard-paths/unix/unix-tests.factor
@@ -14,3 +14,8 @@ sequences tools.test ;
         { "/bin/ps" "/sbin/ps" "/usr/bin/ps" } member?
     ] with-os-env
 ] unit-test
+
+{ t } [
+    "ls" find-in-standard-login-path 
+    { "/bin/ls" "/usr/bin/ls" } member?
+] unit-test

--- a/basis/io/standard-paths/unix/unix.factor
+++ b/basis/io/standard-paths/unix/unix.factor
@@ -16,7 +16,7 @@ M: unix find-in-path*
     utf8 decode [ blank? ] trim ":" split ;
 
 : standard-login-paths ( -- strings )
-    { "-l" "-c" "echo $PATH" }
+    { "-l" "-c" "echo \"$PATH\"" }
     effective-user-id user-passwd shell>> prefix
     binary <process-reader> stream-contents parse-login-paths ;
 


### PR DESCRIPTION
Fish shell automatically split variables whose name ends in "PATH" into lists,
and uses space as separator for output
Colons force fish to use standard $PATH representation