### PR TITLE
compiler.tree.propagation.slots: remove unused word

### DIFF
--- a/basis/compiler/tree/propagation/slots/slots.factor
+++ b/basis/compiler/tree/propagation/slots/slots.factor
@@ -47,9 +47,6 @@ IN: compiler.tree.propagation.slots
         [ swap slot <literal-info> ]
     } 2&& ;
 
-: length-accessor? ( slot info -- ? )
-    [ 1 = ] [ length>> ] bi* and ;
-
 : value-info-slot ( slot info -- info' )
     {
         { [ over 0 = ] [ 2drop fixnum <class-info> ] }


### PR DESCRIPTION
The last use of `length-accessor?` has been removed in
8e227bc874e356f1e292ab18d1bad1d48966746a, which obsoleted the `length` slot.