### PR TITLE
Vim syntax fixups

### DIFF
--- a/basis/editors/vim/generate-syntax/generate-syntax.factor
+++ b/basis/editors/vim/generate-syntax/generate-syntax.factor
@@ -1,10 +1,10 @@
 ! Generate a new factor.vim file for syntax highlighting
-USING: html.templates html.templates.fhtml io.files io.pathnames ;
+USING: io.encodings.utf8 io.files parser ;
 IN: editors.vim.generate-syntax
 
 : generate-vim-syntax ( -- )
-    "resource:misc/factor.vim.fgen" <fhtml>
-    "resource:misc/vim/syntax/factor.vim"
-    template-convert ;
+    "resource:misc/vim/syntax/factor/generated.vim"
+    utf8 "resource:misc/factor.vim.fgen" parse-file
+    with-file-writer ;
 
 MAIN: generate-vim-syntax

--- a/misc/vim/README.md
+++ b/misc/vim/README.md
@@ -6,10 +6,10 @@ more pleasant in Vim.
 
 ## Installation
 
-The file-layout exactly matches the Vim runtime
-structure, so you can install them by copying the contents of this directory
-into `~/.vim/` or the equivalent path on other platforms (Open Vim and type
-`:help 'runtimepath'` for details).
+The file-layout exactly matches the Vim runtime structure,
+so you can install them by copying the contents of this directory
+into `~/.vim/` or the equivalent path on other platforms
+(open Vim and type `:help 'runtimepath'` for details).
 
 ## File organization
 
@@ -17,8 +17,10 @@ The current set of files is as follows:
 
 * ftdetect/factor.vim - Teach Vim when to load Factor support files.
 * ftplugin/factor.vim - Teach Vim to follow the Factor Coding Style guidelines.
+* ftplugin/factor-docs.vim - Teach Vim about documentation style differences.
 * plugin/factor.vim - Teach Vim some commands for navigating Factor source code. See below.
-* syntax/factor.vim - Syntax highlighting for Factor code.
+* syntax/factor.vim - Teach Vim about highlighting Factor source code syntax.
+  * syntax/factor/generated.vim - Syntax highlighting lessons generated from a Factor VM.
 
 ## Commands
 
@@ -70,9 +72,10 @@ The default value is `work`.
 
 ## Note
 
-The syntax-highlighting file is automatically generated to include the
-names of all the vocabularies Factor knows about. To regenerate it manually,
-run the following code in the listener:
+The `syntax/factor/generated.vim` syntax highlighting file
+is automatically generated
+to include the names of all the vocabularies Factor knows about.
+To regenerate it manually, run the following code in the listener:
 
     "editors.vim.generate-syntax" run
 

--- a/misc/vim/syntax/factor.vim
+++ b/misc/vim/syntax/factor.vim
@@ -142,7 +142,7 @@ syn match   factorCallQuotation     /\vcall\V(\v/me=e-1    nextgroup=@factorStac
 syn match   factorExecute           /\vexecute\V(\v/me=e-1 nextgroup=@factorStackEffect
 syn keyword factorCallNextMethod    call-next-method
 
-syn region  factorChar        start=/\v<CHAR:>/ end=/\v\S/
+syn region  factorChar        start=/\v<CHAR:>/ end=/\v\S+>/
 
 syn cluster factorString            contains=factorString,factorTriString,factorPrefixedString
 syn match   factorEscape            /\v\\([\\astnrbvf0e\"]|u\x{6}|u\{\S+}|x\x{2})/  contained display
@@ -166,32 +166,32 @@ syn region  factorMultilineCComment matchgroup=factorMultilineCCommentDelims  st
 syn cluster factorReal                  contains=factorInt,factorFloat,factorPosRatio,factorNegRatio,@factorBin,@factorHex,@factorOct,factorNan
 syn cluster factorNumber                contains=@factorReal,factorComplex
 syn match   factorInt                   /\v<[+-]=[0-9]%([0-9,]*[0-9])?%([eE]%([+-])?[0-9]+)?>/
-syn match   factorFloat                 /\v<[+-]=%([0-9,]*[0-9])?%(\.%(%([0-9,]*[0-9]+)?%([eE]%([+-])?[0-9]+)?)?)?>/
+syn match   factorFloat                 /\v<[+-]=[0-9]%([0-9,]*[0-9])?%(\.%(%([0-9,]*[0-9]+)?%([eE]%([+-])?[0-9]%([0-9,]*[0-9])?)?)?)?>/
 syn match   factorPosRatio              /\v<\+=[0-9]%([0-9,]*[0-9])?%(\+[0-9]%([0-9,]*[0-9]+)?)?\/-=[0-9]%([0-9,]*[0-9]+)?\.?>/
 syn match   factorNegRatio              /\v<\-[0-9]%([0-9,]*[0-9])?%(\-[0-9]%([0-9,]*[0-9]+)?)?\/-=[0-9]%([0-9,]*[0-9]+)?\.?>/
 syn region  factorComplex         start=/\v<C\{>/   end=/\v<\}>/    contains=@factorReal
+syn cluster factorBin                   contains=factorBin
 if !exists('g:factor_syn_no_error')
-  syn match   factorBinError            /\v\<[+-]\=0b[01,]*[^01 ]\S*\>/
-  syn cluster factorBin                 contains=factorBinError
+  syn match   factorBinError            /\v\<[+-]=0b[01,]*[^01 ]\S*\>/
+  syn cluster factorBin                 add=factorBinError
 endif
-syn match   factorBin                   /\v\<[+-]\=0b[01,]\+\>/
-syn cluster factorBin                   add=factorBin
+syn match   factorBin                   /\v\<[+-]=0b[01,]\+\>/
+syn cluster factorHexNoRadixTrans       contains=factorHexNoRadixTrans
+syn cluster factorHex                   contains=factorHex
 if !exists('g:factor_syn_no_error')
   syn match   factorHexNoRadixError     /\v<%(,\S*|\S*,|[-0-9a-fA-Fp,]*[^-0-9a-fA-Fp, ]\S*)>/ contained
-  syn cluster factorHexNoRadixTrans     contains=factorHexNoRadixError
+  syn cluster factorHexNoRadixTrans     add=factorHexNoRadixError
   syn match   factorHexError            /\v<[+-]=0x%(,\S*|\S*,|[-0-9a-fA-Fp,]*[^-0-9a-fA-Fp, ]\S*)>/
-  syn cluster factorHex                 contains=factorHexError
+  syn cluster factorHex                 add=factorHexError
 endif
 syn match   factorHexNoRadixTrans       /\v<[0-9a-fA-F]%([0-9a-fA-F,]*[0-9a-fA-F])?%(\.[0-9a-fA-F]%([0-9a-fA-F,]*[0-9a-fA-F])?)?%(p-=[0-9]%([0-9,]*[0-9])?)?>/ contained transparent
-syn cluster factorHexNoRadixTrans       add=factorHexNoRadixTrans
 syn match   factorHex                   /\v<[+-]=0x[0-9a-fA-F]%([0-9a-fA-F,]*[0-9a-fA-F])?%(\.[0-9a-fA-F]%([0-9a-fA-F,]*[0-9a-fA-F])?)?%(p-=[0-9]%([0-9,]*[0-9])?)?>/
-syn cluster factorHex                   add=factorHex
+syn cluster factorOct                   contains=factorOct
 if !exists('g:factor_syn_no_error')
   syn match   factorOctError             /\v<[+-]=0o%(,\S*|\S*,|[0-7,]*[^0-7, ]\S*)>/
   syn cluster factorOct                 contains=factorOctError
 endif
 syn match   factorOct                   /\v<[+-]=0o[0-7,]+>/
-syn cluster factorOct                   add=factorOct
 syn region  factorNan matchgroup=factorNan start=/\v<NAN:>/ matchgroup=NONE end=/\v<\S+>/ contains=@factorComment,@factorHexNoRadixTrans
 
 syn region  factorBackslash       start=/\v<\\>/   skip=/\v<!>/ end=/\v<\S+>/   contains=@factorComment
@@ -276,7 +276,7 @@ syn cluster factorStackEffect           contains=factorStackEffect
 " Erroring on stack effects without a "--" separator would be nice.
 " Unfortunately, that sort of vacuous detection is above Vim's pay-grade,
 "   especially when stack effects can be nested arbitrarily via types.
-syn match   factorStackEffectSkip   /\v%(\_\s+%(!>.*)?)*/ nextgroup=factorStackEffectRequired,@factorStackEffect transparent contained
+syn match   factorStackEffectSkip       /\v%(\_\s+%(!>.*)?)*/ nextgroup=factorStackEffectRequired,@factorStackEffect transparent contained
 syn region  factorStackEffect       matchgroup=factorStackEffectDelims    start=/\v\V(\v>/  end=/\v<\V)\v>/ contains=@factorStackEffectContents
 syn match   factorStackEffectVar        /\v<\S+>/           contained
 " Note that ":!" parses to the "!" word and doesn't lex as a comment.
@@ -285,10 +285,10 @@ syn match   factorStackEffectVar        /\v<\S+>/           contained
 "   "factorStackEffectType".
 " syn cluster factorStackEffectType contains=factorWord,@factorStackEffect
 syn cluster factorStackEffectType       contains=@factorClusterValue
-syn region  factorStackEffectVar    matchgroup=factorStackEffectVar       start=/v<\S+:>/       matchgroup=NONE end=/\v%(\_\s+%(!>.*)?)+/ contains=@factorComment nextgroup=@factorStackEffectType transparent contained
+syn region  factorStackEffectVar    matchgroup=factorStackEffectVar       start=/\v<\S+:>/       matchgroup=NONE end=/\v%(\_\s+%(!>.*)?)+/ contains=@factorComment nextgroup=@factorStackEffectType transparent contained
 syn match   factorStackEffectType       /\v<:/              contained nextgroup=@factorStackEffectType
 syn match   factorStackEffectRowVar     /\v<\.\.\S+>/       contained
-syn region  factorStackEffectRowVar matchgroup=factorStackEffectRowVar    start=/v<\.\.\S+:>/   matchgroup=NONE end=/\v%(\_\s+%(!>.*)?)+/ contains=@factorComment nextgroup=@factorStackEffectType transparent contained
+syn region  factorStackEffectRowVar matchgroup=factorStackEffectRowVar    start=/\v<\.\.\S+:>/   matchgroup=NONE end=/\v%(\_\s+%(!>.*)?)+/ contains=@factorComment nextgroup=@factorStackEffectType transparent contained
 syn match   factorStackEffectDelims     /\v<-->/            contained
 if !exists('g:factor_syn_no_error')
   syn cluster factorStackEffectContents add=factorStackEffectError


### PR DESCRIPTION
(Thanks, @mrjbq7!) Now:
+ `CHAR:` literals highlight the whole next token.
+ `0b...` binary literals don't require invalid `+=0b` or `-=0b` syntax.
+ Float literals can't start with a `,` separator.
+ Float literals can have exponents with `,` separators.
+ `foo: ...` stack effects function as intended in general.
+ Syntax clusters might be a bit cleaner with `g:factor_syn_no_error`.

Also, update `editors.vim.generate-syntax` & the Vim directory README.