### PR TITLE
[RFC] Don't rely on /etc/ld.so.cache (or: Don't rely on shared object file paths)

### DIFF
--- a/basis/alien/libraries/finder/linux/linux.factor
+++ b/basis/alien/libraries/finder/linux/linux.factor
@@ -1,9 +1,8 @@
 ! Copyright (C) 2013 Björn Lindqvist, Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license
-USING: alien.libraries.finder arrays assocs
-combinators.short-circuit io io.encodings.utf8
-io.launcher kernel sequences sets splitting system
-unicode ;
+USING: alien.libraries.finder arrays assocs combinators.short-circuit
+continuations io io.encodings.utf8 io.launcher kernel sequences sets splitting
+system unicode ;
 IN: alien.libraries.finder.linux
 
 <PRIVATE
@@ -25,8 +24,13 @@ CONSTANT: mach-map {
     ] map ;
 
 : load-ldconfig-cache ( -- seq )
-    "/sbin/ldconfig -p" utf8 [ lines ] with-process-reader
-    rest parse-ldconfig-lines ;
+    [
+        "/sbin/ldconfig -p" utf8 [ lines ] with-process-reader
+        rest parse-ldconfig-lines
+    ] [
+        dup process-failed?
+        [ drop f ] [ rethrow ] if
+    ] recover ;
 
 : ldconfig-arch ( -- str )
     mach-map cpu of { "libc6" } or ;

--- a/basis/alien/libraries/finder/linux/linux.factor
+++ b/basis/alien/libraries/finder/linux/linux.factor
@@ -1,8 +1,8 @@
 ! Copyright (C) 2013 Björn Lindqvist, Doug Coleman.
 ! See http://factorcode.org/license.txt for BSD license
 USING: alien.libraries.finder arrays assocs
-combinators.short-circuit io io.encodings.utf8 io.files
-io.files.info io.launcher kernel sequences sets splitting system
+combinators.short-circuit io io.encodings.utf8
+io.launcher kernel sequences sets splitting system
 unicode ;
 IN: alien.libraries.finder.linux
 


### PR DESCRIPTION
Not all linux distributions support `/etc/ld.so.cache` and `/sbin/ldconfig`.  Factor has it's own implementation of finding libraries, and explicitly wants to read the dynamic loader cache to achieve that on linux systems.  This change will simply return an empty sequence instead of throwing an error, should this lookup fail.

Taking it a step further, I do think that the whole concept of finding a library like this should not be part of the shared library loading process in factor, actually.  There should not be a need to reference the cache explicitly.

From the manpage of `dlopen(3)`:
```

       If filename is NULL, then the returned handle is for the main program. If
       filename contains a slash ("/"), then it is interpreted as a (relative or
       absolute) pathname. Otherwise, the dynamic linker searches for the object
       as follows (see ld.so(8) for further details):

       o (ELF only) If the executable file for the calling program contains a
         DT_RPATH tag, and does not contain a DT_RUNPATH tag, then the directories
         listed in the DT_RPATH tag are searched.

       o If, at the time that the program was started, the environment variable
         LD_LIBRARY_PATH was defined to contain a colon-separated list of
         directories, then these are searched. (As a security measure, this
         variable is ignored for set-user-ID and set-group-ID programs.)

       o (ELF only) If the executable file for the calling program contains a
         DT_RUNPATH tag, then the directories listed in that tag are searched.

       o The cache file /etc/ld.so.cache (maintained by ldconfig(8)) is checked
         to see whether it contains an entry for filename.

```

So in essence, in linux there are multiple ways of specifying runtime
dependencies for shared objects. Different setups (distributions, wrapper
scripts, deployed applications, etc.) make use of different ones of those at
different times. Using `alien.libraries.finder.linux` basically only supports
one of them, which is also not guaranteed to be present/working on every linux
system.

I don't have enough experience writing/deploying ffi-heavy Factor applications
to have a real good educated opinion about that, but:

- Libraries/programs that try to resolve shared object locations at runtime
  using hard-coded paths are often problematic. (In NixOS, for example, they
  usually cannot be packaged without having to patch them.)  Normally, the
  location is specified at link time, or the resolution is left to the loader,
  as stated in dlopen above.

- Because of that, I think that finding a library with e.g. `find-library` is
  actually not something that an application should do, but something that
  should be either resolved at deployment time (which factor acknowledges with
  e.g. `deploy-library`), or replaced by failing to load
  the library and escalating that to the surrounding environment.

To summarize: Because of the way how shared object loading is deferred to runtime in linux, I
don't think there actually is a good way for an application to handle locations
of shared object files of it's own dependencies.  As far as I can tell, that is almost always the job
of the installation/deployment process.