### PR TITLE
TOTP

### DIFF
--- a/extra/totp/totp-docs.factor
+++ b/extra/totp/totp-docs.factor
@@ -31,10 +31,10 @@ $nl
 
 HELP: totp
 { $values
-    { "key" byte-array }
+    { "key" object }
     { "string" string }
 }
-{ $description "Generate a one-time password for the " { $snippet "key" } " based on the current system time. The " { $snippet "string" } " length is " { $link totp-digits } ", and the hash used for HMAC is " { $link totp-hash } "." } ;
+{ $description "Generate a one-time password for the " { $snippet "key" } " based on the current system time. If " { $snippet "key" } " is a " { $link string } ", it is expected to contain the key data in Base 32 encoding, otherwise it should be a " { $link byte-array } ". The " { $snippet "string" } " length is " { $link totp-digits } ", and the hash used for HMAC is " { $link totp-hash } "." } ;
 
 { totp totp* } related-words
 

--- a/extra/totp/totp-docs.factor
+++ b/extra/totp/totp-docs.factor
@@ -22,7 +22,7 @@ $nl
 HELP: totp-hash
 { $var-description "A cryptographically secure " { $link checksum } " to be used by " { $link totp } " for the HMAC. See " { $url "https://en.wikipedia.org/wiki/HMAC" } " for more information."
 $nl
-"Default value is " { $link sha-256 } "." } ;
+"Default value is " { $link sha1 } ", same as used by Google Authenticator." } ;
 
 HELP: totp-digits
 { $var-description "The number of digits returned by " { $link totp } "."

--- a/extra/totp/totp.factor
+++ b/extra/totp/totp.factor
@@ -1,7 +1,8 @@
 ! Copyright (C) 2018 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: calendar checksums.hmac checksums.sha io.binary kernel
-math math.bitwise math.parser namespaces sequences ;
+USING: base32 calendar checksums.hmac checksums.sha io.binary
+kernel math math.bitwise math.parser namespaces sequences
+strings unicode ;
 IN: totp
 
 SYMBOLS: totp-hash totp-digits ;
@@ -28,4 +29,5 @@ PRIVATE>
     [ number>string ] dip [ CHAR: 0 pad-head ] keep tail* ;
 
 : totp ( key -- string )
+    dup string? [ >upper base32> ] when
     now timestamp>count swap totp-hash get totp* totp-digits get digits ;

--- a/extra/totp/totp.factor
+++ b/extra/totp/totp.factor
@@ -5,7 +5,7 @@ math math.bitwise math.parser namespaces sequences ;
 IN: totp
 
 SYMBOLS: totp-hash totp-digits ;
-totp-hash [ sha-256 ] initialize
+totp-hash [ sha1 ] initialize
 totp-digits [ 6 ] initialize
 
 <PRIVATE


### PR DESCRIPTION
Updated the Time-based One-Time Passwords vocab to fully mimic the [Google Authenticator](https://github.com/google/google-authenticator-android) app. Now if I don't have the app on my phone for some reason, I can use simply use Factor.