### PR TITLE
Checksums

### DIFF
--- a/core/checksums/checksums.factor
+++ b/core/checksums/checksums.factor
@@ -23,16 +23,18 @@ M: checksum checksum-lines
 : checksum-file ( path checksum -- value )
     [ binary <file-reader> ] dip checksum-stream ;
 
-TUPLE: checksum-state checksum { bytes byte-vector } ;
+TUPLE: checksum-state < disposable
+    checksum
+    { bytes byte-vector } ;
 
-M: checksum-state dispose drop ;
+M: checksum-state dispose* drop ;
 
 M: checksum-state clone
     call-next-method
     [ clone ] change-bytes ;
 
 : new-checksum-state ( class -- checksum-state )
-    new BV{ } clone >>bytes ;
+    new-disposable BV{ } clone >>bytes ;
 
 GENERIC: initialize-checksum-state ( checksum -- checksum-state )
 GENERIC#: add-checksum-bytes 1 ( checksum-state data -- checksum-state )

--- a/extra/checksums/multi/multi.factor
+++ b/extra/checksums/multi/multi.factor
@@ -25,4 +25,4 @@ M: multi-state get-checksum
         dup states>> [ get-checksum ] map [ >>results ] keep
     ] unless* nip ;
 
-INSTANCE: multi-checksum block-checksum
+INSTANCE: multi-checksum checksum


### PR DESCRIPTION
I'm not sure why the `checksum-state` was not inherited from the `disposable` in the first place, but it seems to make a lot of sense, especially since implementing `dispose` is a requirement.

I didn't run the full test suite on this, so feedback and comments are welcome.