### PR TITLE
contributors: merge the known contributor aliases

### DIFF
--- a/core/assocs/assocs-docs.factor
+++ b/core/assocs/assocs-docs.factor
@@ -409,6 +409,8 @@ HELP: delete-at*
 { $description "Removes an entry from the assoc and outputs the previous value together with a boolean indicating whether it was present." }
 { $side-effects "assoc" } ;
 
+{ delete-at delete-at* ?delete-at } related-words
+
 HELP: rename-at
 { $values { "newkey" object } { "key" object } { "assoc" assoc } }
 { $description "Removes the values associated to " { $snippet "key" } " and re-adds it as " { $snippet "newkey" } ". Does nothing if the assoc does not contain " { $snippet "key" } "." }

--- a/extra/contributors/contributors.factor
+++ b/extra/contributors/contributors.factor
@@ -1,8 +1,23 @@
-! Copyright (C) 2007, 2008 Slava Pestov.
+! Copyright (C) 2007, 2008 Slava Pestov, 2020 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: io io.directories io.encodings.utf8 io.launcher io.pathnames
-math.statistics prettyprint sequences sorting system ;
+USING: assocs fry io io.directories io.encodings.utf8
+io.launcher io.pathnames kernel math.statistics prettyprint
+sequences sorting system ;
 IN: contributors
+
+CONSTANT: aliases {
+    { "Björn Lindqvist" "bjourne@gmail.com" }
+    { "Cat Stevens" "catb0t" }
+    { "Daniel Ehrenberg" "Dan Ehrenberg" }
+    { "Doug Coleman" "U-FROGGER\\erg" "erg" }
+    { "Erik Charlebois" "erikc" }
+    { "KUSUMOTO Norio" "kusumotonorio" }
+    { "Mighty Sheeple" "sheeple" "U-ENCHILADA\\sheeple" }
+    { "Nicolas Pénet" "nicolas-p" }
+    { "Slava Pestov" "slava" "Slava"
+        "U-SLAVA-FB3999113\\Slava" "U-SLAVA-DFB8FF805\\Slava" }
+    { "dharmatech" "U-CUTLER\\dharmatech" }
+}
 
 : changelog ( -- authors )
     image-path parent-directory [
@@ -10,8 +25,13 @@ IN: contributors
         utf8 [ lines ] with-process-reader
     ] with-directory ;
 
+: merge-aliases ( authors -- authors' )
+    aliases [
+        unclip '[ over delete-at* [ _ pick at+ ] [ drop ] if ] each
+    ] each ;
+
 : contributors ( -- )
-    changelog histogram
+    changelog histogram merge-aliases
     sort-values <reversed>
     simple-table. ;
 


### PR DESCRIPTION
What do you think about this?
Without this change the `contributors` vocab is kind of generic and can be used on any git repository, and with this change it's much more specific to the Factor repo. I'm not sure it the change is in line with the original intention behind the vocab.
On the other hand, if it's used on an unrelated repository, there is very little chance that the antialiasing will make any difference at all. It'll essentially be a no-op on almost any other repo in the world.