### PR TITLE
Add support for plan9port acme editor

### DIFF
--- a/basis/editors/acme/acme-docs.factor
+++ b/basis/editors/acme/acme-docs.factor
@@ -1,0 +1,29 @@
+! Copyright (C) 2020 Fred Alger.
+! See http://factorcode.org/license.txt for BSD license.
+USING: editors.acme help.markup help.syntax ;
+IN: editors.acme
+
+ABOUT: "editors.acme"
+
+ARTICLE: "editors.acme" "Plan9 acme editor support"
+"This editor invokes the Plan9 `plumb` command. "
+"With the default Plan 9 plumbing, this will open acme."
+$nl
+"The path to the Plan9 installation is determined by "
+{ $link plan9-path }
+{ $see-also "editor" } ;
+
+HELP: plan9-path
+$description
+"Find the local installation of Plan9 from user space."
+"The " { $link plan9-path } " word will try to locate your Plan9"
+" installation. In order of preference this word checks:"
+$nl
+{
+ $list
+ { "The " { $link plan9-path } " global" }
+ "The PLAN9 environment variable"
+}
+$nl
+"Finally, if neither is available, falls back to "
+"/usr/local/plan9, the default installation path." ;

--- a/basis/editors/acme/acme-tests.factor
+++ b/basis/editors/acme/acme-tests.factor
@@ -1,0 +1,12 @@
+! Copyright (C) 2020 Fred Alger.
+! See http://factorcode.org/license.txt for BSD license.
+USING: editors.acme environment namespaces tools.test ;
+IN: editors.acme.tests
+
+{ "/plan9" } [ "/plan9" \ plan9-path [ plan9-path ] with-variable ] unit-test
+
+{ "/plan9env" } [ f \ plan9-path [
+ "/plan9env" "PLAN9" [ plan9-path ] with-os-env ] with-variable ] unit-test
+
+{ "/usr/local/plan9" } [ f \ plan9-path [
+ f "PLAN9" [ plan9-path ] with-os-env ] with-variable ] unit-test

--- a/basis/editors/acme/acme.factor
+++ b/basis/editors/acme/acme.factor
@@ -1,0 +1,33 @@
+! Copyright (C) 2020 Fred Alger
+! See http://factorcode.org/license.txt for BSD license.
+USING: arrays editors environment io.files.info io.pathnames
+kernel make math.parser namespaces sequences ;
+IN: editors.acme
+
+SINGLETON: acme
+acme editor-class set-global
+
+: plan9-path ( -- path )
+  \ plan9-path get [
+    "PLAN9" os-env [
+      "/usr/local/plan9"
+    ] unless*
+  ] unless* ;
+
+: plan9-tool-path ( tool -- path )
+  [ plan9-path "/bin" append ] dip append-path ;
+
+<PRIVATE
+
+: (plumb-path) ( -- path )
+  "plumb" plan9-tool-path ;
+
+: (massage-pathname) ( file line -- str )
+ over file-info regular-file?
+ [ number>string 2array ":" join ]
+ [ drop ] if ;
+
+PRIVATE>
+
+M: acme editor-command ( file line -- command )
+ [ (plumb-path) , "-d" , "edit" , (massage-pathname) , ] { } make ;

--- a/basis/editors/acme/authors.txt
+++ b/basis/editors/acme/authors.txt
@@ -1,0 +1,1 @@
+Fred Alger

--- a/basis/editors/acme/tags.txt
+++ b/basis/editors/acme/tags.txt
@@ -1,0 +1,1 @@
+not loaded


### PR DESCRIPTION
Straightforward editor integration for `acme`[1]. Been using this locally for a little while now, time to clean it up and submit upstream.

[1] http://acme.cat-v.org