### PR TITLE
urls: Don't escape the path and then url-encode it.

### DIFF
--- a/basis/urls/urls-tests.factor
+++ b/basis/urls/urls-tests.factor
@@ -373,3 +373,6 @@ urls [
 { URL" https://host:1234/path" } [ URL" https://host:1234/path" redacted-url ] unit-test
 { URL" https://user@host:1234/path" } [ URL" https://user@host:1234/path" redacted-url ] unit-test
 { URL" https://user:xxxxx@host:1234/path" } [ URL" https://user:password@host:1234/path" redacted-url ] unit-test
+
+{ "https://foo.com/Profile%20Images%2F3XDmp9Ev01ab" }
+[ "https://foo.com/Profile%20Images%2F3XDmp9Ev01ab" >url present ] unit-test


### PR DESCRIPTION
Add a test case where it breaks without this patch.

Basically %2f and / are different and we can't encode/decode every one we see.