### PR TITLE
images.viewer: Use superclass implementation for model activation/deactivation

### DIFF
--- a/basis/ui/gadgets/gadgets-docs.factor
+++ b/basis/ui/gadgets/gadgets-docs.factor
@@ -205,6 +205,18 @@ HELP: ui-notify-flag
 { $var-description "A " { $link flag } " raised to notify the UI thread that there is work to do." }
 { $see-also notify-ui-thread } ;
 
+HELP: activate-control
+{ $values
+  { "gadget" gadget }
+}
+{ $description "Adds a connection between the gadget and it's model." } ;
+
+HELP: deactivate-control
+{ $values
+  { "gadget" gadget }
+}
+{ $description "Removes the connection between the gadget and it's model" } ;
+
 ARTICLE: "ui-control-impl" "Implementing controls"
 "A " { $emphasis "control" } " is a gadget which is linked to an underlying " { $link model } " by having its " { $snippet "model" } " slot set to a " { $link model } " instance."
 $nl

--- a/basis/ui/gadgets/gadgets.factor
+++ b/basis/ui/gadgets/gadgets.factor
@@ -220,6 +220,17 @@ GENERIC: ungraft* ( gadget -- )
 
 M: gadget ungraft* drop ;
 
+: activate-control ( gadget -- )
+    dup model>> dup [
+        2dup add-connection
+        swap model-changed
+    ] [
+        2drop
+    ] if ;
+
+: deactivate-control ( gadget -- )
+    dup model>> dup [ 2dup remove-connection ] when 2drop ;
+
 <PRIVATE
 
 : graft-queue ( -- dlist )
@@ -261,17 +272,6 @@ M: gadget ungraft* drop ;
 
 : ungraft ( gadget -- )
     dup [ ungraft ] each-child ungraft-later ;
-
-: activate-control ( gadget -- )
-    dup model>> dup [
-        2dup add-connection
-        swap model-changed
-    ] [
-        2drop
-    ] if ;
-
-: deactivate-control ( gadget -- )
-    dup model>> dup [ 2dup remove-connection ] when 2drop ;
 
 : notify ( gadget -- )
     dup graft-state>>

--- a/extra/images/viewer/viewer-docs.factor
+++ b/extra/images/viewer/viewer-docs.factor
@@ -57,25 +57,15 @@ HELP: image.
     { "object" { $or pathname string image } }
 }
 { $description "Displays the image in the listener." } ;
-HELP: start-control
-{ $values
-    { "gadget" gadget }
-}
-{ $description "Adds a connection between the gadget and it's model." } ;
 
-HELP: stop-control
-{ $values
-    { "gadget" gadget }
-}
-{ $description "Removes the connection between the gadget and it's model" } ;
 ARTICLE: "images.viewer" "Displaying Images"
 "The " { $vocab-link "images.viewer" } " vocabulary uses the " { $vocab-link "opengl.textures" }
 " vocabulary to display any instance of " { $link image } "." $nl
 "An " { $link image-gadget } " can be used for static images and " { $instance image-control }
 " for changing images (for example a video feed). For changing images, the image should be contained in " { $instance model }
 ". Change the model value with " { $link set-model } " or mutate the image and call "
-{ $link notify-connections } " when you want to update the image. To stop refreshing the image, call " { $link stop-control } "."
-" To start refreshing again, call " { $link start-control } "."
+{ $link notify-connections } " when you want to update the image. To stop refreshing the image, call " { $link activate-control } "."
+" To start refreshing again, call " { $link deactivate-control } "."
 
 $nl
 "If the " { $link image } " or " { $link model } " containing the image "

--- a/extra/images/viewer/viewer.factor
+++ b/extra/images/viewer/viewer.factor
@@ -104,10 +104,5 @@ M: model set-image [ value>> >>image drop ] [ >>model ] 2bi ;
 
 : image. ( object -- ) <image-gadget> gadget. ;
 
-<PRIVATE
-M: image-control graft* start-control ;
-M: image-control ungraft* [ stop-control ] [ call-next-method ] bi ;
-PRIVATE>
-
 M: image content-gadget
     <image-gadget> ;

--- a/extra/images/viewer/viewer.factor
+++ b/extra/images/viewer/viewer.factor
@@ -98,10 +98,6 @@ M: model set-image [ value>> >>image drop ] [ >>model ] 2bi ;
     \ image-control new-image-gadget* ;
 : image-window ( object -- ) <image-gadget> "Image" open-window ;
 
-! move these words to ui.gadgets because they affect all controls ?
-: stop-control ( gadget -- ) dup model>> [ remove-connection ] [ drop ] if* ;
-: start-control ( gadget -- ) dup model>> [ add-connection ] [ drop ] if* ;
-
 : image. ( object -- ) <image-gadget> gadget. ;
 
 M: image content-gadget


### PR DESCRIPTION
`image-contol` seems to duplicate functionality from `notify` in their `graft*`/`ungraft*` methods with `start-control` and `stop-control`.  If I understood the source correctly, this was supposed to be public API, and `activate-control`/`deactivate-control` look like they implement that same behavior with better updating, so made those public API instead.