### PR TITLE
shell.nix: Add more runtime dependencies, fix opengl dependencies and wrapper

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -35,6 +35,11 @@ in
     [ -n "$1" ] || { printf "Usage: wrapFactor <factor-root>" ; return; }
     local root="$(realpath $1)"
     local binary="''${root}/factor"
+    local wrapped="''${root}/.factor-wrapped"
+    # Remove the wrapped binary if a new VM has been compiled
+    ${lib.getBin file}/bin/file $binary |grep ELF >/dev/null && rm -f "$wrapped"
+    # Restore the factor binary if it was already wrapped
+    [ -e "$wrapped" ] && { mv "$wrapped" "$binary" ; }
     wrapProgram "$binary" --prefix LD_LIBRARY_PATH : ${runtimeLibPath} \
       --argv0 factor
     ln -sf "''${root}/factor.image" "''${root}/.factor-wrapped.image"

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,8 @@ let
     gdk_pixbuf
     gnome2.gtkglext
     pcre
-    mesa_glu
+    libGL
+    libGLU
     freealut
     openssl
     udis86 # available since NixOS 19.09
@@ -18,11 +19,11 @@ let
     libvorbis
     zlib
   ];
-  runtimeLibPath = lib.makeLibraryPath runtimeLibs;
+  runtimeLibPath = "/run/opengl-driver/lib:" + lib.makeLibraryPath runtimeLibs;
 in
 (mkClangShell {
   name = "factor-shell-env";
-  LD_LIBRARY_PATH = "/run/opengl-driver/lib:${runtimeLibPath}" ;
+  LD_LIBRARY_PATH = runtimeLibPath ;
   buildInputs = runtimeLibs ++ [
     # for building factor
     git

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,9 @@ let
     openssl
     udis86 # available since NixOS 19.09
     openal
+    libogg
+    libvorbis
+    zlib
   ];
   runtimeLibPath = lib.makeLibraryPath runtimeLibs;
 in


### PR DESCRIPTION
Required for vocabs:
- ogg
- ogg.vorbis
- compression.zlib.ffi

Theoretically, we would need to include every library that has been declared with `LIBRARY:` to make sure all vocabs with ffi work out-of-the box.  This may result in an unacceptable nix closure size though.
Possibly related: #641 

cc @spacefrogg