### PR TITLE
Specialize some of gadget's default implementations on object instead

### DIFF
--- a/basis/models/models.factor
+++ b/basis/models/models.factor
@@ -58,6 +58,7 @@ DEFER: remove-connection
     [ activate-model ] [ deactivate-model ] [ value>> ] tri ;
 
 GENERIC: model-changed ( model observer -- )
+M: object model-changed 2drop ;
 
 : add-connection ( observer model -- )
     dup connections>>

--- a/basis/ui/gadgets/gadgets.factor
+++ b/basis/ui/gadgets/gadgets.factor
@@ -29,8 +29,6 @@ M: gadget equal? 2drop f ;
 
 M: gadget hashcode* nip identity-hashcode ;
 
-M: gadget model-changed 2drop ;
-
 : gadget-child ( gadget -- child ) children>> first ; inline
 
 : nth-gadget ( n gadget -- child ) children>> nth ; inline
@@ -201,7 +199,7 @@ M: gadget pref-dim* dim>> ;
 
 GENERIC: layout* ( gadget -- )
 
-M: gadget layout* drop ;
+M: object layout* drop ;
 
 : prefer ( gadget -- ) dup pref-dim >>dim drop ;
 
@@ -214,11 +212,11 @@ M: gadget layout* drop ;
 
 GENERIC: graft* ( gadget -- )
 
-M: gadget graft* drop ;
+M: object graft* drop ;
 
 GENERIC: ungraft* ( gadget -- )
 
-M: gadget ungraft* drop ;
+M: object ungraft* drop ;
 
 <PRIVATE
 


### PR DESCRIPTION
This allows implementing mixins which then can specify default behavior for
layouting and grafting for their instances.

Specifically concerns these generics:
- `model-changed`
- `layout*`
- `graft*`
- `ungraft*`
