### PR TITLE
graphs: add closure-as, base closure on that

### DIFF
--- a/core/graphs/graphs-tests.factor
+++ b/core/graphs/graphs-tests.factor
@@ -1,4 +1,5 @@
-USING: assocs graphs kernel namespaces sorting tools.test ;
+USING: assocs graphs hash-sets kernel math namespaces sequences sorting
+tools.test vectors ;
 QUALIFIED: sets
 
 H{ } "g" set
@@ -16,4 +17,12 @@ H{
 
 { { 2 3 4 5 } } [
     2 [ "g" get at sets:members ] closure sets:members natural-sort
+] unit-test
+
+{ t } [ 2 [ "g" get at sets:members ] HS{ } closure-as hash-set? ] unit-test
+{ t } [ 2 [ "g" get at sets:members ] closure hash-set? ] unit-test
+{ t } [ 2 [ "g" get at sets:members ] V{ } closure-as vector? ] unit-test
+
+{ V{ 5 4 3 2 1 0 } } [
+    5 [ [ f ] [ <iota> <reversed> ] if-zero ] V{ } closure-as
 ] unit-test

--- a/core/graphs/graphs.factor
+++ b/core/graphs/graphs.factor
@@ -23,7 +23,13 @@ PRIVATE>
          [ dip ] keep [ (closure) ] 2curry each
      ] [ 3drop ] if ; inline recursive
 
+ : new-empty-set-like ( exemplar -- set )
+     f swap set-like clone ; inline
+
 PRIVATE>
 
+: closure-as ( vertex quot: ( vertex -- edges ) exemplar -- set )
+    new-empty-set-like [ swap (closure) ] keep ; inline
+
 : closure ( vertex quot: ( vertex -- edges ) -- set )
-    HS{ } clone [ swap (closure) ] keep ; inline
+    HS{ } closure-as ; inline


### PR DESCRIPTION
Motivation: `V{ } closure-as` returns elements in reverse post-order.