### PR TITLE
Add a defaulting prettyprinter strategy

### DIFF
--- a/basis/prettyprint/config/config-docs.factor
+++ b/basis/prettyprint/config/config-docs.factor
@@ -32,10 +32,22 @@ HELP: boa-tuples?
 HELP: c-object-pointers?
 { $var-description "Toggles whether C objects such as structs and direct arrays only print their underlying address. If this flag isn't set, C objects will attempt to print their contents. If a C object points to invalid memory, it will display only its address regardless." } ;
 
+HELP: limits-set?
+{ $var-description "Flags whether or not prettyprinter configurations have been set. When true, " { $link defaulting-with-short-limits } " and " { $link defaulting-without-limits } " will not modify prettyprinter configuration. " { $link with-short-limits } " and " { $link without-limits } " will always modify prettyprinter configuration." } ;
+
 HELP: with-short-limits
 { $values { "quot" quotation } }
 { $description "Calls a quotation in a new dynamic scope with prettyprinter limits set to produce a single line of output." } ;
 
+HELP: defaulting-with-short-limits
+{ $values { "quot" quotation } }
+{ $description "Calls a quotation in a new dynamic scope. If " { $link limits-set? } " is " { $link t } " then all existing prettyprinter config will be preserved. If it's " { $link f } " then it defaults to behave like " { $link with-short-limits } "." } ;
+
 HELP: without-limits
 { $values { "quot" quotation } }
 { $description "Calls a quotation in a new dynamic scope with prettyprinter limits set to produce unlimited output." } ;
+
+HELP: defaulting-without-limits
+{ $values { "quot" quotation } }
+{ $description "Calls a quotation in a new dynamic scope. If " { $link limits-set? } " is " { $link t } " then all existing prettyprinter config will be preserved. If it's " { $link f } " then it defaults to behave like " { $link without-limits } "." } ;
+

--- a/basis/prettyprint/config/config.factor
+++ b/basis/prettyprint/config/config.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2003, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: kernel namespaces ;
+USING: kernel locals namespaces ;
 IN: prettyprint.config
 
 ! Configuration
@@ -13,6 +13,7 @@ SYMBOL: number-base
 SYMBOL: string-limit?
 SYMBOL: boa-tuples?
 SYMBOL: c-object-pointers?
+SYMBOL: limits-set?
 
 4 tab-size set-global
 64 margin set-global
@@ -20,6 +21,7 @@ SYMBOL: c-object-pointers?
 100 length-limit set-global
 10 number-base set-global
 t string-limit? set-global
+f limits-set? set-global
 
 : with-short-limits ( quot -- )
     H{
@@ -29,7 +31,11 @@ t string-limit? set-global
         { string-limit? t }
         { boa-tuples? t }
         { c-object-pointers? f }
+        { limits-set? t }
     } clone swap with-variables ; inline
+
+:: defaulting-with-short-limits ( quot -- )
+    limits-set? get [ quot call ] [ quot with-short-limits ] if ; inline
 
 : without-limits ( quot -- )
     H{
@@ -38,4 +44,8 @@ t string-limit? set-global
         { line-limit f }
         { string-limit? f }
         { c-object-pointers? f }
+        { limits-set? t }
     } clone swap with-variables ; inline
+
+:: defaulting-without-limits ( quot -- )
+    limits-set? get [ quot call ] [ quot without-limits ] if ; inline

--- a/basis/prettyprint/prettyprint-docs.factor
+++ b/basis/prettyprint/prettyprint-docs.factor
@@ -36,9 +36,12 @@ ARTICLE: "prettyprint-variables" "Prettyprint control variables"
     string-limit?
     boa-tuples?
     c-object-pointers?
+    limits-set?
 }
-"The default limits are meant to strike a balance between readability, and not producing too much output when large structures are given. There are two combinators that override the defaults:"
+"The default limits are meant to strike a balance between readability, and not producing too much output when large structures are given. There are two combinators that override any settings:"
 { $subsections with-short-limits without-limits }
+"And two combinators that override settings if they are not already overridden:"
+{ $subsections defaulting-with-short-limits defaulting-without-limits }
 "That the " { $link short. } " and " { $link pprint-short } " words wrap calls to " { $link . } " and " { $link pprint } " in " { $link with-short-limits } ". Code that uses the prettyprinter for serialization should use " { $link without-limits } " to avoid producing unreadable output." ;
 
 ARTICLE: "prettyprint-limitations" "Prettyprinter limitations"
@@ -226,9 +229,17 @@ HELP: pprint-short
 { $values { "obj" object } }
 { $description "Prettyprints an object to " { $link output-stream } ". This word rebinds printer control variables to enforce “shorter” output. See " { $link "prettyprint-variables" } "." } ;
 
+HELP: pprint-short-if-unset
+{ $values { "obj" object } }
+{ $description "Prettyprints an object to " { $link output-stream } ". This word rebinds printer control variables to enforce “shorter” output if they are not already rebound. See " { $link "prettyprint-variables" } "." } ;
+
 HELP: short.
 { $values { "obj" object } }
-{ $description "Prettyprints an object to " { $link output-stream } " with a trailing line break. This word rebinds printer control variables to enforce “shorter” output." } ;
+{ $description "Prettyprints an object to " { $link output-stream } " with a trailing line break. This word rebinds printer control variables to enforce “shorter” output. See " { $link "prettyprint-variables" } "." } ;
+
+HELP: short-if-unset.
+{ $values { "obj" object } }
+{ $description "Prettyprints an object to " { $link output-stream } " with a trailing line break. This word rebinds printer control variables to enforce “shorter” output if they are not already rebound. See " { $link "prettyprint-variables" } "." } ;
 
 HELP: .b
 { $values { "n" integer } }

--- a/basis/prettyprint/prettyprint-tests.factor
+++ b/basis/prettyprint/prettyprint-tests.factor
@@ -386,6 +386,14 @@ TUPLE: final-tuple ; final
 
 { "{ ~array~ }\n" } [ [ { { 1 2 } } short. ] with-string-writer ] unit-test
 
+{ "H{ { 1 ~array~ } }\n" } [ [ H{ { 1 { 2 } } } short-if-unset. ] with-string-writer ] unit-test
+
+{ "{ ~array~ }\n" } [ [ { { 1 2 } } short-if-unset. ] with-string-writer ] unit-test
+
+{ "H{ { 1 { 2 } } }\n" } [ [ [ H{ { 1 { 2 } } } short-if-unset. ] without-limits ] with-string-writer ] unit-test
+
+{ "{ { 1 2 } }\n" } [ [ [ { { 1 2 } } short-if-unset. ] without-limits ] with-string-writer ] unit-test
+
 { "H{ { 1 { 2 3 } } }\n" } [
     f nesting-limit [
         [ H{ { 1 { 2 3 } } } . ] with-string-writer

--- a/basis/prettyprint/prettyprint.factor
+++ b/basis/prettyprint/prettyprint.factor
@@ -30,10 +30,15 @@ IN: prettyprint
 : pprint-short ( obj -- )
     [ pprint ] with-short-limits ;
 
+: pprint-short-if-unset ( obj -- )
+    [ pprint ] defaulting-with-short-limits ;
+
 : unparse-short ( obj -- str )
     [ pprint-short ] with-string-writer ;
 
 : short. ( obj -- ) pprint-short nl ;
+
+: short-if-unset. ( obj -- ) pprint-short-if-unset nl ;
 
 : error-in-pprint ( obj -- str )
     class-of name>> "~pprint error: " "~" surround ;
@@ -44,7 +49,7 @@ IN: prettyprint
 
 : stack. ( seq -- )
     [
-        [ short. ] [
+        [ short-if-unset. ] [
             drop [ error-in-pprint ] keep write-object nl
         ] recover
     ] each ;


### PR DESCRIPTION
The motivation for the change is explained in detail in https://github.com/factor/factor/issues/2416 and also in a ramble I did on gitter one night.

This strategy can allow nested prettyprinter scopes that either _do_ or _don't_ allow for complete stack traces.

I'm not a fan of the word names, but had trouble coming up with something great and factor-y.

Any feedback welcome, this is like, my second github pull request in my life. (I'm trying to get better!) If anyone has an idea on a different strategy, I can take a swing at it.