### PR TITLE
xkcd: fix urls

### DIFF
--- a/extra/xkcd/xkcd.factor
+++ b/extra/xkcd/xkcd.factor
@@ -14,7 +14,7 @@ IN: xkcd
 : comic-image ( url -- image )
     http-get nip
     R/ \/\/imgs\.xkcd\.com\/comics\/[^\.]+\.(png|jpg)/
-    first-match >string "http:" prepend load-http-image ;
+    first-match >string "https:" prepend load-http-image ;
 
 : comic-image. ( url -- )
     comic-image image. ;
@@ -32,7 +32,7 @@ IN: xkcd
 PRIVATE>
 
 : xkcd-url ( n -- url )
-    "http://xkcd.com/%s/" sprintf ;
+    "https://xkcd.com/%s/" sprintf ;
 
 : xkcd-image ( n -- image )
     xkcd-url comic-image ;
@@ -41,10 +41,10 @@ PRIVATE>
     xkcd-url comic. ;
 
 : random-xkcd. ( -- )
-    "http://dynamic.xkcd.com/random/comic/" comic. ;
+    "https://c.xkcd.com/random/comic/" comic. ;
 
 : latest-xkcd. ( -- )
-    "http://xkcd.com" comic. ;
+    "https://xkcd.com" comic. ;
 
 TUPLE: xkcd number image ;
 


### PR DESCRIPTION
`random-xkcd.` was broken because the url has changed. I also took a liberty to update urls to use https, as that's what xkcd.com uses by default.

P.S. I haven't looked at factor for a couple of years. I see that it still has regular activity, but the last release was 2.5 years ago. Are there any plans to cut a new release? Any plans for 1.0?