### PR TITLE
http: Make parse-set-cookie matching case insensitive

### DIFF
--- a/basis/http/http.factor
+++ b/basis/http/http.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2003, 2010 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors arrays assocs base64 calendar calendar.format
+USING: accessors arrays ascii assocs base64 calendar calendar.format
 calendar.parser combinators fry hashtables http.parsers io io.crlf
 io.encodings.iana io.encodings.utf8 kernel make math math.parser
 mime.types present sequences sets sorting splitting urls ;
@@ -52,7 +52,7 @@ TUPLE: cookie name value version comment path domain expires max-age http-only s
         f swap
         (parse-set-cookie)
         [
-            swap {
+            over >lower [ swapd ] dip {
                 { "version" [ >>version ] }
                 { "comment" [ >>comment ] }
                 { "expires" [ [ cookie-string>timestamp >>expires ] unless-empty ] }
@@ -61,8 +61,9 @@ TUPLE: cookie name value version comment path domain expires max-age http-only s
                 { "path" [ >>path ] }
                 { "httponly" [ drop t >>http-only ] }
                 { "secure" [ drop t >>secure ] }
-                [ <cookie> dup , nip ]
+                [ drop rot <cookie> dup , ]
             } case
+            nip
         ] assoc-each
         drop
     ] { } make ;


### PR DESCRIPTION
Fixes #2176

The matching is case sensitive but per RFC 6265 clients should match case-insensitively. When an attribute has uppercase letters, it is interpreted as a cookie name instead. This causes the cookie list to be wrongly parsed, cookies can be torn into multiple ones. When a separated attribute without a value is fed back to a request, it causes the problem mentioned in the issue.

I'm a Factor newbie and I guess this could be written better, without clever deep stack shuffling and forbidden shuffle words.