### PR TITLE
shell.nix: Define gdk pixbuf loaders from build dependencies.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,11 @@ in
     makeWrapper
   ];
   shellHook = ''
+    # Set Gdk pixbuf loaders file to the one from the build dependencies here
+    unset GDK_PIXBUF_MODULE_FILE
+    # Defined in gdk-pixbuf setup hook
+    findGdkPixbufLoaders "${pkgs.librsvg}"
+
     wrapFactor () {
     [ -n "$1" ] || { printf "Usage: wrapFactor <factor-root>" ; return; }
     local root="$(realpath $1)"
@@ -41,6 +46,7 @@ in
     # Restore the factor binary if it was already wrapped
     [ -e "$wrapped" ] && { mv "$wrapped" "$binary" ; }
     wrapProgram "$binary" --prefix LD_LIBRARY_PATH : ${runtimeLibPath} \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --argv0 factor
     ln -sf "''${root}/factor.image" "''${root}/.factor-wrapped.image"
     }


### PR DESCRIPTION
This resolves a problem when the wrapped Factor binary is executed with
`GDK_PIXBUF_MODULE_FILE` set to an incompatible version.  This happens if e.g.
Factor is run from within an Emacs that uses newer gdk versions.

Related NixOS issue: https://github.com/NixOS/nixpkgs/issues/54278

In the long run, this should be replaced by a derivation which correctly runs
through all the phases correctly to set up `wrapGAppsHook` correctly.  Even
then, the correct behavior would probably be to have the surrounding
environment (e.g. Emacs) restore the default variable value in it's
sub-environments.