### PR TITLE
Make both-fixnums? foldable, hashcode* flushable

### DIFF
--- a/basis/bootstrap/image/primitives/primitives.factor
+++ b/basis/bootstrap/image/primitives/primitives.factor
@@ -407,7 +407,10 @@ CONSTANT: all-primitives {
     {
         "math.private"
         {
-            { "both-fixnums?" ( x y -- ? ) f { object object } { object } f }
+            {
+                "both-fixnums?" ( x y -- ? ) f
+                { object object } { object } make-foldable
+            }
             {
                 "fixnum+fast" ( x y -- z ) f
                 { fixnum fixnum } { fixnum } make-foldable

--- a/core/kernel/kernel.factor
+++ b/core/kernel/kernel.factor
@@ -292,7 +292,7 @@ UNION: boolean POSTPONE: t POSTPONE: f ;
     [ [ not ] compose ] dip while ; inline
 
 ! Object protocol
-GENERIC: hashcode* ( depth obj -- code )
+GENERIC: hashcode* ( depth obj -- code ) flushable
 
 M: object hashcode* 2drop 0 ; inline
 


### PR DESCRIPTION
I think both-fixnums? can be flushable, even though it can receive mutable inputs.  It will only return `t` for non-mutable inputs though, and `f` for any mutable input.

for `hashcode*`, there is a method which performs a rehash operation, which is not side-effect free.  However, if the result is not needed, it should be possible to optimize out that rehashing.