### PR TITLE
HTTP/2 Server Framework

### DIFF
--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,6 +1,6 @@
 USING: accessors continuations http http.server http.server.requests
 io io.servers io.sockets io.streams.peek
-io.streams.limited kernel namespaces ;
+io.streams.limited kernel namespaces openssl.libssl ; 
 
 IN: http2.server
 
@@ -31,7 +31,7 @@ M: http2-server handle-client*
     ?refresh-all
     request-limit get limited-input
     secure-addr dup port>> local-address get port>> = and
-    [ t ! get tls(1.2?) negotiated thing
+    [ t ! get tls(1.2?) negotiated thing: replace with get_alpn_selected
       [ f start-http2-connection ] ! if h2, send prefix and start full http2
       [ call-next-method ] ! else, revert to http1?
       if ] ! secure case
@@ -51,10 +51,10 @@ M: http2-server handle-client*
             nip
             [ do-request ] ?benchmark 
             [ do-response ] ?benchmark 
-          ]
+          ] if 
         ]
         [ nip handle-client-error ] recover 
-        if ]
+        ]
       if ] ! insecure case
     if
     ;

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,5 +1,5 @@
 USING: accessors continuations http http.server http.server.requests
-io io.servers io.sockets io.streams.peek
+io io.encodings.ascii io.servers io.sockets io.streams.peek
 io.streams.limited kernel namespaces openssl.libssl ; 
 
 IN: http2.server
@@ -58,4 +58,10 @@ M: http2-server handle-client*
       if ] ! insecure case
     if
     ;
+
+: <http2-server> ( -- server )
+    ascii http2-server new-threaded-server
+        "http2.server" >>name
+        "http" protocol-port >>insecure
+        "https" protocol-port >>secure ;
 

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,10 +1,23 @@
-USING: http.server kernel io.server ;
+USING: http.server kernel io.servers ;
 
 IN: http2.server
 
 TUPLE: http2-server < threaded-server ;
 
-! stack effect: ( -- )
-M: http-server handle-client*
+! stack effect: ( threaded-server -- )
+M: http2-server handle-client*
+    t ! check if this is a secure connection or not
+      ! see remote-address variable?
+    [ t ! get tls(1.2?) negotiated thing
+      [ ] ! if h2, send prefix and start full http2
+      [ ] ! else, revert to http1?
+      if ] ! secure case
+    [ ! read initial request as http1
+      t ! check if it asks for upgrade
+      [ ] ! if so, send 101 switching protocols response, start http2,
+          ! including sending prefix and response to initial request.
+      [ ] ! else, finish processing as http1.
+      if ] ! insecure case
+    if
     ;
 

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,4 +1,5 @@
-USING: http http.server kernel io.servers ;
+USING: accessors http http.server io.servers io.sockets kernel
+namespaces ;
 
 IN: http2.server
 
@@ -8,21 +9,20 @@ TUPLE: http2-server < http-server ;
     2drop
     ! TODO: establish http2 connection and carry out requests
     ;
+
 ! stack effect: ( threaded-server -- )
 M: http2-server handle-client*
-    t ! check if this is a secure connection or not
-      ! see remote-address variable?
+    secure-addr dup port>> local-address get port>> = and ! check if this is a secure connection or not
     [ t ! get tls(1.2?) negotiated thing
       [ f start-http2-connection ] ! if h2, send prefix and start full http2
       [ call-next-method ] ! else, revert to http1?
       if ] ! secure case
-    [ ! read initial request as http1
+    [ f ! read initial request as http1
       t ! check if it asks for upgrade
       [ start-http2-connection ] ! if so, send 101 switching protocols response, start http2,
           ! including sending prefix and response to initial request.
-      [ ] ! else, finish processing as http1.
+      [ 2drop ] ! else, finish processing as http1.
       if ] ! insecure case
     if
     ;
-
 

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -4,9 +4,10 @@ io.sockets kernel namespaces ;
 IN: http2.server
 
 ! individual connection stuff
-TUPLE: http2-stream hpack-context ; ! do I even need this?
+TUPLE: http2-stream ; ! do I even need this?
 
-TUPLE: http2-connection streams settings ;
+TUPLE: http2-connection streams settings hpack-decode-context
+hpack-encode-context ;
 
 CONSTANT: client-connection-prefix B{ 0x50 0x52 0x49 0x20 0x2a
             0x20 0x48 0x54 0x54 0x50 0x2f 0x32 0x2e 0x30 0x0d

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -10,9 +10,7 @@ TUPLE: http2-stream ; ! do I even need this?
 TUPLE: http2-connection streams settings hpack-decode-context
 hpack-encode-context ;
 
-CONSTANT: client-connection-prefix B{ 0x50 0x52 0x49 0x20 0x2a
-            0x20 0x48 0x54 0x54 0x50 0x2f 0x32 0x2e 0x30 0x0d
-            0x0a 0x0d 0x0a 0x53 0x4d 0x0d 0x0a 0x0d 0x0a } 
+CONSTANT: client-connection-prefix "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
 : start-http2-connection ( threaded-server prev-req/f -- )
     2drop
@@ -37,7 +35,10 @@ M: http2-server handle-client*
       if ] ! secure case
     [ ! first, check if the thing sent is connection prefix, and
       ! if so, start connection
-      24 peek client-connection-prefix =
+      ! this line should check for the connection prefix, but
+      ! seems to mess up the stream for when the the request is
+      ! read in read-request.
+      f ! 24 input-stream get <peek-stream> stream-peek client-connection-prefix =
       [ f start-http2-connection ]
       [ 
         [

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -40,7 +40,14 @@ M: http2-server handle-client*
         t ! check if it asks for upgrade
         [ start-http2-connection ] ! if so, send 101 switching protocols response, start http2,
             ! including sending prefix and response to initial request.
-        [ 2drop ] ! else, finish processing as http1.
+        [ 
+            ?refresh-all
+            request-limit get limited-input
+            [ read-request ] ?benchmark 
+            [ do-request ] ?benchmark 
+            [ do-response ] ?benchmark 
+          [ handle-client-error ] recover ! else, finish processing as http1.
+        ]
         if ]
       if ] ! insecure case
     if

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -41,11 +41,13 @@ M: http2-server handle-client*
         [ start-http2-connection ] ! if so, send 101 switching protocols response, start http2,
             ! including sending prefix and response to initial request.
         [ 
+        [
             ?refresh-all
             request-limit get limited-input
             [ read-request ] ?benchmark 
             [ do-request ] ?benchmark 
             [ do-response ] ?benchmark 
+        ]
           [ handle-client-error ] recover ! else, finish processing as http1.
         ]
         if ]

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,0 +1,10 @@
+USING: http.server kernel io.server ;
+
+IN: http2.server
+
+TUPLE: http2-server < threaded-server ;
+
+! stack effect: ( -- )
+M: http-server handle-client*
+    ;
+

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,23 +1,28 @@
-USING: http.server kernel io.servers ;
+USING: http http.server kernel io.servers ;
 
 IN: http2.server
 
-TUPLE: http2-server < threaded-server ;
+TUPLE: http2-server < http-server ;
 
+: start-http2-connection ( threaded-server prev-req/f -- )
+    2drop
+    ! TODO: establish http2 connection and carry out requests
+    ;
 ! stack effect: ( threaded-server -- )
 M: http2-server handle-client*
     t ! check if this is a secure connection or not
       ! see remote-address variable?
     [ t ! get tls(1.2?) negotiated thing
-      [ ] ! if h2, send prefix and start full http2
-      [ ] ! else, revert to http1?
+      [ f start-http2-connection ] ! if h2, send prefix and start full http2
+      [ call-next-method ] ! else, revert to http1?
       if ] ! secure case
     [ ! read initial request as http1
       t ! check if it asks for upgrade
-      [ ] ! if so, send 101 switching protocols response, start http2,
+      [ start-http2-connection ] ! if so, send 101 switching protocols response, start http2,
           ! including sending prefix and response to initial request.
       [ ] ! else, finish processing as http1.
       if ] ! insecure case
     if
     ;
+
 

--- a/basis/http2/server/server.factor
+++ b/basis/http2/server/server.factor
@@ -1,27 +1,46 @@
-USING: accessors http http.server io.servers io.sockets kernel
-namespaces ;
+USING: accessors http http.server io io.servers io.streams.peek
+io.sockets kernel namespaces ;
 
 IN: http2.server
 
-TUPLE: http2-server < http-server ;
+! individual connection stuff
+TUPLE: http2-stream hpack-context ; ! do I even need this?
+
+TUPLE: http2-connection streams settings ;
+
+CONSTANT: client-connection-prefix B{ 0x50 0x52 0x49 0x20 0x2a
+            0x20 0x48 0x54 0x54 0x50 0x2f 0x32 0x2e 0x30 0x0d
+            0x0a 0x0d 0x0a 0x53 0x4d 0x0d 0x0a 0x0d 0x0a } 
 
 : start-http2-connection ( threaded-server prev-req/f -- )
     2drop
     ! TODO: establish http2 connection and carry out requests
+    ! send settings frame.
+    ! listen for connection prefix and settings from client.
+    ! save settings and send ack.
     ;
+
+! the server stuff
+TUPLE: http2-server < http-server ;
 
 ! stack effect: ( threaded-server -- )
 M: http2-server handle-client*
-    secure-addr dup port>> local-address get port>> = and ! check if this is a secure connection or not
+    ! check if this is a secure connection or not
+    secure-addr dup port>> local-address get port>> = and
     [ t ! get tls(1.2?) negotiated thing
       [ f start-http2-connection ] ! if h2, send prefix and start full http2
       [ call-next-method ] ! else, revert to http1?
       if ] ! secure case
-    [ f ! read initial request as http1
-      t ! check if it asks for upgrade
-      [ start-http2-connection ] ! if so, send 101 switching protocols response, start http2,
-          ! including sending prefix and response to initial request.
-      [ 2drop ] ! else, finish processing as http1.
+    [ ! first, check if the thing sent is connection prefix, and
+      ! if so, start connection
+      24 peek client-connection-prefix =
+      [ f start-http2-connection ]
+      [ f ! read initial request as http1
+        t ! check if it asks for upgrade
+        [ start-http2-connection ] ! if so, send 101 switching protocols response, start http2,
+            ! including sending prefix and response to initial request.
+        [ 2drop ] ! else, finish processing as http1.
+        if ]
       if ] ! insecure case
     if
     ;


### PR DESCRIPTION
The basic structure for the HTTP/2 server in factor. Currently, it will check if it should upgrade to HTTP/2, and if not defaults to HTTP/1.1. There are some missing features, including checking for the TLS negotiation, so it just defaults to the insecure case. We ran some manual tests by sending a HTTP/1 request, and it gave the expected response. Unit and integration tests should be added at some point by future contributions. 

Also, when checking the input stream, we would encounter some issues when peeking at the bytes for an upgrade request, so at the moment we have hardcoded it to a false (line 41 of the code currently). If there are any ways to resolve that issue, we can apply them before merging.