### PR TITLE
Add command to run unit tests after refreshing

### DIFF
--- a/basis/tools/test/test-docs.factor
+++ b/basis/tools/test/test-docs.factor
@@ -1,4 +1,4 @@
-USING: help.markup help.syntax kernel quotations io ;
+USING: help.markup help.syntax kernel quotations io strings vocabs.refresh ;
 IN: tools.test
 
 ARTICLE: "tools.test" "Unit testing"
@@ -82,6 +82,16 @@ HELP: test
 
 HELP: test-all
 { $description "Runs unit tests for all loaded vocabularies." } ;
+
+HELP: refresh-and-test
+{ $values { "prefix" string } }
+{ $description "Like " { $link refresh } ", but runs unit tests for all reloaded vocabularies afterwards." } ;
+
+HELP: refresh-and-test-all
+{ $values { "prefix" string } }
+{ $description "Like " { $link refresh-all } ", but runs unit tests for all reloaded vocabularies afterwards." } ;
+
+{ refresh-and-test refresh-and-test-all } related-words
 
 HELP: :test-failures
 { $description "Prints all pending unit test failures." } ;

--- a/basis/tools/test/test.factor
+++ b/basis/tools/test/test.factor
@@ -8,7 +8,7 @@ sequences.generalizations source-files source-files.errors
 source-files.errors.debugger splitting stack-checker summary
 system tools.errors tools.time unicode vocabs vocabs.files
 vocabs.hierarchy vocabs.hierarchy.private vocabs.loader
-vocabs.metadata vocabs.parser words ;
+vocabs.metadata vocabs.parser vocabs.refresh words ;
 IN: tools.test
 
 TUPLE: test-failure < source-file-error continuation ;
@@ -225,6 +225,10 @@ M: test-failure error. ( error -- )
 : test ( prefix -- ) loaded-child-vocab-names test-vocabs ;
 
 : test-all ( -- ) "" test ;
+
+: refresh-and-test ( prefix --  ) to-refresh [ do-refresh ] keepdd test-vocabs ;
+
+: refresh-and-test-all ( -- ) "" refresh-and-test ;
 
 : test-main ( -- )
     command-line get [

--- a/basis/ui/tools/tools.factor
+++ b/basis/ui/tools/tools.factor
@@ -1,12 +1,14 @@
 ! Copyright (C) 2006, 2009 Slava Pestov.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: kernel literals memory namespaces sequences system ui
+USING: kernel literals memory namespaces sequences system
+tools.test ui
 ui.backend ui.commands ui.gestures ui.tools.browser
 ui.tools.common ui.tools.error-list ui.tools.listener
 vocabs.refresh ;
 IN: ui.tools
 
 \ refresh-all H{ { +nullary+ t } { +listener+ t } } define-command
+\ refresh-and-test-all H{ { +nullary+ t } { +listener+ t } } define-command
 
 \ save H{ { +nullary+ t } } define-command
 
@@ -25,6 +27,7 @@ tool "common" f {
     { T{ key-down f ${ os macosx? M+ C+ ? } "w" } close-window }
     { T{ key-down f ${ os macosx? M+ C+ ? } "q" } com-exit }
     { T{ key-down f f "F2" } refresh-all }
+    { T{ key-down f { S+ } "F2" } refresh-and-test-all }
     { T{ key-down f f "F3" } show-error-list }
 } os macosx? {
     { T{ key-down f { C+ M+ } "f" } toggle-fullscreen }

--- a/misc/fuel/fuel-listener.el
+++ b/misc/fuel/fuel-listener.el
@@ -211,6 +211,16 @@ With prefix, you're teletransported to the listener's buffer."
       (comint-send-string nil " refresh-all \"Done!\" write nl flush\n"))
     (when arg (pop-to-buffer buf))))
 
+(defun fuel-refresh-and-test-all (&optional arg)
+  "Switch to the listener buffer and invokes Factor's refresh-and-test-all.
+With prefix, you're teletransporteded to the listener's buffer."
+  (interactive "P")
+  (let ((buf (process-buffer (fuel-listener--process))))
+    (with-current-buffer buf
+      (comint-send-string nil "\"Refreshing loaded vocabs and running tests...\" write nl flush")
+      (comint-send-string nil " refresh-and-test-all \"Done!\" write nl flush\n"))
+    (when arg (pop-to-buffer buf))))
+
 (defun fuel-test-vocab (&optional arg)
   "Run the unit tests for the current vocabulary. With prefix argument, ask for
 the vocabulary name."
@@ -281,7 +291,8 @@ the vocabulary name."
          fuel-show-callees :enable (symbol-at-point))
         (mode "Autodoc mode" "\C-c\C-a" fuel-autodoc-mode))
   ("Run file" "\C-c\C-k" fuel-run-file)
-  ("Refresh vocabs" "\C-c\C-r" fuel-refresh-all))
+  ("Refresh vocabs" "\C-c\C-r" fuel-refresh-all)
+  ("Refresh vocabs and test" "\C-c\M-r" fuel-refresh-and-test-all))
 
 (define-key fuel-listener-mode-map [menu-bar completion] 'undefined)
 

--- a/misc/fuel/fuel-mode.el
+++ b/misc/fuel/fuel-mode.el
@@ -226,6 +226,7 @@ interacting with a factor listener is at your disposal.
   ("Run file" ("\C-c\C-k" "\C-c\C-l" "\C-c\C-e\C-k") fuel-run-file)
   ("Run unit tests" "\C-c\C-t" fuel-test-vocab)
   ("Refresh vocabs" "\C-c\C-r" fuel-refresh-all)
+  ("Refresh vocabs and test" "\C-c\M-r" fuel-refresh-and-test-all)
   --
   (menu "Switch to"
         ("Listener" "\C-c\C-z" run-factor)


### PR DESCRIPTION
This saves a bit of typing when one uses `F2` and `"long-vocab.name" test "other-vocab" test` a lot during test-driven development. 

Added a default key binding on `Shift-F2` for the UI Tools windows, and the corresponding `fuel` bindings as `C-c M-r` (open to suggestions on this one, not too happy...)