### PR TITLE
hashtables: Preserve access semantics for alist >hashtable conversion

### DIFF
--- a/core/hashtables/hashtables-tests.factor
+++ b/core/hashtables/hashtables-tests.factor
@@ -184,3 +184,7 @@ H{ } "x" set
 
 ! Random test case
 { "A" } [ 100 <iota> [ dup ] H{ } map>assoc 32 over delete-at "A" 32 pick set-at 32 of ] unit-test
+
+! Alists have prefix priority
+{ 42 } [ { { 1 42 } { 2 10 } { 1 20 } } 1 of ] unit-test
+{ 42 } [ { { 1 42 } { 2 10 } { 1 20 } } >hashtable 1 of ] unit-test

--- a/core/hashtables/hashtables.factor
+++ b/core/hashtables/hashtables.factor
@@ -91,7 +91,7 @@ TUPLE: hashtable
     dupd new-key@ set-nth-pair ; inline
 
 : (rehash) ( alist hash -- )
-    [ swapd (set-at) ] curry assoc-each ; inline
+    [ <reversed> ] dip [ swapd (set-at) ] curry assoc-each ; inline
 
 : hash-large? ( hash -- ? )
     [ count>> 1 fixnum+fast 3 fixnum*fast ]


### PR DESCRIPTION
Alists have a left-to-right first key occurrence wins access strategy.  This
changes the iteration order when converting an alist via `>hashtable`, so that
the first entry will dominate the resulting assoc.