### PR TITLE
assocs.extras: Fix error with assoc-collapse with f as first element

### DIFF
--- a/extra/assocs/extras/extras-tests.factor
+++ b/extra/assocs/extras/extras-tests.factor
@@ -136,3 +136,12 @@ USING: arrays assocs.extras kernel math math.order sequences tools.test ;
     H{ { 3 30 } { 4 40 } } 3array
     [ min ] assoc-collapse
 ] unit-test
+
+{
+    H{ { 2 22 } { 3 30 } { 4 40 } }
+} [
+    f
+    H{ { 2 22 } { 3 33 } }
+    H{ { 3 30 } { 4 40 } } 3array
+    [ min ] assoc-collapse
+] unit-test

--- a/extra/assocs/extras/extras.factor
+++ b/extra/assocs/extras/extras.factor
@@ -80,7 +80,7 @@ IN: assocs.extras
 : assoc-collapse ( seq quot: ( value1 value2 -- new-value ) -- assoc )
     over empty?
     [ 2drop f ]
-    [ [ unclip-slice clone ] [ [ assoc-merge! ] curry ] bi* reduce ] if ; inline
+    [ [ unclip-slice H{ } or clone ] [ [ assoc-merge! ] curry ] bi* reduce ] if ; inline
 
 GENERIC: delete-value-at ( value assoc -- )
 


### PR DESCRIPTION
Since `assoc-collapse` uses a clone of the first assoc in the input sequence as
basis for the resulting assoc, this was failing when the first element was `f`.
Change behavior to return a hashtable instead, since this is the
default behavior for `f new-assoc` as well.