### PR TITLE
Strengthen compiler optimization of resize-{array,byte-array,string} calls

### DIFF
--- a/basis/compiler/tree/propagation/known-words/known-words.factor
+++ b/basis/compiler/tree/propagation/known-words/known-words.factor
@@ -391,3 +391,16 @@ generic-comparison-ops [
 \ tag [
     drop fixnum 0 num-types get [a,b) <class/interval-info>
 ] "outputs" set-word-prop
+
+! Primitive resize operations
+
+: propagate-resize-fixed-length-sequence ( n-info in-info class -- out-info )
+    nip <sequence-info> ;
+
+{ { resize-array array }
+  { resize-byte-array byte-array }
+  { resize-string string } }
+[
+    [ propagate-resize-fixed-length-sequence ] curry
+    "outputs" set-word-prop
+] assoc-each

--- a/basis/compiler/tree/propagation/propagation-tests.factor
+++ b/basis/compiler/tree/propagation/propagation-tests.factor
@@ -44,6 +44,22 @@ IN: compiler.tree.propagation.tests
     [ 42 swap resize-array length ] final-literals first
 ] unit-test
 
+{ f } [
+    [ resize-array ] { resize-array } inlined?
+] unit-test
+
+{ t } [
+    [ 3 { 1 2 3 } resize-array ] { resize-array } inlined?
+] unit-test
+
+{ f } [
+    [ 4 { 1 2 3 } resize-array ] { resize-array } inlined?
+] unit-test
+
+{ f } [
+    [ 4 swap { array } declare resize-array ] { resize-array } inlined?
+] unit-test
+
 ! Byte arrays
 { V{ 3 } } [
     [ 3 <byte-array> length ] final-literals
@@ -63,6 +79,10 @@ IN: compiler.tree.propagation.tests
     [ 43 swap resize-byte-array length ] final-literals first
 ] unit-test
 
+{ t } [
+    [ 3 B{ 1 2 3 } resize-byte-array ] { resize-byte-array } inlined?
+] unit-test
+
 ! Strings
 { V{ 3 } } [
     [ 3 f <string> length ] final-literals
@@ -75,6 +95,10 @@ IN: compiler.tree.propagation.tests
 
 { V{ 44 } } [
     [ 44 swap resize-string length ] final-literals
+] unit-test
+
+{ t } [
+    [ 3 "123" resize-string ] { resize-string } inlined?
 ] unit-test
 
 { V{ t } } [

--- a/basis/compiler/tree/propagation/propagation-tests.factor
+++ b/basis/compiler/tree/propagation/propagation-tests.factor
@@ -35,6 +35,15 @@ IN: compiler.tree.propagation.tests
     [ dup "foo" <array> drop ] final-info first
 ] unit-test
 
+{ t } [
+    [ resize-array length ] final-info first
+    array-capacity <class-info> =
+] unit-test
+
+{ 42 } [
+    [ 42 swap resize-array length ] final-literals first
+] unit-test
+
 ! Byte arrays
 { V{ 3 } } [
     [ 3 <byte-array> length ] final-literals
@@ -46,13 +55,26 @@ IN: compiler.tree.propagation.tests
 ] unit-test
 
 { t } [
-    [ dupd resize-byte-array drop ] final-info first
-    integer-array-capacity <class-info> =
+    [ resize-byte-array length ] final-info first
+    array-capacity <class-info> =
+] unit-test
+
+{ 43 } [
+    [ 43 swap resize-byte-array length ] final-literals first
 ] unit-test
 
 ! Strings
 { V{ 3 } } [
     [ 3 f <string> length ] final-literals
+] unit-test
+
+{ t } [
+    [ resize-string length ] final-info first
+    array-capacity <class-info> =
+] unit-test
+
+{ V{ 44 } } [
+    [ 44 swap resize-string length ] final-literals
 ] unit-test
 
 { V{ t } } [

--- a/basis/compiler/tree/propagation/transforms/transforms.factor
+++ b/basis/compiler/tree/propagation/transforms/transforms.factor
@@ -1,14 +1,12 @@
 ! Copyright (C) 2008, 2011 Slava Pestov, Daniel Ehrenberg.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: accessors alien.c-types assocs classes classes.algebra
-classes.tuple classes.tuple.private combinators
-combinators.short-circuit compiler.tree.propagation.info effects
-fry generalizations generic generic.single growable hash-sets
-hashtables kernel layouts locals math math.integers.private
-math.intervals math.order math.partial-dispatch math.private
-namespaces quotations sequences sequences.generalizations
-sequences.private sets sets.private stack-checker
-stack-checker.dependencies vectors words ;
+USING: accessors alien.c-types arrays assocs byte-arrays classes classes.algebra
+classes.tuple classes.tuple.private combinators combinators.short-circuit
+compiler.tree.propagation.info effects generalizations generic generic.single
+growable hash-sets hashtables kernel layouts math math.integers.private
+math.intervals math.order math.partial-dispatch math.private namespaces
+quotations sequences sequences.generalizations sequences.private sets
+sets.private stack-checker stack-checker.dependencies strings vectors words ;
 FROM: math => float ;
 IN: compiler.tree.propagation.transforms
 
@@ -353,3 +351,13 @@ M\ sets:set intersects? [ intersects?-quot ] 1 define-partial-eval
         [ f ]
     } cond 2nip
 ] "custom-inlining" set-word-prop
+
+: constant-number-info? ( info -- ? )
+    { [ value-info-state? ] [ literal?>> ] [ class>> integer class<= ] } 1&& ;
+
+! Resize-sequences to existing length can be optimized out
+{ resize-array resize-string resize-byte-array } [
+    in-d>> first2 [ value-info ] bi@ slots>> ?first
+    { [ [ constant-number-info? ] both? ] [ [ literal>> ] bi@ = ] } 2&&
+    [ [ nip ] ] [ f ] if
+] [ "custom-inlining" set-word-prop ] curry each


### PR DESCRIPTION
Sets the length info slot of the output sequence to the value passed to the call. Also, inline as `nip` if compiler can prove that the required length is equal to the length of the input sequence.

While these optimization help optimizing code involving creating and converting sequences, I am not sure how to exactly measure the benefit of these optimizations.

I ran all core vocab tests to verify it did not break anything, but it should probably be double-checked whether the optimizations are safe.