### PR TITLE
Dispatch on Words like on Singleton Classes

### DIFF
--- a/basis/compiler/tree/propagation/info/info.factor
+++ b/basis/compiler/tree/propagation/info/info.factor
@@ -86,36 +86,29 @@ UNION: fixed-length array byte-array string ;
         [ [ interval>> empty-interval? ] [ class>> real class<= ] bi and ]
     } 1|| ;
 
-! Hardcoding classes is kind of a hack.
-: min-value ( class -- n )
-    {
-        { fixnum [ most-negative-fixnum ] }
-        { array-capacity [ 0 ] }
-        { integer-array-capacity [ 0 ] }
-        [ drop -1/0. ]
-    } case ;
+GENERIC: min-value ( class -- n )
+GENERIC: max-value ( class -- n )
+GENERIC: class-interval ( class -- i )
+GENERIC: fix-capacity-class ( class -- class' )
 
-: max-value ( class -- n )
-    {
-        { fixnum [ most-positive-fixnum ] }
-        { array-capacity [ max-array-capacity ] }
-        { integer-array-capacity [ max-array-capacity ] }
-        [ drop 1/0. ]
-    } case ;
+M: classoid min-value drop -1/0. ;
+M: classoid max-value drop 1/0. ;
+M: classoid class-interval drop full-interval ;
+M: classoid fix-capacity-class ;
 
-: class-interval ( class -- i )
-    {
-        { fixnum [ fixnum-interval ] }
-        { array-capacity [ array-capacity-interval ] }
-        { integer-array-capacity [ array-capacity-interval ] }
-        [ drop full-interval ]
-    } case ;
+M: \ fixnum min-value drop most-negative-fixnum ;
+M: \ fixnum max-value drop most-positive-fixnum ;
+M: \ fixnum class-interval drop fixnum-interval ;
 
-: fix-capacity-class ( class -- class' )
-    {
-        { array-capacity fixnum }
-        { integer-array-capacity integer }
-    } ?at drop ;
+M: \ array-capacity min-value drop 0 ;
+M: \ array-capacity max-value drop max-array-capacity ;
+M: \ array-capacity class-interval drop array-capacity-interval ;
+M: \ array-capacity fix-capacity-class drop fixnum ;
+
+M: \ integer-array-capacity min-value drop 0 ;
+M: \ integer-array-capacity max-value drop max-array-capacity ;
+M: \ integer-array-capacity class-interval drop array-capacity-interval ;
+M: \ integer-array-capacity fix-capacity-class drop integer ;
 
 : wrap-interval ( interval class -- interval' )
     class-interval 2dup interval-subset? [ drop ] [ nip ] if ;

--- a/core/parser/parser-tests.factor
+++ b/core/parser/parser-tests.factor
@@ -652,3 +652,19 @@ EXCLUDE: qualified.tests.bar => x ;
         { "10 20 30 ;" } <lexer> [ parse-array-def ] with-lexer
     ] with-file-vocabs
 ] unit-test
+
+! Test jit-singletons
+
+IN: generic.parser.tests
+
+: frobhaha ( x -- x ) drop 42 ;
+: flubhaha ( x -- ) drop ;
+: bazhaha ( x -- x ) ;
+
+
+GENERIC: is-a-cool-word ( word -- ? )
+M: word is-a-cool-word drop t ;
+M: \ frobhaha is-a-cool-word drop f ;
+
+{ t } [ \ flubhaha is-a-cool-word ] unit-test
+{ f } [ \ frobhaha is-a-cool-word ] unit-test

--- a/core/words/words.factor
+++ b/core/words/words.factor
@@ -97,7 +97,7 @@ M: word crossref?
 
 GENERIC: subwords ( word -- seq )
 
-M: word subwords drop f ;
+M: word subwords "singleton-class" word-prop [ 1array ] [ f ] if* ;
 
 GENERIC: parent-word ( word -- word/f )
 
@@ -179,6 +179,7 @@ M: word reset-word
         "unannotated-def" "parsing" "inline" "recursive"
         "foldable" "flushable" "reading" "writing" "reader"
         "writer" "delimiter" "deprecated"
+        "singleton-class"
     } remove-word-props ;
 
 : reset-generic ( word -- )


### PR DESCRIPTION
Automatically treat words as singletons with regards to method dispatch.  This uses the wrapper syntax `M: \ some-word some-generic ... ;` to get/generate a predicate class which dispatches as if the word had been defined as a singleton class itself.

As an example usage, I added a commit which shows how this could be used in the front-end compiler to implement some properties in a more abstract way.

I imagine this could also be used instead of word properties for a number of cases, possibly making dispatch a bit more efficient because of inline caching.