### PR TITLE
Fix off-by-one error in rolling-map

### DIFF
--- a/basis/sequences/windowed/windowed-tests.factor
+++ b/basis/sequences/windowed/windowed-tests.factor
@@ -5,6 +5,9 @@ USING: arrays sequences sequences.windowed tools.test ;
 { { { 1 } { 1 2 } { 1 2 3 } { 2 3 4 } { 3 4 5 } { 4 5 6 } } }
 [ { 1 2 3 4 5 6 } 3 <windowed-sequence> [ >array ] map ] unit-test
 
+{ { { 1 } { 1 2 } { 1 2 3 } { 2 3 4 } { 3 4 5 } { 4 5 6 } } }
+[ { 1 2 3 4 5 6 } 3 [ >array ] rolling-map ] unit-test
+
 { 6 }
 [ { 1 2 3 4 5 6 } 3 <windowed-sequence> length ] unit-test
 

--- a/basis/sequences/windowed/windowed.factor
+++ b/basis/sequences/windowed/windowed.factor
@@ -26,7 +26,7 @@ M: windowed-sequence length
 
 :: rolling-map ( ... seq n quot: ( ... slice -- ... elt ) -- ... newseq )
     seq length [
-        [ n [-] ] [ seq <slice-unsafe> ] bi quot call
+        1 + [ n [-] ] [ seq <slice-unsafe> ] bi quot call
     ] { } map-integers ; inline
 
 : rolling-sum ( seq n -- newseq )


### PR DESCRIPTION
`{ 1 2 3 4 5 6 7 8 9 } 3 [ >array ] rolling-map ...`
gives
```
{
    { }
    { 1 }
    { 1 2 }
    { 1 2 3 }
    { 2 3 4 }
    { 3 4 5 }
    { 4 5 6 }
    { 5 6 7 }
    { 6 7 8 }
}
```
The first slice is zero elements long, should be one; the last slice doesn't reach the last element of the sequence.
With this change
`{ 1 2 3 4 5 6 7 8 9 } 3 [ >array ] rolling-map ...`
gives
```
{
    { 1 }
    { 1 2 }
    { 1 2 3 }
    { 2 3 4 }
    { 3 4 5 }
    { 4 5 6 }
    { 5 6 7 }
    { 6 7 8 }
    { 7 8 9 }
}
```
which I think is the expected behaviour.