### PR TITLE
help.lint.coverage: fix coverage on predicate? words

### DIFF
--- a/extra/help/lint/coverage/coverage-tests.factor
+++ b/extra/help/lint/coverage/coverage-tests.factor
@@ -37,6 +37,10 @@ PRIVATE>
 
 { an-empty-word-with-a-unique-name } [ "an-empty-word-with-a-unique-name" find-word ] unit-test
 
+{ { } } [ \ zero-matrix? missing-sections ] unit-test
+{ t } [ \ word-help-coverage? <word-help-coverage> 100%-coverage?>> ] unit-test
+{ t } [ \ zero-matrix? <word-help-coverage> 100%-coverage?>> ] unit-test
+
 {
   V{ "[" { $[ "math" dup lookup-vocab ] } "] " { "zero?" zero? } ": " }
 } [
@@ -65,8 +69,7 @@ PRIVATE>
 ] unit-test
 
 ! make sure this doesn't throw an error (would signify an issue with ignored-words)
-! the contents of all-words is not important
-{ } [ all-words [ <word-help-coverage> ] map drop ] unit-test
+{ } [ { $io-error $prettyprinting-note $nl } [ <word-help-coverage> ] map drop ] unit-test
 
 
 ! Lint system is written weirdly, there's no way to invoke it and get the output

--- a/extra/help/lint/coverage/coverage.factor
+++ b/extra/help/lint/coverage/coverage.factor
@@ -32,6 +32,9 @@ CONSTANT: ignored-words {
     $nl
 }
 
+: (word-help) ( word -- content )
+    dup "help" word-prop [ ] [ word-help* ] ?if ;
+
 GENERIC: write-object* ( object -- )
 M: string write-object* write ;
 M: pair write-object* first2 write-object ;
@@ -118,12 +121,12 @@ M: word-help-coverage summary
     } cond ?remove-$values ;
 
 : word-defines-sections ( word -- seq )
-    "help" word-prop [ ignored-words member? not ] filter [ ?first ] map ;
+    (word-help) [ ignored-words member? ] reject [ ?first ] map ;
 
 ! only words that need examples, need to have them nonempty
 ! not defining examples is not the same as an empty { $examples }
 : empty-examples? ( word -- ? )
-    "help" word-prop \ $examples swap elements [ f ] [ first rest empty? ] if-empty ;
+    (word-help) \ $examples swap elements [ f ] [ first rest empty? ] if-empty ;
 
 : missing-sections ( word -- missing )
     [ should-define ] [ word-defines-sections ] bi diff ;
@@ -136,7 +139,7 @@ PRIVATE>
 GENERIC: <word-help-coverage> ( word -- coverage )
 M: word <word-help-coverage>
     dup [ missing-sections ] [ empty-examples? ] bi
-    2dup 2array { { } f } =
+    2dup [ empty? ] bi@ and
     word-help-coverage boa ; inline
 
 M: string <word-help-coverage>


### PR DESCRIPTION
fix a regression for `predicate?` words revealed by uses of
  `"help" word-prop` over `help:word-help`.

`"help" word-prop` is `f` for `predicate?` words like `array?` and
  `zero-matrix?`. a poorly-written comparison in
  `M\ word <word-help-coverage>` meant that result was effectively
  compared to an empty array { }, instead of just being tested for
  emptiness.

additionally, `(word-help)` is introduced to revive the old behaviour of
  `help:word-help` before the move to split `$inputs` and `$outputs` in
  Help rendering. `(word-help)` provides the actual help content for
  words where `"help" word-prop` is `f`, by calling `word-help*`.

closes #2503 