### PR TITLE
put show-error-list in the touchbar

### DIFF
--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -478,6 +478,7 @@ listener-gadget "touchbar" f {
     { f refresh-all }
     { f com-auto-use }
     { f com-help }
+    { f show-error-list }
 } define-command-map
 
 listener-gadget "file-drop" "Files can be drag-and-dropped onto the listener."


### PR DESCRIPTION
avoids having to pop open Keyboard Viewer to hit the virtual F3 key under Touchbar settings that show Control Strip and App Controls only.