### PR TITLE
Allow `fuel-start-remote-listener` to work with a specified port

### DIFF
--- a/extra/fuel/remote/remote.factor
+++ b/extra/fuel/remote/remote.factor
@@ -13,7 +13,7 @@ IN: fuel.remote
 PRIVATE>
 
 : fuel-start-remote-listener ( port/f -- )
-    print-banner integer? [ 9000 ] unless* <tty-server> start-server drop ;
+    print-banner [ 9000 ] unless* <tty-server> start-server drop ;
 
 : fuel-start-remote-listener* ( -- ) f fuel-start-remote-listener ;
 


### PR DESCRIPTION
The `integer?` check in `fuel-start-remote-listener` turns the integer into a boolean, causing `<tty-server> start-server` to error

```
Bad store to specialized slot
value t
class integer
``` 

removing the `integer?` check allows the function to work as intended