### PR TITLE
On Windows support HOME environment variable

### DIFF
--- a/basis/io/files/windows/windows.factor
+++ b/basis/io/files/windows/windows.factor
@@ -379,6 +379,7 @@ M: windows open-append
 
 M: windows home
     {
+        [ "HOME" os-env ]
         [ "HOMEDRIVE" os-env "HOMEPATH" os-env append-path ]
         [ "USERPROFILE" os-env ]
         [ my-documents ]


### PR DESCRIPTION
HOMEPATH and HOMEDRIVE might be set automatically, and HOME can be used to override.
Also HOME is used by several ported commandline utilities to find configuration files.
If the user has set it, he clearly prefers it.