### PR TITLE
sequences.repeating: Fix repeat behaviour

### DIFF
--- a/extra/sequences/repeating/repeating-tests.factor
+++ b/extra/sequences/repeating/repeating-tests.factor
@@ -5,6 +5,6 @@ USING: sequences.repeating tools.test ;
 
 { { } } [ { 1 2 3 } 0 repeat ] unit-test
 { { 1 2 3 } } [ { 1 2 3 } 1 repeat ] unit-test
-{ { 1 1 2 2 3 3 } } [ { 1 2 3 } 2 repeat ] unit-test
-{ { 1 1 1 2 2 2 3 3 3 } } [ { 1 2 3 } 3 repeat ] unit-test
-{ { 1 1 1 1 2 2 2 2 3 3 3 3 } } [ { 1 2 3 } 4 repeat ] unit-test
+{ { 1 2 3 1 2 3 } } [ { 1 2 3 } 2 repeat ] unit-test
+{ { 1 2 3 1 2 3 1 2 3 } } [ { 1 2 3 } 3 repeat ] unit-test
+{ { 1 2 3 1 2 3 1 2 3 1 2 3 } } [ { 1 2 3 } 4 repeat ] unit-test

--- a/extra/sequences/repeating/repeating-tests.factor
+++ b/extra/sequences/repeating/repeating-tests.factor
@@ -3,8 +3,15 @@ USING: sequences.repeating tools.test ;
 { { 1 2 3 1 2 } } [ { 1 2 3 } 5 cycle ] unit-test
 { { 1 2 3 1 2 3 1 2 3 } } [ { 1 2 3 } 9 cycle ] unit-test
 
+{ { } } [ { 1 2 3 } 0 repeat-elements ] unit-test
+{ { 1 2 3 } } [ { 1 2 3 } 1 repeat-elements ] unit-test
+{ { 1 1 2 2 3 3 } } [ { 1 2 3 } 2 repeat-elements ] unit-test
+{ { 1 1 1 2 2 2 3 3 3 } } [ { 1 2 3 } 3 repeat-elements ] unit-test
+{ { 1 1 1 1 2 2 2 2 3 3 3 3 } } [ { 1 2 3 } 4 repeat-elements ] unit-test
+
 { { } } [ { 1 2 3 } 0 repeat ] unit-test
 { { 1 2 3 } } [ { 1 2 3 } 1 repeat ] unit-test
 { { 1 2 3 1 2 3 } } [ { 1 2 3 } 2 repeat ] unit-test
 { { 1 2 3 1 2 3 1 2 3 } } [ { 1 2 3 } 3 repeat ] unit-test
 { { 1 2 3 1 2 3 1 2 3 1 2 3 } } [ { 1 2 3 } 4 repeat ] unit-test
+

--- a/extra/sequences/repeating/repeating.factor
+++ b/extra/sequences/repeating/repeating.factor
@@ -14,6 +14,9 @@ TUPLE: cycles
 : cycle ( seq length -- new-seq )
     dupd <cycles> swap like ;
 
+: repeat ( seq times -- new-seq )
+    over length * cycle ;
+
 M: cycles length length>> ;
 
 M: cycles set-length length<< ;
@@ -24,21 +27,21 @@ M: cycles virtual-exemplar circular>> ;
 
 INSTANCE: cycles virtual-sequence
 
-TUPLE: repeats
+TUPLE: element-repeats
 { seq sequence read-only }
 { times integer read-only } ;
 
-C: <repeats> repeats
+C: <element-repeats> element-repeats
 
-M: repeats length [ seq>> length ] [ times>> ] bi * ;
+M: element-repeats length [ seq>> length ] [ times>> ] bi * ;
 
-M: repeats virtual@ [ seq>> length mod ] [ seq>> ] bi ;
+M: element-repeats virtual@ [ times>> /i ] [ seq>> ] bi ;
 
-M: repeats virtual-exemplar seq>> ;
+M: element-repeats virtual-exemplar seq>> ;
 
-INSTANCE: repeats immutable-sequence
+INSTANCE: element-repeats immutable-sequence
 
-INSTANCE: repeats virtual-sequence
+INSTANCE: element-repeats virtual-sequence
 
-: repeat ( seq times -- new-seq )
-    dupd <repeats> swap like ;
+: repeat-elements ( seq times -- new-seq )
+    dupd <element-repeats> swap like ;

--- a/extra/sequences/repeating/repeating.factor
+++ b/extra/sequences/repeating/repeating.factor
@@ -32,7 +32,7 @@ C: <repeats> repeats
 
 M: repeats length [ seq>> length ] [ times>> ] bi * ;
 
-M: repeats virtual@ [ times>> /i ] [ seq>> ] bi ;
+M: repeats virtual@ [ seq>> length mod ] [ seq>> ] bi ;
 
 M: repeats virtual-exemplar seq>> ;
 


### PR DESCRIPTION
The current behavior is confusing:

```
{ 1 2 3 } 2 repeat
{ 1 1 2 2 3 3 }
```

I propose to change it to the following, consistent with the behavior of `cycle`:

```
{ 1 2 3 } 2 repeat
{ 1 2 3 1 2 3 }
{ 1 2 3 } 6 cycle
{ 1 2 3 1 2 3 }
```