### PR TITLE
Vim highlighting update

### DIFF
--- a/misc/vim/plugin/factor.vim
+++ b/misc/vim/plugin/factor.vim
@@ -24,9 +24,9 @@ command! -bar -bang -range=1 -nargs=1 -complete=customlist,factor#complete_vocab
             \ execute factor#go_to_vocab_command(<count>,"edit<bang>",<q-args>)
 command! -bar -bang -range=1 -nargs=1 -complete=customlist,factor#complete_vocab_glob NewFactorVocab
             \ execute factor#make_vocab_command(<count>,"edit<bang>",<q-args>)
-command! FactorVocabImpl -bar :call GoToFactorVocabImpl()
-command! FactorVocabDocs -bar :call GoToFactorVocabDocs()
-command! FactorVocabTests -bar :call GoToFactorVocabTests()
+command! -bar FactorVocabImpl :call GoToFactorVocabImpl()
+command! -bar FactorVocabDocs :call GoToFactorVocabDocs()
+command! -bar FactorVocabTests :call GoToFactorVocabTests()
 
 function! FactorFileBase()
     let filename = expand('%:r')

--- a/misc/vim/syntax/factor.vim
+++ b/misc/vim/syntax/factor.vim
@@ -61,6 +61,9 @@ syn match   factorWord   /\v<\S+>/  contains=@factorWord transparent display
 syn cluster factorCluster           contains=factorWord,factorComment,factorMultilineComment,@factorClusterValue,factorDeclaration,factorCall,factorCallNextMethod,@factorWordOps,factorAlien,factorSlot,factorTuple,factorStruct
 syn cluster factorClusterValue      contains=factorBreakpoint,factorBoolean,factorFrySpecifier,factorLocalsSpecifier,factorChar,factorString,@factorNumber,factorBackslash,factorMBackslash,factorLiteral,@factorEffect,@factorQuotation,@factorArray,factorRegexp
 
+" Almost any byte in Factor can be a part of a word
+syn iskeyword 33-126,128-255
+
 " A crash course on Factor's lexer:
 "
 " The "lexer" vocabulary parses lines (arrays of strings) into tokens.


### PR DESCRIPTION
I have had some issues using the vim highlighting tools that come with Factor. I tracked those issues down to two causes: wrongly defined commands and lack of a `iskeyword` option set in the syntax definition file. These have been fixed and tested on vim 9.0.135.