### PR TITLE
Put brackets around ipv6 addresses in `inet6 present`

### DIFF
--- a/basis/io/sockets/sockets-tests.factor
+++ b/basis/io/sockets/sockets-tests.factor
@@ -37,8 +37,8 @@ os unix? [
 
 ! Test present on addrspecs
 { "4.4.4.4:12" } [ "4.4.4.4" 12 <inet4> present ] unit-test
-{ "::1:12" } [ "::1" 12 <inet6> present ] unit-test
-{ "fe80::1%1:12" } [ "fe80::1" 1 12 inet6 boa present ] unit-test
+{ "[::1]:12" } [ "::1" 12 <inet6> present ] unit-test
+{ "[fe80::1%1]:12" } [ "fe80::1" 1 12 inet6 boa present ] unit-test
 
 { B{ 1 2 3 4 } }
 [ "1.2.3.4" T{ inet4 } inet-pton ] unit-test

--- a/basis/io/sockets/sockets.factor
+++ b/basis/io/sockets/sockets.factor
@@ -214,7 +214,7 @@ M: inet6 parse-sockaddr
     [ call-next-method ] [ drop port>> ntohs ] 2bi with-port ;
 
 M: inet6 present
-    [ call-next-method ] [ port>> number>string ] bi ":" glue ;
+    [ call-next-method "[" "]" surround ] [ port>> number>string ] bi ":" glue ;
 
 M: inet6 protocol drop 0 ;
 


### PR DESCRIPTION
This disambiguates host from port. Another option is to use `.` to separate host from port for ipv6, like some netstats do.