### PR TITLE
Block caret code

### DIFF
--- a/basis/ui/gadgets/editors/editors-docs.factor
+++ b/basis/ui/gadgets/editors/editors-docs.factor
@@ -40,16 +40,15 @@ HELP: caret-is-shape
 $nl
 { $code
 "  IN: ui.gadgets.editors"
-"  2 caret-is-shape set"
+"  +box+ caret-shape set-global"
 ""
 } print-element
 $nl
 { $table
   { "Value" "Shape" }
-  { "f" "default (line)" }
-  { "0" "line" }
-  { "1" "box" }
-  { "2" "filled box" }
+  { "+line+" "line (default)" }
+  { "+box+" "box" }
+  { "+filled+" "filled box" }
 } print-element
 
 { $references   "Set desired shape in your .factor-rc file" 

--- a/basis/ui/gadgets/editors/editors-docs.factor
+++ b/basis/ui/gadgets/editors/editors-docs.factor
@@ -33,6 +33,29 @@ HELP: <editor>
 
 { editor-caret editor-mark } related-words
 
+HELP: caret-is-shape
+{ $description
+  "Shape is defined as line, box, or filled box"
+}
+$nl
+{ $code
+"  IN: ui.gadgets.editors"
+"  2 caret-is-shape set"
+""
+} print-element
+$nl
+{ $table
+  { "Value" "Shape" }
+  { "f" "default (line)" }
+  { "0" "line" }
+  { "1" "box" }
+  { "2" "filled box" }
+} print-element
+
+{ $references   "Set desired shape in your .factor-rc file" 
+ "rc-files" }
+    ;
+
 HELP: editor-caret
 { $values { "editor" editor } { "loc" "a pair of integers" } }
 { $description "Outputs the current caret location as a line/column number pair." } ;

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -8,12 +8,13 @@ models.arrow namespaces opengl opengl.gl sequences sorting
 splitting system timers ui.baseline-alignment ui.clipboards
 ui.commands ui.gadgets ui.gadgets.borders
 ui.gadgets.line-support ui.gadgets.menus ui.gadgets.scrollers
-prettyprint ui.gadgets.editors.private math.parser
+prettyprint math.parser
 ui.gestures ui.pens.solid ui.render ui.text ui.theme unicode variables ;
 IN: ui.gadgets.editors
 
 TUPLE: editor < line-gadget
     caret mark
+    caret-shape
     focused? blink blink-timer
     default-text
     preedit-start
@@ -25,8 +26,11 @@ TUPLE: editor < line-gadget
 
 M: editor preedit? preedit-start>> ;
 
-SYMBOL: caret-is-shape 
-: <caret-shape> ( -- shape )  caret-is-shape get <model> ;
+SYMBOLS: +line+ +box+ +filled+ ;
+GLOBAL: caret-is-shape 
++line+ caret-is-shape set-global
+
+: <caret-shape> ( -- shape )  caret-is-shape get-global <model> ;
 
 <PRIVATE
 
@@ -188,10 +192,10 @@ M: editor ungraft*
     (caret-location) (caret-rect) gl-fill-rect ;
 
 : draw-caret-shape ( editor -- )
-    dup caret-shape>> value>> 
+    dup caret-shape>> value>>
     {
-        { 1 [ draw-caret-rect ] }
-        { 2 [ draw-caret-rect-filled ] }
+        { +box+ [ draw-caret-rect ] }
+        { +filled+ [ draw-caret-rect-filled ] }
         [ drop  draw-caret-line ]
     } case ;
     
@@ -199,8 +203,7 @@ M: editor ungraft*
 : draw-caret ( editor -- )
     dup draw-caret? [
         [ editor-caret-color gl-color ] dip
-        [ caret-loc ] [ caret-dim ] bi
-        over v+ gl-line
+        draw-caret-shape
     ] [ drop ] if ;
 
 :: draw-preedit-underlines ( editor -- )

--- a/basis/ui/gadgets/editors/editors.factor
+++ b/basis/ui/gadgets/editors/editors.factor
@@ -8,7 +8,8 @@ models.arrow namespaces opengl opengl.gl sequences sorting
 splitting system timers ui.baseline-alignment ui.clipboards
 ui.commands ui.gadgets ui.gadgets.borders
 ui.gadgets.line-support ui.gadgets.menus ui.gadgets.scrollers
-ui.gestures ui.pens.solid ui.render ui.text ui.theme unicode ;
+prettyprint ui.gadgets.editors.private math.parser
+ui.gestures ui.pens.solid ui.render ui.text ui.theme unicode variables ;
 IN: ui.gadgets.editors
 
 TUPLE: editor < line-gadget
@@ -24,12 +25,16 @@ TUPLE: editor < line-gadget
 
 M: editor preedit? preedit-start>> ;
 
+SYMBOL: caret-is-shape 
+: <caret-shape> ( -- shape )  caret-is-shape get <model> ;
+
 <PRIVATE
 
 : <loc> ( -- loc ) { 0 0 } <model> ;
 
 : init-editor-locs ( editor -- editor )
     <loc> >>caret
+    <caret-shape> >>caret-shape
     <loc> >>mark ; inline
 
 : editor-theme ( editor -- editor )
@@ -166,6 +171,30 @@ M: editor ungraft*
 : draw-caret? ( editor -- ? )
     { [ focused?>> ] [ blink>> ]
       [ [ preedit? not ] [ preedit-selection-mode?>> not ] bi or ] } 1&& ;
+
+: (caret-location) ( editor -- loc dim )
+    [ caret-loc ] [ caret-dim ] bi ;
+
+: (caret-rect) ( dim -- newdim )
+    second [ 2 / ] keep 2array ;
+
+: draw-caret-line ( editor -- )
+    (caret-location) over v+ gl-line ;
+
+: draw-caret-rect ( editor -- )
+    (caret-location) (caret-rect) gl-rect ;
+
+: draw-caret-rect-filled ( editor -- )
+    (caret-location) (caret-rect) gl-fill-rect ;
+
+: draw-caret-shape ( editor -- )
+    dup caret-shape>> value>> 
+    {
+        { 1 [ draw-caret-rect ] }
+        { 2 [ draw-caret-rect-filled ] }
+        [ drop  draw-caret-line ]
+    } case ;
+    
 
 : draw-caret ( editor -- )
     dup draw-caret? [


### PR DESCRIPTION
Introduces 3 kinds of caret shapes: line, box, filled box

(cherry picked from commit 749ecba7c3e80891109273ff714e993afbe003c0)

# Conflicts:
#	basis/ui/gadgets/editors/editors.factor