### PR TITLE
Changed parsing to indicate nesting level during progress.

### DIFF
--- a/core/parser/parser.factor
+++ b/core/parser/parser.factor
@@ -2,9 +2,10 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays classes combinators compiler.units
 continuations definitions effects io io.encodings.utf8 io.files
-kernel lexer math.parser namespaces parser.notes quotations
+kernel lexer math math.parser namespaces parser.notes quotations
 sequences sets slots source-files vectors vocabs vocabs.parser
 words words.symbol ;
+FROM: namespaces => set ;
 IN: parser
 
 : location ( -- loc )
@@ -168,8 +169,25 @@ SYMBOL: bootstrap-syntax
         auto-used? [ print-use-hook get call( -- ) ] when
     ] with-file-vocabs ;
 
-: parsing-file ( path -- )
-    parser-quiet? get [ drop ] [ "Loading " write print flush ] if ;
+SYMBOL: parsing-file-level
+parsing-file-level [ 0 ] initialize
+
+: (parsing-file-level) ( -- string )
+    parsing-file-level get dup
+    [ "" swap <iota> [ drop "." append ] each ]
+    [ drop "" ] if
+    ;
+
+FROM: namespaces => set ; 
+: parsing-file-level++ ( -- )
+    parsing-file-level get  1 +  parsing-file-level set ;
+ 
+: parsing-file-level-- ( -- )
+      parsing-file-level get  1 -  parsing-file-level set ;
+      
+: parsing-file ( file -- )
+    parser-quiet? get [ drop ]
+    [ (parsing-file-level) "Loading " append write print flush ] if ;
 
 : filter-moved ( set1 set2 -- seq )
     swap diff members [
@@ -230,10 +248,15 @@ SYMBOL: bootstrap-syntax
     [
         [ parsing-file ] keep
         [ utf8 <file-reader> ] keep
+        parsing-file-level++
         parse-stream
-    ] [
+        parsing-file-level--
+    ] [ 
         over parse-file-restarts rethrow-restarts
-        drop parse-file
+        drop
+        parsing-file-level++
+        parse-file
+        parsing-file-level--
     ] recover ;
 
 : run-file ( path -- )

--- a/core/parser/parser.factor
+++ b/core/parser/parser.factor
@@ -3,8 +3,9 @@
 USING: accessors arrays classes combinators compiler.units
 continuations definitions effects io io.encodings.utf8 io.files
 kernel lexer math math.parser namespaces parser.notes quotations
-sequences sets slots source-files vectors vocabs vocabs.parser
-words words.symbol ;
+sequences sets slots source-files strings vectors vocabs
+vocabs.parser words words.symbol ;
+
 FROM: namespaces => set ;
 IN: parser
 
@@ -173,17 +174,15 @@ SYMBOL: parsing-file-level
 parsing-file-level [ 0 ] initialize
 
 : (parsing-file-level) ( -- string )
-    parsing-file-level get dup
-    [ "" swap <iota> [ drop "." append ] each ]
-    [ drop "" ] if
-    ;
+    parsing-file-level get
+    [ "" ] [ CHAR: . <string> ] if-zero ;
 
 FROM: namespaces => set ; 
 : parsing-file-level++ ( -- )
-    parsing-file-level get  1 +  parsing-file-level set ;
+    parsing-file-level [ 1 + ] change ;
  
 : parsing-file-level-- ( -- )
-      parsing-file-level get  1 -  parsing-file-level set ;
+    parsing-file-level [ 1 - ] change ;
       
 : parsing-file ( file -- )
     parser-quiet? get [ drop ]


### PR DESCRIPTION
Allows visual indication of nesting during load progress.

```
Loading resource:basis/ui/gadgets/packs/packs-docs.factor
Loading resource:core/generic/generic-docs.factor
Loading resource:core/classes/algebra/algebra-docs.factor
Loading resource:core/generic/hook/hook-docs.factor
Loading resource:core/generic/standard/standard-docs.factor
Loading resource:core/generic/single/single-docs.factor
Loading resource:core/generic/math/math-docs.factor
Loading resource:basis/ui/baseline-alignment/baseline-alignment-docs.factor
Loading resource:basis/delegate/delegate-docs.factor
```

Becomes 
```
Loading resource:basis/ui/gadgets/packs/packs-docs.factor
.Loading resource:core/generic/generic-docs.factor
..Loading resource:core/classes/algebra/algebra-docs.factor
..Loading resource:core/generic/hook/hook-docs.factor
...Loading resource:core/generic/standard/standard-docs.factor
....Loading resource:core/generic/single/single-docs.factor
..Loading resource:core/generic/math/math-docs.factor
.Loading resource:basis/ui/baseline-alignment/baseline-alignment-docs.factor
Loading resource:basis/delegate/delegate-docs.factor
```
(cherry picked from commit 82fcee774af0190523490577c2ae5ae054cd29e5) 