### PR TITLE
Add absolute-path to normalize any new root path. E.G. permit ~user

### DIFF
--- a/core/vocabs/loader/loader.factor
+++ b/core/vocabs/loader/loader.factor
@@ -22,7 +22,7 @@ STARTUP-HOOK: [
 ]
 
 : add-vocab-root ( root -- )
-    trim-tail-separators dup vocab-roots get ?adjoin
+    absolute-path trim-tail-separators dup vocab-roots get ?adjoin
     [ add-vocab-root-hook get-global call( root -- ) ] [ drop ] if ;
 
 SYMBOL: root-cache


### PR DESCRIPTION
User should be able to use tilde in path.