### PR TITLE
contributors: fix an alias in the list of contributors

### DIFF
--- a/extra/contributors/contributors.factor
+++ b/extra/contributors/contributors.factor
@@ -6,7 +6,7 @@ sequences sorting system ;
 IN: contributors
 
 CONSTANT: aliases {
-    { "Alexander Ilin" "ajsoft@yandex.ru" "alex.ilin@protonmail.com" }
+    { "Alexander Ilin" "Alexander Iljin" }
     { "Björn Lindqvist" "bjourne@gmail.com" }
     { "Cat Stevens" "catb0t" }
     { "Daniel Ehrenberg" "Dan Ehrenberg" }


### PR DESCRIPTION
The previous version was not working correctly.