### PR TITLE
Fix `when-empty`

### DIFF
--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -33,7 +33,7 @@ M: sequence shorten 2dup length < [ set-length ] [ 2drop ] if ; inline
 
 : when-empty ( seq quot: ( ..a -- ..b ) -- ) [ drop ] if-empty ; inline
 
-: unless-empty ( seq quot -- ) [ ] swap if-empty ; inline
+: unless-empty ( seq quot: ( ..a seq -- ..b ) -- ) [ ] swap if-empty ; inline
 
 : delete-all ( seq -- ) 0 swap set-length ;
 


### PR DESCRIPTION
According to `if-empty`, the second quotation should have effect `( ..a seq -- ..b )`, but `when-empty` supplies `[ ]`.
It should be `[ drop ]` instead.