### PR TITLE
introduce syntax.terse

### DIFF
--- a/extra/syntax/terse/authors.txt
+++ b/extra/syntax/terse/authors.txt
@@ -1,0 +1,1 @@
+Alex Maestas

--- a/extra/syntax/terse/terse.factor
+++ b/extra/syntax/terse/terse.factor
@@ -1,0 +1,10 @@
+USING: math words ;
+IN: syntax.terse
+
+! shorthand/C-like bitwise ops
+ALIAS: `& bitand
+ALIAS: `| bitor
+ALIAS: `^ bitxor
+ALIAS: `~ bitnot
+ALIAS: `<< shift
+: `>> ( x n -- x/2^n ) neg shift ; inline

--- a/misc/fuel/factor-mode.el
+++ b/misc/fuel/factor-mode.el
@@ -178,7 +178,7 @@ these lines in your .emacs:
 ;;; Regexps galore:
 
 ;; Utility regexp used by other regexps to match a Factor symbol name
-(setq-local symbol-nc "\\(?:\\sw\\|\\s_\\|\"\\|\\s(\\|\\s)\\|\\s\\\\)+")
+(setq-local symbol-nc "\\(?:\\sw\\|\\s_\\|`\\|\"\\|\\s(\\|\\s)\\|\\s\\\\)+")
 (setq-local symbol (format "\\(%s\\)" symbol-nc))
 (setq-local c-symbol-nc "\\(?:\\sw\\|\\s_\\|\\[\\|\\]\\)+")
 (setq-local c-symbol (format "\\(%s\\)" c-symbol-nc))

--- a/misc/fuel/strange-syntax.factor
+++ b/misc/fuel/strange-syntax.factor
@@ -101,3 +101,6 @@ COLOR: #ffffff COLOR: green NAN: 1234 CHAR: m ALIEN: 93
 
 PRIMITIVE: one ( a -- b )
 PRIMITIVE: two ( c -- d )
+
+: `word ( -- ) ;
+: word ( -- ) ; ! this isn't strange, just for contrast with the above


### PR DESCRIPTION
Addresses #2641; realized that `b>>` and `b<<` conflict with accessors, so changed to using backtick instead of b. 