### PR TITLE
match: Fix match-cond documentation

### DIFF
--- a/basis/match/match-docs.factor
+++ b/basis/match/match-docs.factor
@@ -15,7 +15,7 @@ HELP: match
 
 HELP: match-cond
 { $values { "assoc" "a sequence of pairs" } }
-{ $description "Calls the second quotation in the first pair whose first sequence yields a successful " { $link match } " against the top of the stack. The second quotation, when called, has the hashtable returned from the " { $link match } " call bound as the top namespace so " { $link get } " can be used to retrieve the values. A single quotation will always yield a true value. To have a fallthrough match clause use the " { $link _ } " match variable." }
+{ $description "Calls the second quotation in the first pair whose first sequence yields a successful " { $link match } " against the top of the stack. The second quotation, when called, has the hashtable returned from the " { $link match } " call bound as the top namespace so the match variables can be used to retrieve the values. A single quotation will always yield a true value. To have a fallthrough match clause use the " { $link _ } " match variable." }
 { $errors "Throws a " { $link no-match-cond } " error if none of the test quotations yield a true value." }
 { $examples
     { $code


### PR DESCRIPTION
Match vars are self-evaluating, any mention of get can be confusing.