### PR TITLE
New parser for lint.vocabs

### DIFF
--- a/extra/lint/vocabs/vocabs-docs.factor
+++ b/extra/lint/vocabs/vocabs-docs.factor
@@ -57,49 +57,6 @@ HELP: find-unused.
     }
 } ;
 
-HELP: get-imported-words
-{ $values
-    { "string" string }
-    { "hashtable" hashtable }
-}
-{ $description 
-    "Gets all words that have been imported with " { $link \ USE: } " and " { $link \ USING: } " in the given string."
-} ;
-
-HELP: get-vocabs
-{ $values
-    { "string" string }
-    { "seq" sequence }
-}
-{ $description 
-    "Gets all the vocabularies imported in the given string." 
-} ;
-
-HELP: get-words
-{ $values
-    { "name" "a vocab name string" }
-    { "assoc" assoc }
-}
-{ $description 
-    "Gets all the words used in a given vocabulary." 
-} 
-{ $examples
-    { $example "USING: lint.vocabs prettyprint ;"
-        "\"lint.vocabs\" get-words ."
-"{
-    \"lint.vocabs\"
-    {
-        \"get-vocabs\"
-        \"get-words\"
-        \"find-unused-in-file\"
-        \"get-imported-words\"
-        \"find-unused-in-string\"
-        \"find-unused.\"
-        \"find-unused\"
-    }
-}"
-    }
-} ;
 
 ARTICLE: "lint.vocabs" "The Unused Vocabulary Linter"
 "The " { $vocab-link "lint.vocabs" } " vocabulary implements a set of words designed to find unused imports."

--- a/extra/lint/vocabs/vocabs-tests.factor
+++ b/extra/lint/vocabs/vocabs-tests.factor
@@ -2,8 +2,9 @@
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors arrays assocs compiler.units continuations
 formatting hash-sets hashtables io io.encodings.utf8 io.files
-kernel namespaces regexp sequences sequences.deep sets sorting
-splitting tools.test unicode vocabs vocabs.loader ;
+kernel namespaces regexp sequences sequences.deep
+sequences.parser sets sorting splitting tools.test unicode
+vocabs vocabs.loader ;
 IN: lint.vocabs
 
 <PRIVATE
@@ -45,6 +46,18 @@ CONSTANT: ignore-char-backslash     "CHAR: \\ USING: math.functions ;"
 CONSTANT: empty-using-statement     "USING: ; nop ( -- ) ;"
 : ---- ( -- ) "-------------------------------------------------------------------------" print ;
 PRIVATE>
+
+"next-token should get the next non-blank string in the stream:" print
+{ "hello" } [ "hello world!"              <sequence-parser> next-token ] unit-test
+{ "hello" } [ "\n    hello \n world!    " <sequence-parser> next-token ] unit-test
+
+----
+
+"next-token should ignore comments:" print
+{ "world!" } [ "! hello\nworld!"                 <sequence-parser> next-token ] unit-test
+{ "world!" } [ "! h\n! e\n! l\n! l\n! o\nworld!" <sequence-parser> next-token ] unit-test
+
+----
 
 "It should work on multiple lines, with multiple imports across the file: " print
 

--- a/extra/lint/vocabs/vocabs.factor
+++ b/extra/lint/vocabs/vocabs.factor
@@ -7,12 +7,13 @@ namespaces prettyprint.backend prettyprint.sections sequences
 sequences.deep sequences.parser sets sorting splitting strings
 unicode vectors vocabs vocabs.loader vocabs.prettyprint ;
 FROM: namespaces => set ;
+FROM: sequences.parser => next advance ;
 IN: lint.vocabs
 
 <PRIVATE
 SYMBOL: old-dictionary
 SYMBOL: cache
-
+ 
 ! Words for working with the dictionary.
 : save-dictionary ( -- )
     dictionary     get clone 

--- a/extra/lint/vocabs/vocabs.factor
+++ b/extra/lint/vocabs/vocabs.factor
@@ -3,11 +3,10 @@
 USING: accessors arrays assocs combinators
 combinators.short-circuit compiler.units formatting hash-sets
 hashtables io io.encodings.utf8 io.files io.styles kernel
-namespaces prettyprint.backend prettyprint.sections sequences
-sequences.parser sets sorting strings unicode vectors vocabs
-vocabs.loader vocabs.prettyprint ;
+namespaces sequences sequences.parser sets sorting strings 
+unicode vectors vocabs vocabs.loader vocabs.prettyprint 
+vocabs.prettyprint.private ;
 FROM: namespaces => set ;
-FROM: sequences.parser => next advance ;
 IN: lint.vocabs
 
 <PRIVATE
@@ -204,16 +203,6 @@ DEFER: next-token
 
 : reject-unused-vocabs ( assoc hash-set -- seq )
     [is-used?] assoc-reject keys ;
-
-! Take this from vocabs.prettyprint.private so I'm not
-! depending on internal details of vocabs.prettyprint.
-: pprint-using ( seq -- )
-    "syntax" lookup-vocab '[ _ = ] reject
-    [ vocab-name ] sort-with [
-        \ USING: pprint-word
-        [ pprint-vocab ] each
-        \ ; pprint-word
-    ] with-pprint ;
 
 :: print-new-header ( seq -- )
     "Use the following header to remove unused imports: " print

--- a/extra/lint/vocabs/vocabs.factor
+++ b/extra/lint/vocabs/vocabs.factor
@@ -4,8 +4,8 @@ USING: accessors arrays assocs combinators
 combinators.short-circuit compiler.units formatting hash-sets
 hashtables io io.encodings.utf8 io.files io.styles kernel
 namespaces prettyprint.backend prettyprint.sections sequences
-sequences.deep sequences.parser sets sorting splitting strings
-unicode vectors vocabs vocabs.loader vocabs.prettyprint ;
+sequences.parser sets sorting strings unicode vectors vocabs
+vocabs.loader vocabs.prettyprint ;
 FROM: namespaces => set ;
 FROM: sequences.parser => next advance ;
 IN: lint.vocabs


### PR DESCRIPTION
I've updated `lint.vocabs` to use a less fragile system for parsing. It also makes the parsing process more readable than the long regexp I had. Finally, it should prevent false positives with regards to the `multiline` vocab. Some words have been removed in the refactor process. Additionally, `find-unused.` will show a new import header for the user:

![Screenshot_20221213_223840](https://user-images.githubusercontent.com/13488718/207499635-6bad3109-63ce-4177-b069-2b533b476cd4.png)
