### PR TITLE
inverse: Fix swapped + and *

### DIFF
--- a/basis/inverse/inverse-tests.factor
+++ b/basis/inverse/inverse-tests.factor
@@ -73,6 +73,9 @@ C: <nil> nil
 { 0.0 } [ 0.0 pi + [ pi + ] undo ] unit-test
 { } [ 3 [ __ ] undo ] unit-test
 
+{ 2 } [ 4 [ 2 swap + ] undo ] unit-test
+{ 2 } [ 4 [ 2 swap * ] undo ] unit-test
+
 { 2.0 } [ 2 3 ^ [ 3 ^ ] undo ] unit-test
 { 3.0 } [ 2 3 ^ [ 2 swap ^ ] undo ] unit-test
 

--- a/basis/inverse/inverse.factor
+++ b/basis/inverse/inverse.factor
@@ -155,9 +155,9 @@ ERROR: missing-literal ;
     dup { [ word? ] [ symbol? not ] } 1&&
     [ missing-literal ] when ;
 
-\ + [ - ] [ - ] define-math-inverse
+\ + [ - ] [ swap - ] define-math-inverse
 \ - [ + ] [ - ] define-math-inverse
-\ * [ / ] [ / ] define-math-inverse
+\ * [ / ] [ swap / ] define-math-inverse
 \ / [ * ] [ / ] define-math-inverse
 \ ^ [ recip ^ ] [ swap [ log ] bi@ / ] define-math-inverse
 


### PR DESCRIPTION
`2 2 *` and `2 2 swap *` evaluate to `4`. `4 [ 2 * ] undo` evaluates to `2` while `4 [ 2 swap * ] undo` evaluates to `1/2`. Similarly with `+`, where `4 [ 2 swap + ]` evaluates to `-2` instead of `2`.