### PR TITLE
ui.gestures: increase mouse wheel scroll amount

### DIFF
--- a/basis/ui/gestures/gestures.factor
+++ b/basis/ui/gestures/gestures.factor
@@ -310,7 +310,7 @@ SYMBOL: drag-timer
 
 : send-scroll ( direction loc world -- )
     move-hand
-    scroll-direction set-global
+    [ 3 * ] map scroll-direction set-global
     mouse-scroll hand-gadget get-global propagate-gesture ;
 
 : send-action ( world gesture -- )


### PR DESCRIPTION
Scrolling with the mouse wheel seems to scroll a lot less in Factor than it does in most other GUI programs. This change multiplies the scroll by 3 which makes it feel a lot closer to how scrolling works in other programs, requiring less mouse scrolling to move down a page.