### PR TITLE
Fix `read1` and `readln` in the ui.listener

### DIFF
--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -4,17 +4,18 @@ USING: accessors arrays assocs calendar combinators
 combinators.short-circuit concurrency.flags
 concurrency.mailboxes continuations destructors documents
 documents.elements fonts hashtables help help.markup help.tips
-io io.styles kernel lexer listener literals math math.vectors
-models models.arrow models.delay namespaces parser prettyprint
-sequences source-files.errors splitting strings system threads
-ui ui.commands ui.gadgets ui.gadgets.editors ui.gadgets.glass
-ui.gadgets.labeled ui.gadgets.panes ui.gadgets.scrollers
-ui.gadgets.status-bar ui.gadgets.toolbar ui.gadgets.tracks
-ui.gestures ui.operations ui.pens.solid ui.theme
-ui.tools.browser ui.tools.common ui.tools.debugger
-ui.tools.error-list ui.tools.listener.completion
-ui.tools.listener.history ui.tools.listener.popups vocabs
-vocabs.loader vocabs.parser vocabs.refresh words ;
+io io.styles kernel lexer listener listener.private literals
+math math.vectors models models.arrow models.delay namespaces
+parser prettyprint sequences source-files.errors splitting
+strings system threads ui ui.commands ui.gadgets
+ui.gadgets.editors ui.gadgets.glass ui.gadgets.labeled
+ui.gadgets.panes ui.gadgets.scrollers ui.gadgets.status-bar
+ui.gadgets.toolbar ui.gadgets.tracks ui.gestures ui.operations
+ui.pens.solid ui.theme ui.tools.browser ui.tools.common
+ui.tools.debugger ui.tools.error-list
+ui.tools.listener.completion ui.tools.listener.history
+ui.tools.listener.popups vocabs vocabs.loader vocabs.parser
+vocabs.refresh words ;
 IN: ui.tools.listener
 
 TUPLE: interactor < source-editor

--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -142,7 +142,7 @@ M: word (print-input)
     control-value rest [ { "" } ] when-empty ;
 
 : write-back-unused ( quot -- )
-    [ set-control-value ] [ model>> clear-undo drop ] tri ; inline
+    [ set-control-value ] [ model>> clear-undo ] tri ; inline
 
 : interactor-read-unsafe-finish ( n interactor -- )
     [ consume-n-chars ] write-back-unused ;

--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -437,11 +437,6 @@ MACRO: (stream-read-quot) ( q1 q2 -- quot/f )
         ] [ nip ] if 
     ] ;
 
-: handle-finish ( interactor --  )
-    +from-listener?+ get
-        [ interactor-finish        ] 
-        [ interactor-readln-finish ] if ;
-
 : step-read-quot ( interactor -- quot/f )
     [ interactor-yield ] 
     [ interactor-finish ] (stream-read-quot) ;

--- a/basis/ui/tools/listener/listener.factor
+++ b/basis/ui/tools/listener/listener.factor
@@ -147,6 +147,11 @@ M: word (print-input)
 : interactor-read-unsafe-finish ( n interactor -- )
     [ consume-n-chars ] write-back-unused ;
 
+DEFER: get-listener
+: interactor-read-until-finish ( str chr -- str chr )
+    over length 1 + get-listener input>> 
+    interactor-read-unsafe-finish ;
+
 : interactor-read1-finish ( interactor -- )
     [ consume-char ] write-back-unused ;
 
@@ -229,12 +234,13 @@ M: interactor stream-read1
 
 M: interactor stream-read-until
     swap '[
-        _ interactor-read [
+        _ yield-if-empty [
             join-lines CHAR: \n suffix
             [ _ member? ] dupd find
             [ [ head ] when* ] dip dup not
         ] [ f f f ] if*
-    ] [ drop ] produce swap [ concat "" prepend-as ] dip ;
+    ] [ drop ] produce swap [ concat "" prepend-as ] dip 
+    interactor-read-until-finish ;
 
 M: interactor dispose drop ;
 


### PR DESCRIPTION
These changes should fix `read1` and `readln` in the UI Listener. I've added specialized `interactor-read*-finish` and `interactor-read*` words to handle the actual behavior or `read1` and `readln`. This should leave any word that depends on existing implementation of `interactor-read` unchanged.

Marking this as draft as I have to make changes to `read` as well. Currently, `n read n read ...` exhibits the same bug. Should be able to apply the same fix, but I need to take a break for today. Feel free to offer feedback.