### PR TITLE
io.crlf: add use-crlf to support output streams with CRLF for EOL

### DIFF
--- a/basis/io/crlf/authors.txt
+++ b/basis/io/crlf/authors.txt
@@ -1,2 +1,3 @@
 Daniel Ehrenberg
 Slava Pestov
+Alexander Ilin

--- a/basis/io/crlf/crlf-docs.factor
+++ b/basis/io/crlf/crlf-docs.factor
@@ -1,6 +1,6 @@
-! Copyright (C) 2009 Daniel Ehrenberg
+! Copyright (C) 2009, 2023 Daniel Ehrenberg, Alexander Ilin
 ! See https://factorcode.org/license.txt for BSD license.
-USING: help.syntax help.markup sequences ;
+USING: help.syntax help.markup io sequences ;
 IN: io.crlf
 
 HELP: crlf
@@ -14,5 +14,8 @@ HELP: read-crlf
 HELP: read-?crlf
 { $values { "seq" sequence } }
 { $description "Reads until the next LF (line feed) or CRLF (carriage return followed by line feed) from the current input stream, throwing an error if CR is present without immediately being followed by LF." } ;
+
+HELP: use-crlf
+{ $description "Substitutes the current " { $link output-stream } " with a wrapper that outputs CR followed by LF for every " { $link stream-nl } " call (words like " { $link print } " and " { $link nl } " use that internally)." } ;
 
 { crlf>lf lf>crlf } related-words

--- a/basis/io/crlf/crlf-tests.factor
+++ b/basis/io/crlf/crlf-tests.factor
@@ -26,3 +26,7 @@ USING: io.crlf tools.test io.streams.string io ;
 { "abcd" } [ "a\nb\r\ncd" [ 5 read-ignoring-crlf ] with-string-reader ] unit-test
 { "abcde" } [ "a\nb\r\ncd\r\ne" [ 5 read-ignoring-crlf ] with-string-reader ] unit-test
 { "abcde" } [ "a\nb\r\ncd\r\ne\nfghi" [ 5 read-ignoring-crlf ] with-string-reader ] unit-test
+
+{ "Hello\r\nworld.\r\n" } [
+    [ use-crlf "Hello" print "world." write nl ] with-string-writer
+] unit-test

--- a/basis/io/crlf/crlf.factor
+++ b/basis/io/crlf/crlf.factor
@@ -1,7 +1,8 @@
-! Copyright (C) 2009 Daniel Ehrenberg, Slava Pestov
+! Copyright (C) 2009, 2023 Daniel Ehrenberg, Slava Pestov, Alexander Ilin
 ! See https://factorcode.org/license.txt for BSD license.
-USING: byte-vectors io io.private kernel math namespaces sbufs
-sequences splitting ;
+USING: accessors byte-vectors delegate delegate.protocols
+destructors io io.private kernel math namespaces sbufs sequences
+splitting ;
 IN: io.crlf
 
 : crlf ( -- )
@@ -61,3 +62,18 @@ IN: io.crlf
 
 : read-ignoring-crlf ( n -- seq/f )
     input-stream get stream-read-ignoring-crlf ;
+
+TUPLE: crlf-stream underlying ;
+INSTANCE: crlf-stream output-stream
+CONSULT: output-stream-protocol crlf-stream underlying>> ;
+
+C: <crlf-stream> crlf-stream
+
+M: crlf-stream dispose underlying>> dispose ;
+
+M: crlf-stream stream-nl
+    CHAR: \r over stream-write1
+    CHAR: \n swap stream-write1 ;
+
+: use-crlf ( -- )
+    output-stream [ <crlf-stream> ] change ;

--- a/basis/io/crlf/summary.txt
+++ b/basis/io/crlf/summary.txt
@@ -1,1 +1,1 @@
-Writing and reading until \r\n
+Writing with and reading until \r\n


### PR DESCRIPTION
How do you like the idea of this stream modifier?
Not sure if that's in the spirit of things, to call such a state changer function that updates the context.
I'm open to suggestions about naming of the things in this PR.

The main thing to look at here is the word `use-crlf`, which modifies the current `output-stream` by wrapping it in a class with a custom `stream-nl` method. The latter outputs CRLF.