### PR TITLE
refactor: remove duplicate word

### DIFF
--- a/core/hash-sets/hash-sets.factor
+++ b/core/hash-sets/hash-sets.factor
@@ -19,8 +19,6 @@ TUPLE: hash-set
 : probe ( array i probe# -- array i probe# )
     1 fixnum+fast [ fixnum+fast over wrap ] keep ; inline
 
-: no-key ( key array -- array n ? ) nip f f ; inline
-
 : (key@) ( key array i probe# -- array n ? )
     [ 3dup swap array-nth ] dip over +empty+ eq?
     [ 4drop no-key ] [


### PR DESCRIPTION
[no-key] already exists in hashtables.factor