### PR TITLE
arrays: add ?pair

### DIFF
--- a/core/arrays/arrays-docs.factor
+++ b/core/arrays/arrays-docs.factor
@@ -37,6 +37,8 @@ $nl
 { $subsections resize-array }
 "The class of two-element arrays:"
 { $subsections pair }
+"Conditionally creating arrays:"
+{ $subsections ?pair }
 "Arrays can be accessed without bounds checks in a pointer unsafe way."
 { $subsections "arrays-unsafe" } ;
 
@@ -78,3 +80,7 @@ HELP: resize-array
 
 HELP: pair
 { $class-description "The class of two-element arrays, known as pairs." } ;
+
+HELP: ?pair
+{ $values { "x" object } { "y" object } { "?" boolean } { "pair/f" { $maybe array } } }
+{ $description "Create a new two-element array if " { $snippet "?" } " is true, otherwise return " { $link POSTPONE: f } "." } ;

--- a/core/arrays/arrays-tests.factor
+++ b/core/arrays/arrays-tests.factor
@@ -27,3 +27,6 @@ math sequences tools.test vectors ;
 { t } [
     1 2 2array pair?
 ] unit-test
+
+{ f } [ 1 2 f ?pair ] unit-test
+{ { 1 2 } } [ 1 2 t ?pair ] unit-test

--- a/core/arrays/arrays.factor
+++ b/core/arrays/arrays.factor
@@ -27,3 +27,4 @@ INSTANCE: array sequence
 : 4array ( w x y z -- array ) { } 4sequence ; inline
 
 PREDICATE: pair < array length>> 2 number= ;
+: ?pair ( x y ? -- pair/f ) -rot 2array and ; inline


### PR DESCRIPTION
What do you think, should we add this?
Kinda belongs to the arrays vocab, but not that useful to be in the core, so I'm not sure about the placement.
This word is useful if we want to convert the result of `assoc-find` back to the pair form.