### PR TITLE
tools.scaffold: expand and document unit test scaffolding

### DIFF
--- a/basis/tools/scaffold/scaffold-docs.factor
+++ b/basis/tools/scaffold/scaffold-docs.factor
@@ -93,7 +93,7 @@ HELP: scaffold-tests
 { $values
     { "vocab" "a vocabulary specifier" }
 }
-{ $description "Takes an existing vocabulary and creates an empty tests file help for each word. This word only works if no tests file yet exists." } ;
+{ $description "Takes an existing vocabulary and creates an empty tests file. This word only works if no tests file yet exists." } ;
 
 HELP: scaffold-vocab-in
 { $values

--- a/basis/tools/scaffold/scaffold-docs.factor
+++ b/basis/tools/scaffold/scaffold-docs.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2008 Doug Coleman.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: help.markup help.syntax kernel strings words vocabs sequences ;
+USING: arrays help.markup help.syntax kernel strings words vocabs sequences ;
 IN: tools.scaffold
 
 HELP: developer-name
@@ -125,6 +125,50 @@ HELP: scaffold-rc
 HELP: using
 { $description "Stores the vocabularies that are pulled into the documentation file from looking up the stack effect types." } ;
 
+HELP: make-unit-test
+{ $values
+    { "answer" string } { "code" string }
+    { "str" string }
+}
+{ $description "Takes a code snippet and an answer string and returns a unit-test code snippet for use with " { $vocab-link "tools.test" } " vocabulary. The answer string should represent an array of values left on the stack by the code snippet." }
+{ $examples
+    { $example
+        "USING: io tools.scaffold ;"
+        "\"{ 2 2 3 }\" \"3 2 dup rot\" make-unit-test write"
+        "{ 2 2 3 } [\n    3 2 dup rot\n] unit-test"
+    }
+}
+{ $see-also read-unit-test } ;
+
+HELP: run-string
+{ $values
+    { "string" string }
+    { "datastack" array }
+}
+{ $description "Parses and executes the string on an empty datastack, returning the resulting datastack as an array." }
+{ $see-also read-unit-test } ;
+
+HELP: read-unit-test
+{ $values
+    { "str/f" { $maybe string } }
+}
+{ $description "Consumes a code snippet from input stream, runs it, and returns a unit-test code snippet for use with " { $vocab-link "tools.test" } " vocabulary. If no characters were read before the empty line returns " { $link f } " instead. On the interactive listener input is consumed until an empty line." }
+{ $see-also run-string make-unit-test scaffold-unit-tests } ;
+
+HELP: read-unit-tests
+{ $values
+    { "str" string }
+}
+{ $description "Reads code snippets by the means of " { $link read-unit-test } " until two empty lines are input. Returns them separated with two newlines." } ;
+
+HELP: scaffold-unit-tests
+{ $values
+    { "vocab" "a vocabulary specifier" }
+}
+{ $description "Takes an existing vocabulary and creates an empty test file if one isn't present yet. Reads code snippets separated by empty lines from input stream until a double empty line. After each snippet prints a unit test based on the snippet to output stream and appends it to the test file." { $nl }
+"This word enables quick creation of unit tests by recording outputs of code snippets and getting immediate feedback to fix any discrepancies as they occur." }
+{ $see-also read-unit-test } ;
+
 ARTICLE: "tools.scaffold" "Scaffold tool"
 "Scaffold setup:"
 { $subsections developer-name }
@@ -138,7 +182,7 @@ ARTICLE: "tools.scaffold" "Scaffold tool"
     scaffold-n-examples
     help.
 }
-"Types that are unrecognized by the scaffold generator will be of type " { $link null } ". The developer should change these to strings that describe the stack effect names instead." $nl
+"Types that are unrecognized by the scaffold generator will be of type " { $link object } ". The developer should change these to strings that describe the stack effect names instead." $nl
 "Scaffolding a configuration file:"
 { $subsections
     scaffold-rc
@@ -146,6 +190,12 @@ ARTICLE: "tools.scaffold" "Scaffold tool"
     scaffold-factor-rc
     scaffold-factor-roots
     scaffold-emacs
+}
+"Scaffolding a test file:"
+{ $subsections
+    scaffold-tests
+    scaffold-unit-tests
+    read-unit-test
 }
 ;
 

--- a/basis/tools/scaffold/scaffold-tests.factor
+++ b/basis/tools/scaffold/scaffold-tests.factor
@@ -4,6 +4,7 @@ USING: help.markup io.streams.string kernel sequences
 tools.scaffold tools.scaffold.private tools.test unicode ;
 IN: tools.scaffold.tests
 
+
 : undocumented-word ( obj1 obj2 -- obj3 obj4 )
     [ >lower ] [ >upper ] bi* ;
 
@@ -23,7 +24,8 @@ IN: tools.scaffold.tests
 {
 "HELP: iota
 { $class-description \"\" } ;
-" }
+"
+}
 [
     [ \ iota scaffold-word-docs ] with-string-writer
 ] unit-test
@@ -37,4 +39,14 @@ IN: tools.scaffold.tests
 
 : test-maybe ( obj -- obj/f ) ;
 
-{ } [ \ test-maybe scaffold-word-docs ] unit-test
+{
+"HELP: test-maybe
+{ $values
+    { \"obj\" object }
+    { \"obj/f\" { $maybe object } }
+}
+{ $description \"\" } ;
+"
+}
+[ [ \ test-maybe scaffold-word-docs ] with-string-writer ]
+unit-test

--- a/basis/tools/scaffold/scaffold-tests.factor
+++ b/basis/tools/scaffold/scaffold-tests.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2009 Doug Coleman.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: help.markup io.streams.string kernel sequences
+USING: help.markup io.streams.string kernel math sequences
 tools.scaffold tools.scaffold.private tools.test unicode ;
 IN: tools.scaffold.tests
 
@@ -50,3 +50,31 @@ IN: tools.scaffold.tests
 }
 [ [ \ test-maybe scaffold-word-docs ] with-string-writer ]
 unit-test
+
+
+{ "{ \"foofoo\" } [\n    \"foo\" dup append\n] unit-test\n" } [
+    "\"foo\" dup append" [ read-unit-test ] with-string-reader
+] unit-test
+
+
+{
+    "{\n    \"foobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbazfoobarbaz\"\n} [\n    \"foobarbaz\" 3 [ dup append ] times\n] unit-test\n"
+} [
+    "\"foobarbaz\" 3 [ dup append ] times"
+    [ read-unit-test ] with-string-reader
+] unit-test
+
+
+{ "foobar [\n    baz\n] unit-test\n" } [
+    "foobar" "baz" make-unit-test
+] unit-test
+
+
+{ "foobar [\n    foz\n    baz\n] unit-test\n" } [
+    "foobar" "foz\nbaz" make-unit-test
+] unit-test
+
+
+{ { 2 } } [
+    "2 1 + 3 * 7 -" run-string
+] unit-test

--- a/basis/tools/scaffold/scaffold.factor
+++ b/basis/tools/scaffold/scaffold.factor
@@ -5,9 +5,9 @@ classes classes.error combinators combinators.short-circuit
 continuations effects eval hashtables help.markup interpolate io
 io.directories io.encodings.utf8 io.files io.pathnames
 io.streams.string kernel math math.parser namespaces prettyprint
-quotations sequences sets sorting splitting strings system
-timers unicode urls vocabs vocabs.loader vocabs.metadata words
-words.symbol ;
+prettyprint.config quotations sequences sets sorting splitting
+strings system timers unicode urls vocabs vocabs.loader
+vocabs.metadata words words.symbol ;
 IN: tools.scaffold
 
 SYMBOL: developer-name
@@ -341,11 +341,13 @@ M: word scaffold-docs scaffold-word-docs ;
 : set-scaffold-tests-file ( vocab path -- )
     [ tests-file-string ] dip utf8 set-file-contents ;
 
+: vocab>test-path ( vocab -- string )
+    "-tests.factor" vocab/suffix>path ;
+
 PRIVATE>
 
 : scaffold-tests ( vocab -- )
-    ensure-vocab-exists
-    dup "-tests.factor" vocab/suffix>path
+    ensure-vocab-exists dup vocab>test-path
     scaffolding? [
         set-scaffold-tests-file
     ] [
@@ -409,16 +411,22 @@ ${example-indent}}
 : run-string ( string -- datastack )
     parse-string V{ } clone swap with-datastack ; inline
 
-: scaffold-unit-test ( -- str/f )
+: read-unit-test ( -- str/f )
     read-contents dup "" = [
         drop f
     ] [
-        [ run-string unparse ] keep
+        [ run-string [ unparse ] without-limits ] keep
         make-unit-test
     ] if ;
 
-: scaffold-unit-tests ( -- str )
-    [ scaffold-unit-test dup ] [ ] produce nip "\n\n" join ;
+: read-unit-tests ( -- str )
+    [ read-unit-test dup ] [ ] produce nip "\n\n" join ;
+
+: scaffold-unit-tests ( vocab -- )
+    dup scaffold-tests vocab>test-path
+    [ read-unit-test ]
+    [ dup print "\n\n" prepend
+        over utf8 [ write ] with-file-appender ] while* drop ;
 
 HOOK: scaffold-emacs os ( -- )
 


### PR DESCRIPTION
As discussed on discord.
Changes:
- renamed `scaffold-unit-test` and `scaffold-unit-tests` to `read-unit-test` and `read-unit-tests`
- `read-unit-test` now uses `without-limits` for `unparse`
- added a new `scaffold-unit-tests` with expanded interactivity and adding tests directly to the appropriate test file
- documented test scaffolding words
- added unit tests for most test scaffolding words