### PR TITLE
Fix for local definitions

### DIFF
--- a/basis/bootstrap/image/image.factor
+++ b/basis/bootstrap/image/image.factor
@@ -6,7 +6,7 @@ classes.tuple.private combinators combinators.short-circuit
 combinators.smart command-line compiler.codegen.relocation
 compiler.units endian generic generic.single.private grouping
 hashtables hashtables.private io io.encodings.binary io.files
-io.pathnames kernel kernel.private layouts make math
+io.pathnames kernel kernel.private layouts locals.types make math
 math.bitwise math.order namespaces namespaces.private parser
 parser.notes prettyprint quotations sequences sequences.private
 source-files splitting strings system vectors vocabs words ;
@@ -474,6 +474,9 @@ M: quotation prepare-object
 : emit-special-objects ( -- )
     special-objects get [ swap emit-special-object ] assoc-each ;
 
+: emit-locals ( -- )
+    bootstrapping-image get [ dup local? [ emit-word ] [ drop ] if ] each ;
+
 : fixup-header ( -- )
     heap-size data-heap-size-offset fixup ;
 
@@ -508,7 +511,7 @@ M: quotation prepare-object
     "Serializing special object table..." print flush
     emit-special-objects
     "Performing word fixups..." print flush
-    fixup-words
+    emit-locals fixup-words
     "Performing header fixups..." print flush
     fixup-header
     "Image length: " write bootstrapping-image get length .


### PR DESCRIPTION
Due to locals storing their original definition (which includes many otherwise undefined words) under a `lambda` prop, using any local words in core would cause `make-my-image` to crash.

This solves that by properly emitting all the `local?` words it finds. There might be a better place to emit these words, but this seemed the cleanest and most direct. It also seems to work, which is a bonus.

I should note however that I am not very familiar with how images work, and so I am not 100% sure of the implications of this change...

This change was motivated by [this PR](https://github.com/factor/factor/pull/2851) which utilizes a locals word.