### PR TITLE
Raylib update bindings and add RLGL bindings

### DIFF
--- a/extra/raylib/raylib.factor
+++ b/extra/raylib/raylib.factor
@@ -25,7 +25,7 @@ LIBRARY: raylib
 CONSTANT: RAYLIB_VERSION_MAJOR 4
 CONSTANT: RAYLIB_VERSION_MINOR 5
 CONSTANT: RAYLIB_VERSION_PATCH 0
-CONSTANT: RAYLIB_VERSION  "4.5-dev"
+CONSTANT: RAYLIB_VERSION  "4.5"
 
 ! Enumerations ---------------------------------------------------------
 
@@ -688,7 +688,9 @@ STRUCT: VrStereoConfig
 STRUCT: FilePathList
     { capacity uint }                 ! Filepaths max entries
     { count uint }                    ! Filepaths entries count
-    { paths char** } ;                ! Filepaths entries
+    { _paths c-string* } ;             ! Filepaths entries
+
+ARRAY-SLOT: FilePathList c-string _paths [ count>> ] paths
 
 ! Constants ----------------------------------------------------------------
 
@@ -741,6 +743,7 @@ FUNCTION-ALIAS: maximize-window void MaximizeWindow ( )                         
 FUNCTION-ALIAS: minimize-window void MinimizeWindow ( )                                  ! Set window state: minimized, if resizable (only PLATFORM_DESKTOP)
 FUNCTION-ALIAS: restore-window void RestoreWindow ( )                                    ! Set window state: not minimized/maximized (only PLATFORM_DESKTOP)
 FUNCTION-ALIAS: set-window-icon void SetWindowIcon ( Image image )                       ! Set icon for window (only PLATFORM_DESKTOP)
+FUNCTION-ALIAS: set-window-icons void SetWindowIcons ( Image* images, int count )
 FUNCTION-ALIAS: set-window-title void SetWindowTitle ( c-string title )                  ! Set title for window (only PLATFORM_DESKTOP)
 FUNCTION-ALIAS: set-window-position void SetWindowPosition ( int x, int y )              ! Set window position on screen (only PLATFORM_DESKTOP)
 FUNCTION-ALIAS: set-window-monitor void SetWindowMonitor ( int monitor )                 ! Set monitor for the current window (fullscreen mode)
@@ -811,6 +814,7 @@ FUNCTION-ALIAS: unload-vr-stereo-config void UnloadVrStereoConfig ( VrStereoConf
 ! NOTE: Shader functionality is not available on OpenGL 1.1
 FUNCTION-ALIAS: load-shader Shader LoadShader ( c-string vsFileName, c-string fsFileName )                                       ! Load shader from files and bind default locations
 FUNCTION-ALIAS: load-shader-from-memory Shader LoadShaderFromMemory ( c-string vsCode, c-string fsCode )                         ! Load shader from code strings and bind default locations
+FUNCTION-ALIAS: is-shader-ready bool IsShaderReady ( Shader shader )                                                             ! Check if a shader is ready
 FUNCTION-ALIAS: get-shader-location int GetShaderLocation ( Shader shader, c-string uniformName )                                ! Get shader uniform location
 FUNCTION-ALIAS: get-shader-location-attrib int GetShaderLocationAttrib ( Shader shader, c-string attribName )                    ! Get shader attribute location
 FUNCTION-ALIAS: set-shader-value void SetShaderValue ( Shader shader, int locIndex, void* value, ShaderUniformDataType uniformType ) ! Set shader uniform value
@@ -824,8 +828,8 @@ FUNCTION-ALIAS: get-mouse-ray Ray GetMouseRay ( Vector2 mousePosition, Camera ca
 FUNCTION-ALIAS: get-camera-matrix Matrix GetCameraMatrix ( Camera camera )                                                    ! Get camera transform matrix (view matrix)
 FUNCTION-ALIAS: get-camera-matrix-2d Matrix GetCameraMatrix2D ( Camera2D camera )                                             ! Get camera 2d transform matrix
 FUNCTION-ALIAS: get-world-to-screen Vector2 GetWorldToScreen ( Vector3 position, Camera camera )                              ! Get the screen space position for a 3d world space position
-FUNCTION-ALIAS: get-world-to-screen-ex Vector2 GetWorldToScreenEx ( Vector3 position, Camera camera, int width, int height )  ! Get size position for a 3d world space position
 FUNCTION-ALIAS: get-world-to-screen-2d Vector2 GetWorldToScreen2D ( Vector2 position, Camera2D camera )                       ! Get the screen space position for a 2d camera world space position
+FUNCTION-ALIAS: get-world-to-screen-ex Vector2 GetWorldToScreenEx ( Vector3 position, Camera camera, int width, int height )  ! Get size position for a 3d world space position
 FUNCTION-ALIAS: get-screen-to-world-2d Vector2 GetScreenToWorld2D ( Vector2 position, Camera2D camera )                       ! Get the world space position for a 2d camera screen space position
 
 ! Timing-related functions
@@ -877,19 +881,19 @@ FUNCTION-ALIAS: get-working-directory c-string GetWorkingDirectory ( )          
 FUNCTION-ALIAS: get-application-directory c-string GetApplicationDirectory ( )                        ! Get the directory if the running application (uses static string)
 FUNCTION-ALIAS: change-directory bool ChangeDirectory ( c-string dir )                                ! Change working directory, return true on success
 FUNCTION-ALIAS: is-path-file bool IsPathFile ( c-string path )                                        ! Check if a given path is a file or a directory
-FUNCTION-ALIAS: load-directory-files char** LoadDirectoryFiles ( c-string dirPath, int* count )       ! Get filenames in a directory path (memory should be freed)
-FUNCTION-ALIAS: load-directory-files-ex char** LoadDirectoryFilesEx ( c-string dirPath, c-string filter, bool scanSubDirs )       ! Get filenames in a directory path (memory should be freed)
-FUNCTION-ALIAS: unload-directory-files void UnloadDirectoryFiles ( )                                  ! Clear directory files paths buffers (free memory)
+FUNCTION-ALIAS: load-directory-files FilePathList LoadDirectoryFiles ( c-string dirPath )       ! Get filenames in a directory path (memory should be freed)
+FUNCTION-ALIAS: load-directory-files-ex FilePathList LoadDirectoryFilesEx ( c-string dirPath, c-string filter, bool scanSubDirs )       ! Get filenames in a directory path (memory should be freed)
+FUNCTION-ALIAS: unload-directory-files void UnloadDirectoryFiles ( FilePathList files )               ! Clear directory files paths buffers (free memory)
 FUNCTION-ALIAS: is-file-dropped bool IsFileDropped ( )                                                ! Check if a file has been dropped into window
-FUNCTION-ALIAS: load-dropped-files c-string* LoadDroppedFiles ( int* count )                          ! Get dropped files names (memory should be freed)
-FUNCTION-ALIAS: unload-dropped-files void UnloadDroppedFiles ( )                                      ! Clear dropped files paths buffer (free memory)
+FUNCTION-ALIAS: load-dropped-files FilePathList LoadDroppedFiles ( )                          ! Get dropped files names (memory should be freed)
+FUNCTION-ALIAS: unload-dropped-files void UnloadDroppedFiles ( FilePathList files )                                      ! Clear dropped files paths buffer (free memory)
 FUNCTION-ALIAS: get-file-mod-time long GetFileModTime ( c-string fileName )                           ! Get file modification time (last write time)
 
 ! Compression/Encoding functionality
-FUNCTION-ALIAS: compress-data uchar* CompressData ( uchar* data, int dataLength, int* compDataLength )         ! Compress data (DEFLATE algorithm)
-FUNCTION-ALIAS: decompress-data uchar* DecompressData ( uchar* compData, int compDataLength, int* dataLength ) ! Decompress data (DEFLATE algorithm)
-FUNCTION-ALIAS: encode-data-base64 uchar* EncodeDataBase64 ( uchar* data, int dataLength, int* outputLength )  ! Encode data to Base64 string
-FUNCTION-ALIAS: decode-data-base64 uchar* DecodeDataBase64 ( uchar* data, int* outputLength )                  ! Decode Base64 string data
+FUNCTION-ALIAS: compress-data uchar* CompressData ( uchar* data, int dataLength, int* compDataLength )          ! Compress data (DEFLATE algorithm)
+FUNCTION-ALIAS: decompress-data uchar* DecompressData ( uchar* compData, int compDataLength, int* dataLength )  ! Decompress data (DEFLATE algorithm)
+FUNCTION-ALIAS: encode-data-base64 c-string EncodeDataBase64 ( uchar* data, int dataLength, int* outputLength ) ! Encode data to Base64 string
+FUNCTION-ALIAS: decode-data-base64 uchar* DecodeDataBase64 ( uchar* data, int* outputLength )                   ! Decode Base64 string data
 
 ! ------------------------------------------------------------------------------------
 ! Input Handling Functions (Module: core)
@@ -1029,6 +1033,7 @@ FUNCTION-ALIAS: load-image-anim Image LoadImageAnim ( c-string fileName, int* fr
 FUNCTION-ALIAS: load-image-from-memory Image LoadImageFromMemory ( c-string fileType, c-string fileData, int dataSize )          ! Load image from memory buffer, fileType refers to extension: i.e. '.png'
 FUNCTION-ALIAS: load-image-from-texture Image LoadImageFromTexture ( Texture2D texture )                                         ! Load image from GPU texture data
 FUNCTION-ALIAS: load-image-from-screen Image LoadImageFromScreen ( )                                                             ! Load image from screen buffer and (screenshot)
+FUNCTION-ALIAS: is-image-ready bool IsImageReady ( Image image )                                                                 ! Check if an image is ready
 FUNCTION-ALIAS: unload-image void UnloadImage ( Image image )                                                                    ! Unload image from CPU memory (RAM)
 FUNCTION-ALIAS: export-image bool ExportImage ( Image image, c-string fileName )                                                 ! Export image data to file, returns true on success
 FUNCTION-ALIAS: export-image-as-code bool ExportImageAsCode ( Image image, c-string fileName )                                   ! Export image as code file defining an array of bytes, returns true on success
@@ -1104,7 +1109,9 @@ FUNCTION-ALIAS: load-texture Texture2D LoadTexture ( c-string fileName )        
 FUNCTION-ALIAS: load-texture-from-image Texture2D LoadTextureFromImage ( Image image )                                           ! Load texture from image data
 FUNCTION-ALIAS: load-texture-cubemap TextureCubemap LoadTextureCubemap ( Image image, CubemapLayout layout )                     ! Load cubemap from image, multiple image cubemap layouts supported
 FUNCTION-ALIAS: load-render-texture RenderTexture2D LoadRenderTexture ( int width, int height )                                  ! Load texture for rendering (framebuffer)
+FUNCTION-ALIAS: is-texture-ready bool IsTextureReady ( Texture2D texture )                                                            ! Check if a texture is ready
 FUNCTION-ALIAS: unload-texture void UnloadTexture ( Texture2D texture )                                                          ! Unload texture from GPU memory (VRAM)
+FUNCTION-ALIAS: is-render-texture-ready void IsRenderTextureReady ( RenderTexture2D target )                                     ! Check if a render texture is ready
 FUNCTION-ALIAS: unload-render-texture void UnloadRenderTexture ( RenderTexture2D target )                                        ! Unload render texture from GPU memory (VRAM)
 FUNCTION-ALIAS: update-texture void UpdateTexture ( Texture2D texture, void* pixels )                                            ! Update GPU texture with new data
 FUNCTION-ALIAS: update-texture-rec void UpdateTextureRec ( Texture2D texture, Rectangle rec, void* pixels )                      ! Update GPU texture rectangle with new data
@@ -1119,11 +1126,8 @@ FUNCTION-ALIAS: draw-texture void DrawTexture ( Texture2D texture, int posX, int
 FUNCTION-ALIAS: draw-texture-v void DrawTextureV ( Texture2D texture, Vector2 position, Color tint )                             ! Draw a Texture2D with position defined as Vector2
 FUNCTION-ALIAS: draw-texture-ex void DrawTextureEx ( Texture2D texture, Vector2 position, float rotation, float scale, Color tint ) ! Draw a Texture2D with extended parameters
 FUNCTION-ALIAS: draw-texture-rec void DrawTextureRec ( Texture2D texture, Rectangle source, Vector2 position, Color tint )       ! Draw a part of a texture defined by a rectangle
-! FUNCTION-ALIAS: draw-texture-quad void DrawTextureQuad ( Texture2D texture, Vector2 tiling, Vector2 offset, Rectangle quad, Color tint ) ! Draw texture quad with tiling and offset parameters
-! FUNCTION-ALIAS: draw-texture-tiled void DrawTextureTiled ( Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, float scale, Color tint ) ! Draw part of a texture (defined by a rectangle) with rotation and scale tiled into dest.
 FUNCTION-ALIAS: draw-texture-pro void DrawTexturePro ( Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, Color tint ) ! Draw a part of a texture defined by a rectangle with 'pro' parameters
 FUNCTION-ALIAS: draw-texture-npatch void DrawTextureNPatch ( Texture2D texture, NPatchInfo nPatchInfo, Rectangle dest, Vector2 origin, float rotation, Color tint ) ! Draws a texture (or part of it) that stretches or shrinks nicely
-! FUNCTION-ALIAS: draw-texture-poly void DrawTexturePoly ( Texture2D texture, Vector2 center, Vector2* points, Vector2* texcoords, int pointCount, Color tint ) ! Draw a textured polygon
 
 ! Color/pixel related functions
 FUNCTION-ALIAS: fade Color Fade ( Color color, float alpha )                                   ! Get color with alpha applied, alpha goes from 0.0f to 1.0f
@@ -1152,6 +1156,7 @@ FUNCTION-ALIAS: load-font Font LoadFont ( c-string fileName )                   
 FUNCTION-ALIAS: load-font-ex Font LoadFontEx ( c-string fileName, int fontSize, int* fontChars, int glyphCount )     ! Load font from file with extended parameters, use NULL for fontChars and 0 for glyphCount to load the default character set
 FUNCTION-ALIAS: load-font-from-image Font LoadFontFromImage ( Image image, Color key, int firstChar )                ! Load font from Image (XNA style)
 FUNCTION-ALIAS: load-font-from-memory Font LoadFontFromMemory ( c-string fileType, c-string fileData, int dataSize, int fontSize, int* fontChars, int glyphCount )  ! Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
+FUNCTION-ALIAS: is-font-ready bool IsFontReady ( Font font )                                                         ! Check if a font is ready
 FUNCTION-ALIAS: load-font-data GlyphInfo* LoadFontData ( c-string  fileData, int dataSize, int fontSize, int* fontChars, int glyphCount, FontType type )  ! Load font data for further use
 FUNCTION-ALIAS: gen-image-font-atlas Image GenImageFontAtlas ( GlyphInfo* chars, Rectangle** recs, int glyphCount, int fontSize, int padding, int packMethod )  ! Generate image font atlas using chars info
 FUNCTION-ALIAS: unload-font-data void UnloadFontData ( GlyphInfo* chars, int glyphCount )                            ! Unload font chars info data (RAM)
@@ -1188,7 +1193,7 @@ FUNCTION-ALIAS: codepoint-to-utf8 c-string CodepointToUTF8 ( int codepoint, int*
 ! NOTE: Some strings allocate memory internally for returned strings, just be careful!
 FUNCTION-ALIAS: text-copy int TextCopy ( c-string  dst, c-string src )                                ! Copy one string to another, returns bytes copied
 FUNCTION-ALIAS: text-is-equal bool TextIsEqual ( c-string text1, c-string text2 )                     ! Check if two text string are equal
-FUNCTION-ALIAS: text-length uint TextLength ( c-string text )                                         ! Get text length, checks for ' ' ending
+FUNCTION-ALIAS: text-length uint TextLength ( c-string text )                                         ! Get text length, checks for '\0' ending
 ! FUNCTION: c-string TextFormat ( c-string text, ... )                                                  ! Text formatting with variables (sprintf() style)
 FUNCTION-ALIAS: text-subtext c-string TextSubtext ( c-string text, int position, int length )         ! Get a piece of a text string
 FUNCTION-ALIAS: text-replace c-string TextReplace ( c-string  text, c-string replace, c-string by )   ! Replace text string (WARNING: memory must be freed!)
@@ -1216,8 +1221,6 @@ FUNCTION-ALIAS: draw-cube void DrawCube ( Vector3 position, float width, float h
 FUNCTION-ALIAS: draw-cube-v void DrawCubeV ( Vector3 position, Vector3 size, Color color )            ! Draw cube (Vector version)
 FUNCTION-ALIAS: draw-cube-wires void DrawCubeWires ( Vector3 position, float width, float height, float length, Color color ) ! Draw cube wires
 FUNCTION-ALIAS: draw-cube-wires-v void DrawCubeWiresV ( Vector3 position, Vector3 size, Color color ) ! Draw cube wires (Vector version)
-! FUNCTION-ALIAS: draw-cube-texture void DrawCubeTexture ( Texture2D texture, Vector3 position, float width, float height, float length, Color color )  ! Draw cube textured
-! FUNCTION-ALIAS: draw-cube-texture-rec void DrawCubeTextureRec ( Texture2D texture, Rectangle source, Vector3 position, float width, float height, float length, Color color )  ! Draw cube with a region of a texture
 FUNCTION-ALIAS: draw-sphere void DrawSphere ( Vector3 centerPos, float radius, Color color )          ! Draw sphere
 FUNCTION-ALIAS: draw-sphere-ex void DrawSphereEx ( Vector3 centerPos, float radius, int rings, int slices, Color color ) ! Draw sphere with extended parameters
 FUNCTION-ALIAS: draw-sphere-wires void DrawSphereWires ( Vector3 centerPos, float radius, int rings, int slices, Color color ) ! Draw sphere wires
@@ -1238,8 +1241,8 @@ FUNCTION-ALIAS: draw-grid void DrawGrid ( int slices, float spacing )           
 ! Model management functions
 FUNCTION-ALIAS: load-model Model LoadModel ( c-string fileName )                                      ! Load model from files (meshes and materials)
 FUNCTION-ALIAS: load-model-from-mesh Model LoadModelFromMesh ( Mesh mesh )                            ! Load model from generated mesh (default material)
+FUNCTION-ALIAS: is-model-ready bool IsModelReady ( Model model )                                      ! Check if a model is ready
 FUNCTION-ALIAS: unload-model void UnloadModel ( Model model )                                         ! Unload model (including meshes) from memory (RAM and/or VRAM)
-FUNCTION-ALIAS: unload-model-keep-meshes void UnloadModelKeepMeshes ( Model model )                   ! Unload model (but not meshes) from memory (RAM and/or VRAM)
 FUNCTION-ALIAS: get-model-bounding-box BoundingBox GetModelBoundingBox ( Model model )                ! Compute model bounding box limits (considers all meshes)
 
 ! Model drawing functions
@@ -1278,6 +1281,7 @@ FUNCTION-ALIAS: gen-mesh-cubicmap Mesh GenMeshCubicmap ( Image cubicmap, Vector3
 ! Material loading/unloading functions
 FUNCTION-ALIAS: load-materials Material* LoadMaterials ( c-string fileName, int* materialCount )      ! Load materials from model file
 FUNCTION-ALIAS: load-material-default Material LoadMaterialDefault ( )                                ! Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
+FUNCTION-ALIAS: is-material-ready bool IsMaterialReady ( Material material )                          ! check if a material is ready
 FUNCTION-ALIAS: unload-material void UnloadMaterial ( Material material )                             ! Unload material from GPU memory (VRAM)
 FUNCTION-ALIAS: set-material-texture void SetMaterialTexture ( Material* material, int mapType, Texture2D texture ) ! Set texture for a material map type  ( Material_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
 FUNCTION-ALIAS: set-model-mesh-material void SetModelMeshMaterial ( Model* model, int meshId, int materialId ) ! Set material for a mesh
@@ -1348,8 +1352,10 @@ FUNCTION-ALIAS: set-master-volume void SetMasterVolume ( float volume )         
 ! Wave/Sound loading/unloading functions
 FUNCTION-ALIAS: load-wave Wave LoadWave ( c-string fileName )                                   ! Load wave data from file
 FUNCTION-ALIAS: load-wave-from-memory Wave LoadWaveFromMemory ( c-string fileType, c-string fileData, int dataSize )  ! Load wave from memory buffer, fileType refers to extension: i.e. '.wav'
+FUNCTION-ALIAS: is-wave-ready bool IsWaveReady ( Wave wave )                                    ! Checks if wave data is ready
 FUNCTION-ALIAS: load-sound Sound LoadSound ( c-string fileName )                                ! Load sound from file
 FUNCTION-ALIAS: load-sound-from-wave Sound LoadSoundFromWave ( Wave wave )                      ! Load sound from wave data
+FUNCTION-ALIAS: is-sound-ready bool IsSoundReady ( Sound sound )                                ! Checks if a sound is ready
 FUNCTION-ALIAS: update-sound void UpdateSound ( Sound sound, void* data, int sampleCount )      ! Update sound buffer with new data
 FUNCTION-ALIAS: unload-wave void UnloadWave ( Wave wave )                                       ! Unload wave data
 FUNCTION-ALIAS: unload-sound void UnloadSound ( Sound sound )                                   ! Unload sound
@@ -1361,22 +1367,20 @@ FUNCTION-ALIAS: play-sound void PlaySound ( Sound sound )                       
 FUNCTION-ALIAS: stop-sound void StopSound ( Sound sound )                                       ! Stop playing a sound
 FUNCTION-ALIAS: pause-sound void PauseSound ( Sound sound )                                     ! Pause a sound
 FUNCTION-ALIAS: resume-sound void ResumeSound ( Sound sound )                                   ! Resume a paused sound
-FUNCTION-ALIAS: play-sound-multi void PlaySoundMulti ( Sound sound )                            ! Play a sound (using multichannel buffer pool)
-FUNCTION-ALIAS: stop-sound-multi void StopSoundMulti ( )                                        ! Stop any sound playing (using multichannel buffer pool)
-FUNCTION-ALIAS: get-sounds-playing int GetSoundsPlaying ( )                                     ! Get number of sounds playing in the multichannel
 FUNCTION-ALIAS: is-sound-playing bool IsSoundPlaying ( Sound sound )                            ! Check if a sound is currently playing
 FUNCTION-ALIAS: set-sound-volume void SetSoundVolume ( Sound sound, float volume )              ! Set volume for a sound (1.0 is max level)
 FUNCTION-ALIAS: set-sound-pitch void SetSoundPitch ( Sound sound, float pitch )                 ! Set pitch for a sound (1.0 is base level)
 FUNCTION-ALIAS: set-sound-pan void SetSoundPan ( Sound sound, float pan )                       ! Set pan for a sound (0.5 is center)
-FUNCTION-ALIAS: wave-format void WaveFormat ( Wave* wave, int sampleRate, int sampleSize, int channels ) ! Convert wave data to desired format
 FUNCTION-ALIAS: wave-copy Wave WaveCopy ( Wave wave )                                           ! Copy a wave to a new wave
 FUNCTION-ALIAS: wave-crop void WaveCrop ( Wave* wave, int initSample, int finalSample )         ! Crop a wave to defined samples range
+FUNCTION-ALIAS: wave-format void WaveFormat ( Wave* wave, int sampleRate, int sampleSize, int channels ) ! Convert wave data to desired format
 FUNCTION-ALIAS: load-wave-samples float* LoadWaveSamples ( Wave wave )                          ! Load samples data from wave as a floats array
 FUNCTION-ALIAS: unload-wave-samples void UnloadWaveSamples ( float* samples )                   ! Unload samples data loaded with LoadWaveSamples()
 
 ! Music management functions
 FUNCTION-ALIAS: load-music-stream Music LoadMusicStream ( c-string fileName )                   ! Load music stream from file
 FUNCTION-ALIAS: load-music-stream-from-memory Music LoadMusicStreamFromMemory ( c-string fileType, c-string data, int dataSize ) ! Load music stream from data
+FUNCTION-ALIAS: is-music-ready bool IsMusicReady ( Music music )                                ! Checks if a music stream is ready
 FUNCTION-ALIAS: unload-music-stream void UnloadMusicStream ( Music music )                      ! Unload music stream
 FUNCTION-ALIAS: play-music-stream void PlayMusicStream ( Music music )                          ! Start music playing
 FUNCTION-ALIAS: is-music-stream-playing bool IsMusicStreamPlaying ( Music music )               ! Check if music is playing
@@ -1393,6 +1397,7 @@ FUNCTION-ALIAS: get-music-time-played float GetMusicTimePlayed ( Music music )  
 
 ! AudioStream management functions
 FUNCTION-ALIAS: load-audio-stream AudioStream LoadAudioStream ( uint sampleRate, uint sampleSize, uint channels ) ! Load audio stream (to stream raw audio pcm data)
+FUNCTION-ALIAS: is-audio-stream-ready AudioStream IsAudioStreamReady ( AudioStream stream )                       ! Checks if an audio stream is ready
 FUNCTION-ALIAS: unload-audio-stream void UnloadAudioStream ( AudioStream stream )                                 ! Unload audio stream and free memory
 FUNCTION-ALIAS: update-audio-stream void UpdateAudioStream ( AudioStream stream, void* data, int frameCount )     ! Update audio stream buffers with data
 FUNCTION-ALIAS: is-audio-stream-processed bool IsAudioStreamProcessed ( AudioStream stream )                      ! Check if any audio stream buffers requires refill
@@ -1406,8 +1411,12 @@ FUNCTION-ALIAS: set-audio-stream-pitch void SetAudioStreamPitch ( AudioStream st
 FUNCTION-ALIAS: set-audio-stream-pan void SetAudioStreamPan ( AudioStream stream, float pan )                     ! Set pan for audio stream (0.5 is center)
 FUNCTION-ALIAS: set-audio-stream-buffer-size-default void SetAudioStreamBufferSizeDefault ( int size )            ! Default size for new audio streams
 FUNCTION-ALIAS: set-audio-stream-callback void SetAudioStreamCallback ( AudioStream stream, AudioCallback callback ) ! Audio thread callback to request new data
+
 FUNCTION-ALIAS: attach-audio-stream-processor void AttachAudioStreamProcessor ( AudioStream stream, AudioCallback processor ) ! Attach audio stream processor to stream
 FUNCTION-ALIAS: detach-audio-stream-processor void DetachAudioStreamProcessor ( AudioStream stream, AudioCallback processor ) ! Detach audio stream processor from stream
+
+FUNCTION-ALIAS: attach-audio-mixed-processor void AttachAudioMixedProcessor ( AudioCallback processor ) ! Attach audio stream processor to the entire audio pipeline
+FUNCTION-ALIAS: detach-audio-mixed-processor void DetachAudioMixedProcessor ( AudioCallback processor ) ! Detach audio stream processor from the entire audio pipeline
 
 ! Destructors
 DESTRUCTOR: unload-audio-stream

--- a/extra/raylib/tags.txt
+++ b/extra/raylib/tags.txt
@@ -1,1 +1,2 @@
 bindings
+games

--- a/extra/rlgl/authors.txt
+++ b/extra/rlgl/authors.txt
@@ -1,0 +1,1 @@
+CapitalEx

--- a/extra/rlgl/demo/authors.txt
+++ b/extra/rlgl/demo/authors.txt
@@ -1,0 +1,1 @@
+CapitalEx

--- a/extra/rlgl/demo/demo.factor
+++ b/extra/rlgl/demo/demo.factor
@@ -1,0 +1,139 @@
+! Copyright (C) 2023 CapitalEx.
+! See https:!factorcode.org/license.txt for BSD license.
+! A port of https://github.com/raysan5/raylib/blob/master/examples/models/models_rlgl_solar_system.c
+USING: accessors classes.struct kernel math math.functions
+math.trig ranges raylib rlgl sequences combinators.extras ;
+IN: rlgl.demo
+
+! Some raylib combinators
+: with-drawing ( clear-color quot -- )
+    swap begin-drawing clear-background
+    call end-drawing ; inline
+
+: with-matrix ( quot -- )
+    rlPushMatrix call rlPopMatrix ; inline
+
+: while-window-open ( quot -- )
+    [ window-should-close not ] swap while ; inline
+
+: with-camera-3d ( camera quot -- )
+    swap begin-mode-3d call end-mode-3d ; inline
+
+CONSTANT:      screenWidth 800
+CONSTANT:     screenHeight 450
+CONSTANT:        sunRadius 4.0
+CONSTANT:      earthRadius 0.6
+CONSTANT: earthOrbitRadius 8.0
+CONSTANT:       moonRadius 0.16
+CONSTANT:  moonOrbitRadius 1.5
+CONSTANT:    rotationSpeed 0.2
+
+:: draw-sphere-basic ( color -- )
+    16 16 :> ( rings slices )
+    rings 2 + slices 6 * * rlCheckRenderBatchLimit drop
+
+    RL_TRIANGLES rlBegin
+        color [ r>> ] [ g>> ] [ b>> ] [ a>> ] quad rlColor4ub
+        rings 2 + [0..b) slices [0..b) [| i j |
+            270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad sin *
+            270 180 rings 1 + / i * + deg>rad sin
+            270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad cos *
+                        rlVertex3f
+
+            270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad sin *
+            270 180 rings 1 + / i 1 + * + deg>rad sin
+            270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad cos *
+                        rlVertex3f
+
+            270 180 rings 1 + / i 1 + * + deg>rad cos j 360 * slices / deg>rad sin *
+            270 180 rings 1 + / i 1 + * + deg>rad sin
+            270 180 rings 1 + / i 1 + * + deg>rad cos j 360 * slices / deg>rad cos *
+                        rlVertex3f
+
+            270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad sin *
+            270 180 rings 1 + / i * + deg>rad sin
+            270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad cos *
+                        rlVertex3f
+
+            270 180 rings 1 + / i * + deg>rad cos j 1 + 360 * slices / deg>rad sin *
+            270 180 rings 1 + / i * + deg>rad sin
+            270 180 rings 1 + / i * + deg>rad cos j 1 + 360 * slices / deg>rad cos *
+                        rlVertex3f
+
+            270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad sin *
+            270 180 rings 1 + / i 1 + * + deg>rad sin
+            270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad cos *
+                        rlVertex3f
+        ] cartesian-each
+    rlEnd ;
+
+: draw-sun ( scale -- )
+    dup dup rlScalef GOLD draw-sphere-basic ;
+
+: draw-moon ( radius rotation orbit-radius orbit-rotation -- )
+    0.0 1.0 0.0 rlRotatef
+        0.0 0.0 rlTranslatef
+    0.0 1.0 0.0 rlRotatef
+    dup dup rlScalef
+    LIGHTGRAY draw-sphere-basic ;
+
+: draw-earth ( radius rotation -- )
+    0.25 1.0 0.0 rlRotatef dup dup rlScalef
+    BLUE draw-sphere-basic ;
+
+: draw-earth-and-moon ( moonRadius       moonRotation
+                        moonOrbitRadius  moonOrbitRotation
+                        earthRadius      earthRotation
+                        earthOrbitRadius earthOrbitRotation -- )
+    0.0 1.0 0.0 rlRotatef 0.0 0.0 rlTranslatef
+    [ draw-earth ] with-matrix draw-moon ;
+
+: draw-solar-system ( moonRadius       moonRotation
+                      moonOrbitRadius  moonOrbitRotation
+                      earthRadius      earthRotation
+                      earthOrbitRadius earthOrbitRotation 
+                      sunRadius -- )
+    [ draw-sun ] [ draw-earth-and-moon ] [ with-matrix ] bi@ ;
+
+:: main ( -- )
+    screenWidth screenHeight "raylib [models] example - rlgl module usage with push/pop matrix transformations"
+        init-window
+
+    Camera3D <struct>
+            16.0 16.0 16.0 <Vector3> >>position
+             0.0  0.0  0.0 <Vector3> >>target
+             0.0  1.0  0.0 <Vector3> >>up
+                      45.0           >>fovy
+        CAMERA_PERSPECTIVE           >>projection
+    :> camera
+
+    0.0 0.0 :> ( earthRotation! earthOrbitRotation! )
+    0.0 0.0 :> ( moonRotation!  moonOrbitRotation!  )
+
+    60 set-target-fps [
+        camera CAMERA_ORBITAL update-camera
+
+        5.0 rotationSpeed * earthRotation + earthRotation!
+        365.0 360.0 / 5.0 rotationSpeed * * rotationSpeed * earthOrbitRotation + earthOrbitRotation!
+        rotationSpeed 2.0 * moonRotation + moonRotation!
+        rotationSpeed 8.0 * moonOrbitRotation + moonOrbitRotation!
+
+        RAYWHITE [
+            camera [
+                moonRadius  moonRotation  moonOrbitRadius  moonOrbitRotation
+                earthRadius earthRotation earthOrbitRadius earthOrbitRotation
+                sunRadius   draw-solar-system
+
+                0.0 0.0 0.0 <Vector3> earthOrbitRadius 1 0 0 <Vector3> 90.0 RED 0.5 fade
+                    draw-circle-3d
+
+                20 1.0 draw-grid
+            ] with-camera-3d
+
+            "EARTH ORBITING AROUND THE SUN!" 400 10 20 MAROON draw-text
+            "Using Factor!"                  400 40 20 GOLD   draw-text
+            10 10 draw-fps
+        ] with-drawing
+    ] while-window-open
+
+    close-window ;

--- a/extra/rlgl/demo/demo.factor
+++ b/extra/rlgl/demo/demo.factor
@@ -11,7 +11,7 @@ IN: rlgl.demo
     call end-drawing ; inline
 
 : with-matrix ( quot -- )
-    rlPushMatrix call rlPopMatrix ; inline
+    rl-push-matrix call rl-pop-matrix ; inline
 
 : while-window-open ( quot -- )
     [ window-should-close not ] swap while ; inline
@@ -30,62 +30,62 @@ CONSTANT:    rotationSpeed 0.2
 
 :: draw-sphere-basic ( color -- )
     16 16 :> ( rings slices )
-    rings 2 + slices 6 * * rlCheckRenderBatchLimit drop
+    rings 2 + slices 6 * * rl-check-render-batch-limit drop
 
-    RL_TRIANGLES rlBegin
-        color [ r>> ] [ g>> ] [ b>> ] [ a>> ] quad rlColor4ub
+    RL_TRIANGLES rl-begin
+        color [ r>> ] [ g>> ] [ b>> ] [ a>> ] quad rl-color4ub
         rings 2 + [0..b) slices [0..b) [| i j |
             270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad sin *
             270 180 rings 1 + / i * + deg>rad sin
             270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad cos *
-                        rlVertex3f
+                        rl-vertex3f
 
             270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad sin *
             270 180 rings 1 + / i 1 + * + deg>rad sin
             270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad cos *
-                        rlVertex3f
+                        rl-vertex3f
 
             270 180 rings 1 + / i 1 + * + deg>rad cos j 360 * slices / deg>rad sin *
             270 180 rings 1 + / i 1 + * + deg>rad sin
             270 180 rings 1 + / i 1 + * + deg>rad cos j 360 * slices / deg>rad cos *
-                        rlVertex3f
+                        rl-vertex3f
 
             270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad sin *
             270 180 rings 1 + / i * + deg>rad sin
             270 180 rings 1 + / i * + deg>rad cos j 360 * slices / deg>rad cos *
-                        rlVertex3f
+                        rl-vertex3f
 
             270 180 rings 1 + / i * + deg>rad cos j 1 + 360 * slices / deg>rad sin *
             270 180 rings 1 + / i * + deg>rad sin
             270 180 rings 1 + / i * + deg>rad cos j 1 + 360 * slices / deg>rad cos *
-                        rlVertex3f
+                        rl-vertex3f
 
             270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad sin *
             270 180 rings 1 + / i 1 + * + deg>rad sin
             270 180 rings 1 + / i 1 + * + deg>rad cos j 1 + 360 * slices / deg>rad cos *
-                        rlVertex3f
+                        rl-vertex3f
         ] cartesian-each
-    rlEnd ;
+    rl-end ;
 
 : draw-sun ( scale -- )
-    dup dup rlScalef GOLD draw-sphere-basic ;
+    dup dup rl-scalef GOLD draw-sphere-basic ;
 
 : draw-moon ( radius rotation orbit-radius orbit-rotation -- )
-    0.0 1.0 0.0 rlRotatef
-        0.0 0.0 rlTranslatef
-    0.0 1.0 0.0 rlRotatef
-    dup dup rlScalef
+    0.0 1.0 0.0 rl-rotatef
+        0.0 0.0 rl-translatef
+    0.0 1.0 0.0 rl-rotatef
+    dup dup rl-scalef
     LIGHTGRAY draw-sphere-basic ;
 
 : draw-earth ( radius rotation -- )
-    0.25 1.0 0.0 rlRotatef dup dup rlScalef
+    0.25 1.0 0.0 rl-rotatef dup dup rl-scalef
     BLUE draw-sphere-basic ;
 
 : draw-earth-and-moon ( moonRadius       moonRotation
                         moonOrbitRadius  moonOrbitRotation
                         earthRadius      earthRotation
                         earthOrbitRadius earthOrbitRotation -- )
-    0.0 1.0 0.0 rlRotatef 0.0 0.0 rlTranslatef
+    0.0 1.0 0.0 rl-rotatef 0.0 0.0 rl-translatef
     [ draw-earth ] with-matrix draw-moon ;
 
 : draw-solar-system ( moonRadius       moonRotation
@@ -137,3 +137,5 @@ CONSTANT:    rotationSpeed 0.2
     ] while-window-open
 
     close-window ;
+
+MAIN: main

--- a/extra/rlgl/rlgl.factor
+++ b/extra/rlgl/rlgl.factor
@@ -1,7 +1,9 @@
 ! Copyright (C) 2023 CapitalEx.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: alien alien.c-types alien.libraries alien.syntax
-classes.struct combinators kernel multiline raylib system ;
+USING: accessors alien alien.c-types alien.libraries
+alien.syntax classes.struct combinators kernel math multiline
+raylib raylib.util system ;
+FROM: alien.c-types => float ;
 IN: rlgl
 
 <<
@@ -108,10 +110,10 @@ STRUCT: rlVertexBuffer
     { vboId        uint[4] }  ! OpenGL Vertex Buffer Objects id ( 4 types of vertex data )
 ;
 
-ARRAY-SLOTS: rlVertexBuffer float _vertices  [ elementCount>> 3 * ] vertices 
-ARRAY-SLOTS: rlVertexBuffer float _texcoords [ elementCount>> 2 * ] texcoords
-ARRAY-SLOTS: rlVertexBuffer uchar _colors    [ elementCount>> 4 * ] colors
-ARRAY-SLOTS: rlVertexBuffer uint  _indices   [ elementCount>> 6 * ] indices
+ARRAY-SLOT: rlVertexBuffer float _vertices  [ elementCount>> 3 * ] vertices 
+ARRAY-SLOT: rlVertexBuffer float _texcoords [ elementCount>> 2 * ] texcoords
+ARRAY-SLOT: rlVertexBuffer uchar _colors    [ elementCount>> 4 * ] colors
+ARRAY-SLOT: rlVertexBuffer uint  _indices   [ elementCount>> 6 * ] indices
 
 ! Draw call type
 ! NOTE: Only texture changes register a new draw, other state-change-related elements are not
@@ -134,8 +136,8 @@ STRUCT: rlRenderBatch
     { currentDepth   float            } ! Current depth value for next draw
 ;
 
-ARRAY-SLOTS: rlRenderBatch rlVertexBuffer _vertexBuffer [ bufferCount>> ] vertexBuffer
-ARRAY-SLOTS: rlRenderBatch rlDrawCall _draws [ drawCounter>> ] draws
+ARRAY-SLOT: rlRenderBatch rlVertexBuffer _vertexBuffer [ bufferCount>> ] vertexBuffer
+ARRAY-SLOT: rlRenderBatch rlDrawCall _draws [ drawCounter>> ] draws
 
 ! OpenGL version
 ENUM: rlGlVersion

--- a/extra/rlgl/rlgl.factor
+++ b/extra/rlgl/rlgl.factor
@@ -1,0 +1,491 @@
+! Copyright (C) 2023 CapitalEx.
+! See https://factorcode.org/license.txt for BSD license.
+USING: alien alien.c-types alien.libraries alien.syntax
+classes.struct combinators kernel multiline raylib system ;
+IN: rlgl
+
+<<
+"raylib" {
+    { [ os windows? ] [ "raylib.dll" ] }
+    { [ os macosx? ] [ "libraylib.dylib" ] }
+    { [ os unix? ] [ "libraylib.so" ] }
+} cond cdecl add-library
+
+"raylib" deploy-library
+>>
+
+CONSTANT: RLGL_VERSION "4.5"
+
+CONSTANT: RL_TEXTURE_WRAP_S                       0x2802      ! GL_TEXTURE_WRAP_S
+CONSTANT: RL_TEXTURE_WRAP_T                       0x2803      ! GL_TEXTURE_WRAP_T
+CONSTANT: RL_TEXTURE_MAG_FILTER                   0x2800      ! GL_TEXTURE_MAG_FILTER
+CONSTANT: RL_TEXTURE_MIN_FILTER                   0x2801      ! GL_TEXTURE_MIN_FILTER
+
+CONSTANT: RL_TEXTURE_FILTER_NEAREST               0x2600      ! GL_NEAREST
+CONSTANT: RL_TEXTURE_FILTER_LINEAR                0x2601      ! GL_LINEAR
+CONSTANT: RL_TEXTURE_FILTER_MIP_NEAREST           0x2700      ! GL_NEAREST_MIPMAP_NEAREST
+CONSTANT: RL_TEXTURE_FILTER_NEAREST_MIP_LINEAR    0x2702      ! GL_NEAREST_MIPMAP_LINEAR
+CONSTANT: RL_TEXTURE_FILTER_LINEAR_MIP_NEAREST    0x2701      ! GL_LINEAR_MIPMAP_NEAREST
+CONSTANT: RL_TEXTURE_FILTER_MIP_LINEAR            0x2703      ! GL_LINEAR_MIPMAP_LINEAR
+CONSTANT: RL_TEXTURE_FILTER_ANISOTROPIC           0x3000      ! Anisotropic filter (custom identifier)
+CONSTANT: RL_TEXTURE_MIPMAP_BIAS_RATIO            0x4000      ! Texture mipmap bias, percentage ratio (custom identifier)
+
+CONSTANT: RL_TEXTURE_WRAP_REPEAT                  0x2901      ! GL_REPEAT
+CONSTANT: RL_TEXTURE_WRAP_CLAMP                   0x812F      ! GL_CLAMP_TO_EDGE
+CONSTANT: RL_TEXTURE_WRAP_MIRROR_REPEAT           0x8370      ! GL_MIRRORED_REPEAT
+CONSTANT: RL_TEXTURE_WRAP_MIRROR_CLAMP            0x8742      ! GL_MIRROR_CLAMP_EXT
+
+! Matrix modes (equivalent to OpenGL)
+CONSTANT: RL_MODELVIEW                            0x1700      ! GL_MODELVIEW
+CONSTANT: RL_PROJECTION                           0x1701      ! GL_PROJECTION
+CONSTANT: RL_TEXTURE                              0x1702      ! GL_TEXTURE
+
+! Primitive assembly draw modes
+CONSTANT: RL_LINES                                0x0001      ! GL_LINES
+CONSTANT: RL_TRIANGLES                            0x0004      ! GL_TRIANGLES
+CONSTANT: RL_QUADS                                0x0007      ! GL_QUADS
+
+! GL equivalent data types
+CONSTANT: RL_UNSIGNED_BYTE                        0x1401      ! GL_UNSIGNED_BYTE
+CONSTANT: RL_FLOAT                                0x1406      ! GL_FLOAT
+
+! GL buffer usage hint
+CONSTANT: RL_STREAM_DRAW                          0x88E0      ! GL_STREAM_DRAW
+CONSTANT: RL_STREAM_READ                          0x88E1      ! GL_STREAM_READ
+CONSTANT: RL_STREAM_COPY                          0x88E2      ! GL_STREAM_COPY
+CONSTANT: RL_STATIC_DRAW                          0x88E4      ! GL_STATIC_DRAW
+CONSTANT: RL_STATIC_READ                          0x88E5      ! GL_STATIC_READ
+CONSTANT: RL_STATIC_COPY                          0x88E6      ! GL_STATIC_COPY
+CONSTANT: RL_DYNAMIC_DRAW                         0x88E8      ! GL_DYNAMIC_DRAW
+CONSTANT: RL_DYNAMIC_READ                         0x88E9      ! GL_DYNAMIC_READ
+CONSTANT: RL_DYNAMIC_COPY                         0x88EA      ! GL_DYNAMIC_COPY
+
+! GL Shader type
+CONSTANT: RL_FRAGMENT_SHADER                      0x8B30      ! GL_FRAGMENT_SHADER
+CONSTANT: RL_VERTEX_SHADER                        0x8B31      ! GL_VERTEX_SHADER
+CONSTANT: RL_COMPUTE_SHADER                       0x91B9      ! GL_COMPUTE_SHADER
+
+! GL blending factors
+CONSTANT: RL_ZERO                                 0           ! GL_ZERO
+CONSTANT: RL_ONE                                  1           ! GL_ONE
+CONSTANT: RL_SRC_COLOR                            0x0300      ! GL_SRC_COLOR
+CONSTANT: RL_ONE_MINUS_SRC_COLOR                  0x0301      ! GL_ONE_MINUS_SRC_COLOR
+CONSTANT: RL_SRC_ALPHA                            0x0302      ! GL_SRC_ALPHA
+CONSTANT: RL_ONE_MINUS_SRC_ALPHA                  0x0303      ! GL_ONE_MINUS_SRC_ALPHA
+CONSTANT: RL_DST_ALPHA                            0x0304      ! GL_DST_ALPHA
+CONSTANT: RL_ONE_MINUS_DST_ALPHA                  0x0305      ! GL_ONE_MINUS_DST_ALPHA
+CONSTANT: RL_DST_COLOR                            0x0306      ! GL_DST_COLOR
+CONSTANT: RL_ONE_MINUS_DST_COLOR                  0x0307      ! GL_ONE_MINUS_DST_COLOR
+CONSTANT: RL_SRC_ALPHA_SATURATE                   0x0308      ! GL_SRC_ALPHA_SATURATE
+CONSTANT: RL_CONSTANT_COLOR                       0x8001      ! GL_CONSTANT_COLOR
+CONSTANT: RL_ONE_MINUS_CONSTANT_COLOR             0x8002      ! GL_ONE_MINUS_CONSTANT_COLOR
+CONSTANT: RL_CONSTANT_ALPHA                       0x8003      ! GL_CONSTANT_ALPHA
+CONSTANT: RL_ONE_MINUS_CONSTANT_ALPHA             0x8004      ! GL_ONE_MINUS_CONSTANT_ALPHA
+
+! GL blending functions/equations
+CONSTANT: RL_FUNC_ADD                             0x8006      ! GL_FUNC_ADD
+CONSTANT: RL_MIN                                  0x8007      ! GL_MIN
+CONSTANT: RL_MAX                                  0x8008      ! GL_MAX
+CONSTANT: RL_FUNC_SUBTRACT                        0x800A      ! GL_FUNC_SUBTRACT
+CONSTANT: RL_FUNC_REVERSE_SUBTRACT                0x800B      ! GL_FUNC_REVERSE_SUBTRACT
+CONSTANT: RL_BLEND_EQUATION                       0x8009      ! GL_BLEND_EQUATION
+CONSTANT: RL_BLEND_EQUATION_RGB                   0x8009      ! GL_BLEND_EQUATION_RGB   ! (Same as BLEND_EQUATION)
+CONSTANT: RL_BLEND_EQUATION_ALPHA                 0x883D      ! GL_BLEND_EQUATION_ALPHA
+CONSTANT: RL_BLEND_DST_RGB                        0x80C8      ! GL_BLEND_DST_RGB
+CONSTANT: RL_BLEND_SRC_RGB                        0x80C9      ! GL_BLEND_SRC_RGB
+CONSTANT: RL_BLEND_DST_ALPHA                      0x80CA      ! GL_BLEND_DST_ALPHA
+CONSTANT: RL_BLEND_SRC_ALPHA                      0x80CB      ! GL_BLEND_SRC_ALPHA
+CONSTANT: RL_BLEND_COLOR                          0x8005      ! GL_BLEND_COLOR
+
+
+STRUCT: rlVertexBuffer
+    { elementCount int  }  ! Number of elements in the buffer ( QUADS )
+    { vertices  float*  }  ! Vertex position ( XYZ - 3 components per vertex ) ( shader-location = 0 )
+    { texcoords float*  }  ! Vertex texture coordinates ( UV - 2 components per vertex ) ( shader-location = 1 )
+    { colors    uchar*  }  ! Vertex colors ( RGBA - 4 components per vertex ) ( shader-location = 3 )
+    { indices   uint*   }  ! Vertex indices ( in case vertex data comes indexed ) ( 6 indices per quad )
+    { vaoId     uint    }  ! OpenGL Vertex Array Object id
+    { vboId     uint[4] }  ! OpenGL Vertex Buffer Objects id ( 4 types of vertex data )
+;
+
+! Draw call type
+! NOTE: Only texture changes register a new draw, other state-change-related elements are not
+! used at this moment ( vaoId, shaderId, matrices ), raylib just forces a batch draw call if any
+! of those state-change happens ( this is done in core module )
+STRUCT: rlDrawCall
+    { mode             int  }                 ! Drawing mode: LINES, TRIANGLES, QUADS
+    { vertexCount      int  }             ! Number of vertex of the draw
+    { vertexAlignment  int  }        ! Number of vertex required for index alignment ( LINES, TRIANGLES )
+    { textureId        uint }    ! Texture id to be used on the draw -> Use to create new draw call if changes
+; 
+
+! rlRenderBatch type
+STRUCT: rlRenderBatch
+    { bufferCount    int             } ! Number of vertex buffers ( multi-buffering support )
+    { currentBuffer  int             } ! Current buffer tracking in case of multi-buffering
+    { vertexBuffer   rlVertexBuffer* } ! Dynamic buffer ( s ) for vertex data
+    { draws          rlDrawCall*     } ! Draw calls array, depends on textureId
+    { drawCounter    int             } ! Draw calls counter
+    { currentDepth   float           } ! Current depth value for next draw
+;
+
+! OpenGL version
+ENUM: rlGlVersion
+    RL_OPENGL_11                ! OpenGL 1.1
+    RL_OPENGL_21                ! OpenGL 2.1 ( GLSL 120 )
+    RL_OPENGL_33                ! OpenGL 3.3 ( GLSL 330 )
+    RL_OPENGL_43                ! OpenGL 4.3 ( using GLSL 330 )
+    RL_OPENGL_ES_20             ! OpenGL ES 2.0 ( GLSL 100 )
+; 
+
+! Trace log level
+! NOTE: Organized by priority level
+ENUM: rlTraceLogLevel 
+    RL_LOG_ALL                  ! Display all logs
+    RL_LOG_TRACE                ! Trace logging, intended for internal use only
+    RL_LOG_DEBUG                ! Debug logging, used for internal debugging, it should be disabled on release builds
+    RL_LOG_INFO                 ! Info logging, used for program execution info
+    RL_LOG_WARNING              ! Warning logging, used on recoverable failures
+    RL_LOG_ERROR                ! Error logging, used on unrecoverable failures
+    RL_LOG_FATAL                ! Fatal logging, used to abort program: exit ( EXIT_FAILURE )
+    RL_LOG_NONE                 ! Disable logging
+;
+
+! Texture pixel formats
+! NOTE: Support depends on OpenGL version
+ENUM: rlPixelFormat
+    RL_PIXELFORMAT_UNCOMPRESSED_GRAYSCALE          ! 8 bit per pixel ( no alpha )
+    RL_PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA         ! 8*2 bpp ( 2 channels )
+    RL_PIXELFORMAT_UNCOMPRESSED_R5G6B5             ! 16 bpp
+    RL_PIXELFORMAT_UNCOMPRESSED_R8G8B8             ! 24 bpp
+    RL_PIXELFORMAT_UNCOMPRESSED_R5G5B5A1           ! 16 bpp ( 1 bit alpha )
+    RL_PIXELFORMAT_UNCOMPRESSED_R4G4B4A4           ! 16 bpp ( 4 bit alpha )
+    RL_PIXELFORMAT_UNCOMPRESSED_R8G8B8A8           ! 32 bpp
+    RL_PIXELFORMAT_UNCOMPRESSED_R32                ! 32 bpp ( 1 channel - float )
+    RL_PIXELFORMAT_UNCOMPRESSED_R32G32B32          ! 32*3 bpp ( 3 channels - float )
+    RL_PIXELFORMAT_UNCOMPRESSED_R32G32B32A32       ! 32*4 bpp ( 4 channels - float )
+    RL_PIXELFORMAT_COMPRESSED_DXT1_RGB             ! 4 bpp ( no alpha )
+    RL_PIXELFORMAT_COMPRESSED_DXT1_RGBA            ! 4 bpp ( 1 bit alpha )
+    RL_PIXELFORMAT_COMPRESSED_DXT3_RGBA            ! 8 bpp
+    RL_PIXELFORMAT_COMPRESSED_DXT5_RGBA            ! 8 bpp
+    RL_PIXELFORMAT_COMPRESSED_ETC1_RGB             ! 4 bpp
+    RL_PIXELFORMAT_COMPRESSED_ETC2_RGB             ! 4 bpp
+    RL_PIXELFORMAT_COMPRESSED_ETC2_EAC_RGBA        ! 8 bpp
+    RL_PIXELFORMAT_COMPRESSED_PVRT_RGB             ! 4 bpp
+    RL_PIXELFORMAT_COMPRESSED_PVRT_RGBA            ! 4 bpp
+    RL_PIXELFORMAT_COMPRESSED_ASTC_4x4_RGBA        ! 8 bpp
+    RL_PIXELFORMAT_COMPRESSED_ASTC_8x8_RGBA        ! 2 bpp
+; 
+
+! Texture parameters: filter mode
+! NOTE 1: Filtering considers mipmaps if available in the texture
+! NOTE 2: Filter is accordingly set for minification and magnification
+ENUM: rlTextureFilter
+    RL_TEXTURE_FILTER_POINT            ! No filter, just pixel approximation
+    RL_TEXTURE_FILTER_BILINEAR         ! Linear filtering
+    RL_TEXTURE_FILTER_TRILINEAR        ! Trilinear filtering ( linear with mipmaps )
+    RL_TEXTURE_FILTER_ANISOTROPIC_4X   ! Anisotropic filtering 4x
+    RL_TEXTURE_FILTER_ANISOTROPIC_8X   ! Anisotropic filtering 8x
+    RL_TEXTURE_FILTER_ANISOTROPIC_16X  ! Anisotropic filtering 16x
+; 
+
+! Color blending modes ( pre-defined )
+ENUM: rlBlendMode
+    RL_BLEND_ALPHA                     ! Blend textures considering alpha ( default )
+    RL_BLEND_ADDITIVE                  ! Blend textures adding colors
+    RL_BLEND_MULTIPLIED                ! Blend textures multiplying colors
+    RL_BLEND_ADD_COLORS                ! Blend textures adding colors ( alternative )
+    RL_BLEND_SUBTRACT_COLORS           ! Blend textures subtracting colors ( alternative )
+    RL_BLEND_ALPHA_PREMULTIPLY         ! Blend premultiplied textures considering alpha
+    RL_BLEND_CUSTOM                    ! Blend textures using custom src/dst factors ( use rlSetBlendFactors ( ) )
+    RL_BLEND_CUSTOM_SEPARATE           !  Blend textures using custom src/dst factors ( use rlSetBlendFactorsSeparate ( ) )
+;
+
+! Shader location point type
+ENUM: rlShaderLocationIndex
+    RL_SHADER_LOC_VERTEX_POSITION      ! Shader location: vertex attribute: position
+    RL_SHADER_LOC_VERTEX_TEXCOORD01    ! Shader location: vertex attribute: texcoord01
+    RL_SHADER_LOC_VERTEX_TEXCOORD02    ! Shader location: vertex attribute: texcoord02
+    RL_SHADER_LOC_VERTEX_NORMAL        ! Shader location: vertex attribute: normal
+    RL_SHADER_LOC_VERTEX_TANGENT       ! Shader location: vertex attribute: tangent
+    RL_SHADER_LOC_VERTEX_COLOR         ! Shader location: vertex attribute: color
+    RL_SHADER_LOC_MATRIX_MVP           ! Shader location: matrix uniform: model-view-projection
+    RL_SHADER_LOC_MATRIX_VIEW          ! Shader location: matrix uniform: view ( camera transform )
+    RL_SHADER_LOC_MATRIX_PROJECTION    ! Shader location: matrix uniform: projection
+    RL_SHADER_LOC_MATRIX_MODEL         ! Shader location: matrix uniform: model ( transform )
+    RL_SHADER_LOC_MATRIX_NORMAL        ! Shader location: matrix uniform: normal
+    RL_SHADER_LOC_VECTOR_VIEW          ! Shader location: vector uniform: view
+    RL_SHADER_LOC_COLOR_DIFFUSE        ! Shader location: vector uniform: diffuse color
+    RL_SHADER_LOC_COLOR_SPECULAR       ! Shader location: vector uniform: specular color
+    RL_SHADER_LOC_COLOR_AMBIENT        ! Shader location: vector uniform: ambient color
+    RL_SHADER_LOC_MAP_ALBEDO           ! Shader location: sampler2d texture: albedo ( same as: RL_SHADER_LOC_MAP_DIFFUSE )
+    RL_SHADER_LOC_MAP_METALNESS        ! Shader location: sampler2d texture: metalness ( same as: RL_SHADER_LOC_MAP_SPECULAR )
+    RL_SHADER_LOC_MAP_NORMAL           ! Shader location: sampler2d texture: normal
+    RL_SHADER_LOC_MAP_ROUGHNESS        ! Shader location: sampler2d texture: roughness
+    RL_SHADER_LOC_MAP_OCCLUSION        ! Shader location: sampler2d texture: occlusion
+    RL_SHADER_LOC_MAP_EMISSION         ! Shader location: sampler2d texture: emission
+    RL_SHADER_LOC_MAP_HEIGHT           ! Shader location: sampler2d texture: height
+    RL_SHADER_LOC_MAP_CUBEMAP          ! Shader location: samplerCube texture: cubemap
+    RL_SHADER_LOC_MAP_IRRADIANCE       ! Shader location: samplerCube texture: irradiance
+    RL_SHADER_LOC_MAP_PREFILTER        ! Shader location: samplerCube texture: prefilter
+    RL_SHADER_LOC_MAP_BRDF             ! Shader location: sampler2d texture: brdf
+;
+
+CONSTANT: RL_SHADER_LOC_MAP_DIFFUSE   RL_SHADER_LOC_MAP_ALBEDO
+CONSTANT: RL_SHADER_LOC_MAP_SPECULAR  RL_SHADER_LOC_MAP_METALNESS
+
+! Shader uniform data type
+ENUM: rlShaderUniformDataType
+    RL_SHADER_UNIFORM_FLOAT            ! Shader uniform type: float
+    RL_SHADER_UNIFORM_VEC2             ! Shader uniform type: vec2 ( 2 float )
+    RL_SHADER_UNIFORM_VEC3             ! Shader uniform type: vec3 ( 3 float )
+    RL_SHADER_UNIFORM_VEC4             ! Shader uniform type: vec4 ( 4 float )
+    RL_SHADER_UNIFORM_INT              ! Shader uniform type: int
+    RL_SHADER_UNIFORM_IVEC2            ! Shader uniform type: ivec2 ( 2 int )
+    RL_SHADER_UNIFORM_IVEC3            ! Shader uniform type: ivec3 ( 3 int )
+    RL_SHADER_UNIFORM_IVEC4            ! Shader uniform type: ivec4 ( 4 int )
+    RL_SHADER_UNIFORM_SAMPLER2D        ! Shader uniform type: sampler2d
+;
+
+! Shader attribute data types
+ENUM: rlShaderAttributeDataType
+    RL_SHADER_ATTRIB_FLOAT              ! Shader attribute type: float
+    RL_SHADER_ATTRIB_VEC2               ! Shader attribute type: vec2 ( 2 float )
+    RL_SHADER_ATTRIB_VEC3               ! Shader attribute type: vec3 ( 3 float )
+    RL_SHADER_ATTRIB_VEC4               ! Shader attribute type: vec4 ( 4 float )
+;
+
+! Framebuffer attachment type
+! NOTE: By default up to 8 color channels defined, but it can be more
+ENUM: rlFramebufferAttachType
+    RL_ATTACHMENT_COLOR_CHANNEL0  ! Framebuffer attachment type: color 0
+    RL_ATTACHMENT_COLOR_CHANNEL1  ! Framebuffer attachment type: color 1
+    RL_ATTACHMENT_COLOR_CHANNEL2  ! Framebuffer attachment type: color 2
+    RL_ATTACHMENT_COLOR_CHANNEL3  ! Framebuffer attachment type: color 3
+    RL_ATTACHMENT_COLOR_CHANNEL4  ! Framebuffer attachment type: color 4
+    RL_ATTACHMENT_COLOR_CHANNEL5  ! Framebuffer attachment type: color 5
+    RL_ATTACHMENT_COLOR_CHANNEL6  ! Framebuffer attachment type: color 6
+    RL_ATTACHMENT_COLOR_CHANNEL7  ! Framebuffer attachment type: color 7
+    { RL_ATTACHMENT_DEPTH   100 } ! Framebuffer attachment type: depth
+    { RL_ATTACHMENT_STENCIL 200 } ! Framebuffer attachment type: stencil
+; 
+
+! Framebuffer texture attachment type
+ENUM: rlFramebufferAttachTextureType
+    RL_ATTACHMENT_CUBEMAP_POSITIVE_X  ! Framebuffer texture attachment type: cubemap, +X side
+    RL_ATTACHMENT_CUBEMAP_NEGATIVE_X   ! Framebuffer texture attachment type: cubemap, -X side
+    RL_ATTACHMENT_CUBEMAP_POSITIVE_Y   ! Framebuffer texture attachment type: cubemap, +Y side
+    RL_ATTACHMENT_CUBEMAP_NEGATIVE_Y   ! Framebuffer texture attachment type: cubemap, -Y side
+    RL_ATTACHMENT_CUBEMAP_POSITIVE_Z   ! Framebuffer texture attachment type: cubemap, +Z side
+    RL_ATTACHMENT_CUBEMAP_NEGATIVE_Z   ! Framebuffer texture attachment type: cubemap, -Z side
+    { RL_ATTACHMENT_TEXTURE2D    100 } ! Framebuffer texture attachment type: texture2d
+    { RL_ATTACHMENT_RENDERBUFFER 200 } ! Framebuffer texture attachment type: renderbuffer
+; 
+
+! Face culling mode
+ENUM: rlCullMode
+    RL_CULL_FACE_FRONT
+    RL_CULL_FACE_BACK
+; 
+
+FUNCTION: void rlMatrixMode ( int mode )                     ! Choose the current matrix to be transformed
+FUNCTION: void rlPushMatrix ( )                         ! Push the current matrix to stack
+FUNCTION: void rlPopMatrix ( )                          ! Pop latest inserted matrix from stack
+FUNCTION: void rlLoadIdentity ( )                       ! Reset current matrix to identity matrix
+FUNCTION: void rlTranslatef ( float x, float y, float z )    ! Multiply the current matrix by a translation matrix
+FUNCTION: void rlRotatef ( float angle, float x, float y, float z )   ! Multiply the current matrix by a rotation matrix
+FUNCTION: void rlScalef ( float x, float y, float z )        ! Multiply the current matrix by a scaling matrix
+FUNCTION: void rlMultMatrixf ( float* matf )                 ! Multiply the current matrix by another matrix
+FUNCTION: void rlFrustum ( double left, double right, double bottom, double top, double znear, double zfar ) 
+FUNCTION: void rlOrtho ( double left, double right, double bottom, double top, double znear, double zfar ) 
+FUNCTION: void rlViewport ( int x, int y, int width, int height )  ! Set the viewport area
+
+! ------------------------------------------------------------------------------------
+! Functions Declaration - Vertex level operations
+! ------------------------------------------------------------------------------------
+FUNCTION: void rlBegin ( int mode )                          ! Initialize drawing mode ( how to organize vertex )
+FUNCTION: void rlEnd ( )                                ! Finish vertex providing
+FUNCTION: void rlVertex2i ( int x, int y )                   ! Define one vertex ( position ) - 2 int
+FUNCTION: void rlVertex2f ( float x, float y )               ! Define one vertex ( position ) - 2 float
+FUNCTION: void rlVertex3f ( float x, float y, float z )      ! Define one vertex ( position ) - 3 float
+FUNCTION: void rlTexCoord2f ( float x, float y )             ! Define one vertex ( texture coordinate ) - 2 float
+FUNCTION: void rlNormal3f ( float x, float y, float z )      ! Define one vertex ( normal ) - 3 float
+FUNCTION: void rlColor4ub ( uchar r, uchar g, uchar b, uchar a )   ! Define one vertex ( color ) - 4 byte
+FUNCTION: void rlColor3f ( float x, float y, float z )           ! Define one vertex ( color ) - 3 float
+FUNCTION: void rlColor4f ( float x, float y, float z, float w )  ! Define one vertex ( color ) - 4 float
+
+! ------------------------------------------------------------------------------------
+! Functions Declaration - OpenGL style functions ( common to 1.1, 3.3+, ES2 )
+! NOTE: This functions are used to completely abstract raylib code from OpenGL layer,
+! some of them are direct wrappers over OpenGL calls, some others are custom
+! ------------------------------------------------------------------------------------
+
+! Vertex buffers state
+FUNCTION: bool rlEnableVertexArray ( uint vaoId )      ! Enable vertex array ( VAO, if supported )
+FUNCTION: void rlDisableVertexArray ( )                   ! Disable vertex array ( VAO, if supported )
+FUNCTION: void rlEnableVertexBuffer ( uint id )        ! Enable vertex buffer ( VBO )
+FUNCTION: void rlDisableVertexBuffer ( )                  ! Disable vertex buffer ( VBO )
+FUNCTION: void rlEnableVertexBufferElement ( uint id ) ! Enable vertex buffer element ( VBO element )
+FUNCTION: void rlDisableVertexBufferElement ( )           ! Disable vertex buffer element ( VBO element )
+FUNCTION: void rlEnableVertexAttribute ( uint index )  ! Enable vertex attribute index
+FUNCTION: void rlDisableVertexAttribute ( uint index ) ! Disable vertex attribute index
+! #if defined ( GRAPHICS_API_OPENGL_11 )
+! FUNCTION: void rlEnableStatePointer ( int vertexAttribType, void* buffer )     ! Enable attribute state pointer
+! FUNCTION: void rlDisableStatePointer ( int vertexAttribType )                  ! Disable attribute state pointer
+! #endif
+
+! Textures state
+FUNCTION: void rlActiveTextureSlot ( int slot )                ! Select and active a texture slot
+FUNCTION: void rlEnableTexture ( uint id )             ! Enable texture
+FUNCTION: void rlDisableTexture ( )                       ! Disable texture
+FUNCTION: void rlEnableTextureCubemap ( uint id )      ! Enable texture cubemap
+FUNCTION: void rlDisableTextureCubemap ( )                ! Disable texture cubemap
+FUNCTION: void rlTextureParameters ( uint id, int param, int value )  ! Set texture parameters ( filter, wrap )
+FUNCTION: void rlCubemapParameters ( uint id, int param, int value )  ! Set cubemap parameters ( filter, wrap )
+
+! Shader state
+FUNCTION: void rlEnableShader ( uint id )              ! Enable shader program
+FUNCTION: void rlDisableShader ( )                        ! Disable shader program
+
+! Framebuffer state
+FUNCTION: void rlEnableFramebuffer ( uint id )         ! Enable render texture ( fbo )
+FUNCTION: void rlDisableFramebuffer ( )                   ! Disable render texture ( fbo ), return to default framebuffer
+FUNCTION: void rlActiveDrawBuffers ( int count )               ! Activate multiple draw color buffers
+
+! General render state
+FUNCTION: void rlEnableColorBlend ( )                      ! Enable color blending
+FUNCTION: void rlDisableColorBlend ( )                    ! Disable color blending
+FUNCTION: void rlEnableDepthTest ( )                      ! Enable depth test
+FUNCTION: void rlDisableDepthTest ( )                     ! Disable depth test
+FUNCTION: void rlEnableDepthMask ( )                      ! Enable depth write
+FUNCTION: void rlDisableDepthMask ( )                     ! Disable depth write
+FUNCTION: void rlEnableBackfaceCulling ( )                ! Enable backface culling
+FUNCTION: void rlDisableBackfaceCulling ( )               ! Disable backface culling
+FUNCTION: void rlSetCullFace ( int mode )                      ! Set face culling mode
+FUNCTION: void rlEnableScissorTest ( )                    ! Enable scissor test
+FUNCTION: void rlDisableScissorTest ( )                   ! Disable scissor test
+FUNCTION: void rlScissor ( int x, int y, int width, int height )  ! Scissor test
+FUNCTION: void rlEnableWireMode ( )                       ! Enable wire mode
+FUNCTION: void rlDisableWireMode ( )                      ! Disable wire mode
+FUNCTION: void rlSetLineWidth ( float width )                  ! Set the line drawing width
+FUNCTION: float rlGetLineWidth ( )                        ! Get the line drawing width
+FUNCTION: void rlEnableSmoothLines ( )                    ! Enable line aliasing
+FUNCTION: void rlDisableSmoothLines ( )                   ! Disable line aliasing
+FUNCTION: void rlEnableStereoRender ( )                   ! Enable stereo rendering
+FUNCTION: void rlDisableStereoRender ( )                  ! Disable stereo rendering
+FUNCTION: bool rlIsStereoRenderEnabled ( )                ! Check if stereo render is enabled
+
+FUNCTION: void rlClearColor ( uchar r, uchar g, uchar b, uchar a )  ! Clear color buffer with color
+FUNCTION: void rlClearScreenBuffers ( )                   ! Clear used screen buffers ( color and depth )
+FUNCTION: void rlCheckErrors ( )                          ! Check and log OpenGL error codes
+FUNCTION: void rlSetBlendMode ( int mode )                     ! Set blending mode
+FUNCTION: void rlSetBlendFactors ( int glSrcFactor, int glDstFactor, int glEquation )  ! Set blending mode factor and equation ( using OpenGL factors )
+FUNCTION: void rlSetBlendFactorsSeparate ( int glSrcRGB, int glDstRGB, int glSrcAlpha, int glDstAlpha, int glEqRGB, int glEqAlpha )  ! Set blending mode factors and equations separately ( using OpenGL factors )
+
+! ------------------------------------------------------------------------------------
+! Functions Declaration - rlgl functionality
+! ------------------------------------------------------------------------------------
+! rlgl initialization functions
+FUNCTION: void rlglInit ( int width, int height )              ! Initialize rlgl ( buffers, shaders, textures, states )
+FUNCTION: void rlglClose ( )                              ! De-initialize rlgl ( buffers, shaders, textures )
+FUNCTION: void rlLoadExtensions ( void* loader )               ! Load OpenGL extensions ( loader function required )
+FUNCTION: int rlGetVersion ( )                            ! Get current OpenGL version
+FUNCTION: void rlSetFramebufferWidth ( int width )             ! Set current framebuffer width
+FUNCTION: int rlGetFramebufferWidth ( )                   ! Get default framebuffer width
+FUNCTION: void rlSetFramebufferHeight ( int height )           ! Set current framebuffer height
+FUNCTION: int rlGetFramebufferHeight ( )                  ! Get default framebuffer height
+
+FUNCTION: uint rlGetTextureIdDefault ( )          ! Get default texture id
+FUNCTION: uint rlGetShaderIdDefault ( )           ! Get default shader id
+FUNCTION: int* rlGetShaderLocsDefault ( )                 ! Get default shader locations
+
+! Render batch management
+! NOTE: rlgl provides a default render batch to behave like OpenGL 1.1 immediate mode
+! but this render batch API is exposed in case of custom batches are required
+FUNCTION: rlRenderBatch rlLoadRenderBatch ( int numBuffers, int bufferElements )   ! Load a render batch system
+FUNCTION: void rlUnloadRenderBatch ( rlRenderBatch batch )                         ! Unload render batch system
+FUNCTION: void rlDrawRenderBatch ( rlRenderBatch* batch )                          ! Draw render batch data ( Update->Draw->Reset )
+FUNCTION: void rlSetRenderBatchActive ( rlRenderBatch* batch )                     ! Set the active render batch for rlgl ( NULL for default internal )
+FUNCTION: void rlDrawRenderBatchActive ( )                                    ! Update and draw internal render batch
+FUNCTION: bool rlCheckRenderBatchLimit ( int vCount )                              ! Check internal buffer overflow for a given number of vertex
+
+FUNCTION: void rlSetTexture ( uint id )                ! Set current texture for render batch and check buffers limits
+
+! ------------------------------------------------------------------------------------------------------------------------
+
+! Vertex buffers management
+FUNCTION: uint rlLoadVertexArray ( )                                ! Load vertex array ( vao ) if supported
+FUNCTION: uint rlLoadVertexBuffer ( void* buffer, int size, bool dynamic )             ! Load a vertex buffer attribute
+FUNCTION: uint rlLoadVertexBufferElement ( void* buffer, int size, bool dynamic )      ! Load a new attributes element buffer
+FUNCTION: void rlUpdateVertexBuffer ( uint bufferId, void* data, int dataSize, int offset )      ! Update GPU buffer with new data
+FUNCTION: void rlUpdateVertexBufferElements ( uint id, void* data, int dataSize, int offset )    ! Update vertex buffer elements with new data
+FUNCTION: void rlUnloadVertexArray ( uint vaoId ) 
+FUNCTION: void rlUnloadVertexBuffer ( uint vboId ) 
+FUNCTION: void rlSetVertexAttribute ( uint index, int compSize, int type, bool normalized, int stride, void* pointer ) 
+FUNCTION: void rlSetVertexAttributeDivisor ( uint index, int divisor ) 
+FUNCTION: void rlSetVertexAttributeDefault ( int locIndex, void* value, int attribType, int count )  ! Set vertex attribute default value
+FUNCTION: void rlDrawVertexArray ( int offset, int count ) 
+FUNCTION: void rlDrawVertexArrayElements ( int offset, int count, void* buffer ) 
+FUNCTION: void rlDrawVertexArrayInstanced ( int offset, int count, int instances ) 
+FUNCTION: void rlDrawVertexArrayElementsInstanced ( int offset, int count, void* buffer, int instances ) 
+
+! Textures management
+FUNCTION: uint rlLoadTexture ( void* data, int width, int height, int format, int mipmapCount )  ! Load texture in GPU
+FUNCTION: uint rlLoadTextureDepth ( int width, int height, bool useRenderBuffer )                ! Load depth texture/renderbuffer ( to be attached to fbo )
+FUNCTION: uint rlLoadTextureCubemap ( void* data, int size, int format )                         ! Load texture cubemap
+FUNCTION: void rlUpdateTexture ( uint id, int offsetX, int offsetY, int width, int height, int format, void* data )   ! Update GPU texture with new data
+FUNCTION: void rlGetGlTextureFormats ( int format, uint* glInternalFormat, uint* glFormat, uint* glType )   ! Get OpenGL internal formats
+FUNCTION: char* rlGetPixelFormatName ( uint format )               ! Get name string for pixel format
+FUNCTION: void rlUnloadTexture ( uint id )                               ! Unload texture from GPU memory
+FUNCTION: void rlGenTextureMipmaps ( uint id, int width, int height, int format, int* mipmaps )  ! Generate mipmap data for selected texture
+FUNCTION: void* rlReadTexturePixels ( uint id, int width, int height, int format )               ! Read texture pixel data
+FUNCTION: uchar* rlReadScreenPixels ( int width, int height )            ! Read screen pixel data ( color buffer )
+
+! Framebuffer management ( fbo )
+FUNCTION: uint rlLoadFramebuffer ( int width, int height )               ! Load an empty framebuffer
+FUNCTION: void rlFramebufferAttach ( uint fboId, uint texId, int attachType, int texType, int mipLevel )   ! Attach texture/renderbuffer to a framebuffer
+FUNCTION: bool rlFramebufferComplete ( uint id )                         ! Verify framebuffer is complete
+FUNCTION: void rlUnloadFramebuffer ( uint id )                           ! Delete framebuffer from GPU
+
+! Shaders management
+FUNCTION: uint rlLoadShaderCode ( char* vsCode, char* fsCode )     ! Load shader from code strings
+FUNCTION: uint rlCompileShader ( char* shaderCode, int type )            ! Compile custom shader and return shader id ( type: RL_VERTEX_SHADER, RL_FRAGMENT_SHADER, RL_COMPUTE_SHADER )
+FUNCTION: uint rlLoadShaderProgram ( uint vShaderId, uint fShaderId )  ! Load custom shader program
+FUNCTION: void rlUnloadShaderProgram ( uint id )                               ! Unload shader program
+FUNCTION: int rlGetLocationUniform ( uint shaderId, char* uniformName )  ! Get shader location uniform
+FUNCTION: int rlGetLocationAttrib ( uint shaderId, char* attribName )    ! Get shader location attribute
+FUNCTION: void rlSetUniform ( int locIndex, void* value, int uniformType, int count )    ! Set shader value uniform
+FUNCTION: void rlSetUniformMatrix ( int locIndex, Matrix mat )                         ! Set shader value matrix
+FUNCTION: void rlSetUniformSampler ( int locIndex, uint textureId )            ! Set shader value sampler
+FUNCTION: void rlSetShader ( uint id, int* locs )                              ! Set shader currently active ( id and locations )
+
+! Compute shader management
+FUNCTION: uint rlLoadComputeShaderProgram ( uint shaderId )            ! Load compute shader program
+FUNCTION: void rlComputeShaderDispatch ( uint groupX, uint groupY, uint groupZ )   ! Dispatch compute shader ( equivalent to* draw* for graphics pipeline )
+
+! Shader buffer storage object management ( ssbo )
+FUNCTION: uint rlLoadShaderBuffer ( uint size, void* data, int usageHint )  ! Load shader storage buffer object ( SSBO )
+FUNCTION: void rlUnloadShaderBuffer ( uint ssboId )                            ! Unload shader storage buffer object ( SSBO )
+FUNCTION: void rlUpdateShaderBuffer ( uint id, void* data, uint dataSize, uint offset )  ! Update SSBO buffer data
+FUNCTION: void rlBindShaderBuffer ( uint id, uint index )              ! Bind SSBO buffer
+FUNCTION: void rlReadShaderBuffer ( uint id, void* dest, uint count, uint offset )  ! Read SSBO buffer data ( GPU->CPU )
+FUNCTION: void rlCopyShaderBuffer ( uint destId, uint srcId, uint destOffset, uint srcOffset, uint count )  ! Copy SSBO data between buffers
+FUNCTION: uint rlGetShaderBufferSize ( uint id )                       ! Get SSBO buffer size
+
+! Buffer management
+FUNCTION: void rlBindImageTexture ( uint id, uint index, int format, bool readonly )   ! Bind image texture
+
+! Matrix state management
+FUNCTION: Matrix rlGetMatrixModelview ( )                                   ! Get internal modelview matrix
+FUNCTION: Matrix rlGetMatrixProjection ( )                                  ! Get internal projection matrix
+FUNCTION: Matrix rlGetMatrixTransform ( )                                   ! Get internal accumulated transform matrix
+FUNCTION: Matrix rlGetMatrixProjectionStereo ( int eye )                         ! Get internal projection matrix for stereo render ( selected eye )
+FUNCTION: Matrix rlGetMatrixViewOffsetStereo ( int eye )                         ! Get internal view offset matrix for stereo render ( selected eye )
+FUNCTION: void rlSetMatrixProjection ( Matrix proj )                             ! Set a custom projection matrix ( replaces internal projection matrix )
+FUNCTION: void rlSetMatrixModelview ( Matrix view )                              ! Set a custom modelview matrix ( replaces internal modelview matrix )
+FUNCTION: void rlSetMatrixProjectionStereo ( Matrix right, Matrix left )         ! Set eyes projection matrices for stereo rendering
+FUNCTION: void rlSetMatrixViewOffsetStereo ( Matrix right, Matrix left )         ! Set eyes view offsets matrices for stereo rendering
+
+! Quick and dirty cube/quad buffers load->draw->unload
+FUNCTION: void rlLoadDrawCube ( )      ! Load and draw a cube
+FUNCTION: void rlLoadDrawQuad ( )      ! Load and draw a quad

--- a/extra/rlgl/tags.txt
+++ b/extra/rlgl/tags.txt
@@ -1,0 +1,1 @@
+bindings opengl games


### PR DESCRIPTION
Resolves #2804 by updating our bindings from `4.5-dev` to `4.5`. It removes functions no longer in raylib, fixes API discrepancies, and adds a new `ARRAY-SLOT`.

Added rlgl bindings, hopefully I didn't miss anything critical. I also ported over one of the demo's using rlgl.