### PR TITLE
assocs.extras: Move some often-used words to core

### DIFF
--- a/basis/cache/cache.factor
+++ b/basis/cache/cache.factor
@@ -40,7 +40,7 @@ PRIVATE>
 : purge-cache ( cache -- )
     dup [ assoc>> ] [ max-age>> ] bi V{ } clone [
         '[
-            nip dup age>> 1 + [ >>age ] keep
+            dup age>> 1 + [ >>age ] keep
             _ < [ drop t ] [ _ dispose-to f ] if
-        ] assoc-filter >>assoc drop 
+        ] filter-values >>assoc drop 
     ] keep [ last rethrow ] unless-empty ;

--- a/basis/cocoa/messages/messages.factor
+++ b/basis/cocoa/messages/messages.factor
@@ -254,7 +254,7 @@ ERROR: no-objc-type name ;
     objc-methods get >alist
     [ first CHAR: . swap member? ] filter
     [ first "." split1 nip ] collect-by
-    [ nip values members length 1 > ] assoc-filter ;
+    [ values members length 1 > ] filter-values ;
 
 : method-count ( class -- c-direct-array )
     0 uint <ref> [ class_copyMethodList (free) ] keep uint deref ;

--- a/basis/combinators/smart/smart-tests.factor
+++ b/basis/combinators/smart/smart-tests.factor
@@ -89,7 +89,7 @@ IN: combinators.smart.tests
 
 { 1 1 1 } [ 1 3 [ ] smart-with times ] unit-test
 { "BCD" } [ 1 "ABC" [ + ] smart-with map ] unit-test
-{ H{ { 1 2 } } } [ 1 H{ { 1 2 } { 3 4 } } [ drop = ] smart-with assoc-filter ] unit-test
+{ H{ { 1 2 } } } [ 1 H{ { 1 2 } { 3 4 } } [ = ] smart-with filter-keys ] unit-test
 
 : test-cleave>sequence ( obj -- seq )  { [ 1 + ] [ sq ] [ 1 - ] } V{ } cleave>sequence ;
 \ test-cleave>sequence def>> must-infer

--- a/basis/compiler/cfg/predecessors/predecessors.factor
+++ b/basis/compiler/cfg/predecessors/predecessors.factor
@@ -12,7 +12,7 @@ IN: compiler.cfg.predecessors
 : update-phi ( bb ##phi -- )
     [
         swap predecessors>>
-        '[ drop _ member-eq? ] assoc-filter
+        '[ _ member-eq? ] filter-keys
     ] change-inputs drop ;
 
 : update-phis ( bb -- )

--- a/basis/compiler/cfg/representations/selection/selection.factor
+++ b/basis/compiler/cfg/representations/selection/selection.factor
@@ -127,7 +127,7 @@ M: vreg-insn compute-insn-costs
     ] each-basic-block ;
 
 : minimize-costs ( costs -- representations )
-    [ nip assoc-empty? ] assoc-reject
+    [ assoc-empty? ] reject-values
     [ >alist alist-min first ] assoc-map ;
 
 : compute-representations ( cfg -- )

--- a/basis/compiler/cfg/stacks/local/local-tests.factor
+++ b/basis/compiler/cfg/stacks/local/local-tests.factor
@@ -154,7 +154,7 @@ IN: compiler.cfg.stacks.local.tests
         ! a i j el
         77 eq?
         [
-            rot drop and
+            nipd and
         ]
         [
             ! a i j

--- a/basis/compiler/crossref/crossref.factor
+++ b/basis/compiler/crossref/crossref.factor
@@ -16,7 +16,7 @@ generic-call-site-crossref [ H{ } clone ] initialize
     compiled-crossref get at ;
 
 : dependencies-of ( word dep-type -- assoc )
-    [ all-dependencies-of ] dip '[ nip _ dependency>= ] assoc-filter ;
+    [ all-dependencies-of ] dip '[ _ dependency>= ] filter-values ;
 
 : outdated-definition-usages ( set -- assocs )
     filter-word-defs [ +definition+ dependencies-of ] map ;
@@ -31,7 +31,7 @@ generic-call-site-crossref [ H{ } clone ] initialize
 : outdated-conditional-usages ( set -- assocs )
     members H{ } clone '[
         +conditional+ dependencies-of
-        [ drop _ dependencies-satisfied? ] assoc-reject
+        [ _ dependencies-satisfied? ] reject-keys
     ] map ;
 
 : generic-call-sites-of ( word -- assoc )
@@ -44,7 +44,7 @@ generic-call-site-crossref [ H{ } clone ] initialize
     concat f like "generic-call-sites" set-word-prop ;
 
 : store-dependencies-of-type ( word assoc symbol prop-name -- )
-    [ rot '[ nip _ = ] assoc-filter keys ] dip set-word-prop ;
+    [ rot '[ _ = ] filter-values keys ] dip set-word-prop ;
 
 : store-dependencies ( word assoc -- )
     keys "dependencies" set-word-prop ;

--- a/basis/compiler/tree/dead-code/simple/simple.factor
+++ b/basis/compiler/tree/dead-code/simple/simple.factor
@@ -38,7 +38,7 @@ M: #shuffle compute-live-values*
 M: #alien-node compute-live-values* nip look-at-inputs ;
 
 : filter-mapping ( assoc -- assoc' )
-    live-values get '[ drop _ key? ] assoc-filter ;
+    live-values get '[ _ key? ] filter-keys ;
 
 : filter-corresponding ( new old -- old' )
     zip filter-mapping values ;

--- a/basis/compiler/tree/escape-analysis/allocations/allocations.factor
+++ b/basis/compiler/tree/escape-analysis/allocations/allocations.factor
@@ -110,7 +110,7 @@ SYMBOL: escaping-allocations
 
 : compute-escaping-allocations ( -- )
     allocations get escaping-values get
-    '[ drop _ (escaping-value?) ] assoc-filter
+    '[ _ (escaping-value?) ] filter-keys
     escaping-allocations set ;
 
 : escaping-allocation? ( value -- ? )

--- a/basis/compiler/tree/tuple-unboxing/tuple-unboxing.factor
+++ b/basis/compiler/tree/tuple-unboxing/tuple-unboxing.factor
@@ -162,5 +162,5 @@ M: #alien-callback unbox-tuples* ;
 
 : unbox-tuples ( nodes -- nodes )
     allocations get escaping-allocations get
-    [ nip key? ] curry assoc-all?
+    [ key? ] curry all-values?
     [ [ unbox-tuples* ] map-nodes ] unless ;

--- a/basis/cpu/arm/64/64.factor
+++ b/basis/cpu/arm/64/64.factor
@@ -27,7 +27,7 @@ M: arm.64 %load-immediate ( reg val -- )
     [ XZR MOVr ] [
         { 0 1 2 3 } [
             tuck -16 * shift 0xffff bitand
-        ] with map>alist [ nip 0 = ] assoc-reject
+        ] with map>alist [ 0 = ] reject-values
         unclip
         overd first2 rot MOVZ
         [ first2 rot MOVK ] with each

--- a/basis/etc-hosts/etc-hosts.factor
+++ b/basis/etc-hosts/etc-hosts.factor
@@ -22,7 +22,6 @@ M: unix hosts-path "/etc/hosts" ;
 MEMO: system-hosts ( -- hosts ) hosts-path parse-hosts ;
 
 : host>ips ( host -- ips )
-    system-hosts [ member? nip ] with assoc-filter keys ;
+    system-hosts [ member? ] with filter-values keys ;
 
-: ip>hosts ( ip -- hosts )
-    system-hosts at ;
+: ip>hosts ( ip -- hosts ) system-hosts at ;

--- a/basis/fixups/fixups.factor
+++ b/basis/fixups/fixups.factor
@@ -66,14 +66,17 @@ CONSTANT: word-renames {
     { "count*" { "percent-of" "0.99" } }
     { "more?" { "deref?" "0.99" } }
     { "plox" { "?transmute" "0.99" } }
-    ! { "?if" { "?if" "0.99" } }
     { "ensure-non-negative" { "assert-non-negative" "0.99" } }
     { "order" { "dispatch-order" "0.99" } }
     { "TEST:" { "DEFINE-TEST-WORD:" "0.99" } }
+    { "assoc-all-key?" { "all-keys?" "0.100" } }
+    { "assoc-all-value?" { "all-values?" "0.100" } }
+    { "assoc-any-key?" { "any-key?" "0.100" } }
+    { "assoc-any-value?" { "any-value?" "0.100" } } 
 }
 
 : compute-assoc-fixups ( continuation name assoc -- seq )
-    swap '[ drop _ = ] assoc-filter [
+    swap '[ _ = ] filter-keys [
         drop { }
     ] [
         swap '[

--- a/basis/furnace/auth/providers/couchdb/couchdb.factor
+++ b/basis/furnace/auth/providers/couchdb/couchdb.factor
@@ -112,12 +112,10 @@ TUPLE: couchdb-auth-provider
     url>user ;
 
 : strip-hash ( hash1 -- hash2 )
-    [ drop first CHAR: _ = ] assoc-reject ;
+    [ first CHAR: _ = ] reject-keys ;
 
-: at-or-k ( key hash -- newkey )
-    ?at drop ;
-: value-at-or-k ( key hash -- newkey )
-    ?value-at drop ;
+: at-or-k ( key hash -- newkey ) ?at drop ;
+: value-at-or-k ( key hash -- newkey ) ?value-at drop ;
 
 : map-fields-forward ( assoc field-map -- assoc )
     [ swapd at-or-k swap ] curry assoc-map ;

--- a/basis/hints/hints.factor
+++ b/basis/hints/hints.factor
@@ -25,7 +25,7 @@ M: object specializer-declaration class-of ;
 : make-specializer ( specs -- quot )
     dup length <iota> <reversed>
     [ (picker) 2array ] 2map
-    [ drop object eq? ] assoc-reject
+    [ object eq? ] reject-keys
     [ [ t ] ] [
         [ swap specializer-predicate append ] { } assoc>map
         [ ] [ swap [ f ] \ if 3array [ ] append-as ] map-reduce

--- a/basis/html/templates/chloe/compiler/compiler.factor
+++ b/basis/html/templates/chloe/compiler/compiler.factor
@@ -7,10 +7,10 @@ xml.data xml.entities xml.writer ;
 IN: html.templates.chloe.compiler
 
 : chloe-attrs-only ( assoc -- assoc' )
-    [ drop chloe-name? ] assoc-filter ;
+    [ chloe-name? ] filter-keys ;
 
 : non-chloe-attrs-only ( assoc -- assoc' )
-    [ drop chloe-name? ] assoc-reject ;
+    [ chloe-name? ] reject-keys ;
 
 : chloe-tag? ( tag -- ? )
     dup xml? [ body>> ] when

--- a/basis/html/templates/chloe/components/components.factor
+++ b/basis/html/templates/chloe/components/components.factor
@@ -20,7 +20,7 @@ M: singleton-class component-tag
     bi* ;
 
 : compile-component-attrs ( tag class -- )
-    [ attrs>> [ drop main>> "name" = ] assoc-reject ] dip
+    [ attrs>> [ main>> "name" = ] reject-keys ] dip
     [ all-slots swap '[ name>> _ at compile-attr ] each ]
     [ [ boa ] [code-with] ]
     bi ;

--- a/basis/logging/analysis/analysis.factor
+++ b/basis/logging/analysis/analysis.factor
@@ -52,7 +52,7 @@ SYMBOL: message-histogram
 
 : analysis. ( errors word-histogram message-histogram -- )
     nl "==== FREQUENT MESSAGES:" print nl
-    "Total: " write dup values sum . nl
+    "Total: " write dup sum-values . nl
     [
         [ first name>> write bl ]
         [ second write ": " write ]

--- a/basis/math/floats/env/env.factor
+++ b/basis/math/floats/env/env.factor
@@ -53,8 +53,8 @@ HOOK: (fp-env-registers) cpu ( -- registers )
 
 : fp-env-register ( -- register ) (fp-env-registers) first ;
 
-:: mask> ( bits assoc -- symbols )
-    assoc [| k v | bits v mask zero? ] assoc-reject keys ;
+: mask> ( bits assoc -- symbols )
+    [ mask zero? ] with reject-values keys ;
 : >mask ( symbols assoc -- bits )
     over empty?
     [ 2drop 0 ]

--- a/basis/math/partial-dispatch/partial-dispatch.factor
+++ b/basis/math/partial-dispatch/partial-dispatch.factor
@@ -115,7 +115,7 @@ M: word integer-op-input-classes
     [ [ dup 3array ] [ swap ?lookup-method ] 2bi ] with { } map>assoc
     sift-values
     [ def>> ] assoc-map
-    [ nip length 1 = ] assoc-filter
+    [ length 1 = ] filter-values
     [ first ] assoc-map % ;
 
 SYMBOL: math-ops
@@ -135,7 +135,7 @@ SYMBOL: fast-math-ops
     [ drop math-class-max swap method-for-class >boolean ] if ;
 
 : (derived-ops) ( word assoc -- words )
-    swap '[ swap first _ eq? nip ] assoc-filter ;
+    swap '[ first _ eq? ] filter-keys ;
 
 : derived-ops ( word -- words )
     [ 1array ] [ math-ops get (derived-ops) values ] bi append ;
@@ -150,11 +150,10 @@ SYMBOL: fast-math-ops
     [ math-ops get (derived-ops) ] [ fast-math-ops get (derived-ops) ] bi
     [
         [
-            drop
             [ second integer class<= ]
             [ third integer class<= ]
             bi and
-        ] assoc-filter values
+        ] filter-keys values
     ] bi@ append ;
 
 : each-derived-op ( word quot -- )

--- a/basis/math/vectors/simd/simd-tests.factor
+++ b/basis/math/vectors/simd/simd-tests.factor
@@ -239,17 +239,17 @@ TUPLE: simd-test-failure
 
 : remove-float-words ( alist -- alist' )
     { distance vsqrt n/v v/n v/ normalize }
-    '[ drop _ member? ] assoc-reject ;
+    '[ _ member? ] reject-keys ;
 
 : remove-integer-words ( alist -- alist' )
     { vlshift vrshift v*high v*hs+ }
-    '[ drop _ member? ] assoc-reject ;
+    '[ _ member? ] reject-keys ;
 
 : boolean-ops ( -- words )
     { vand vandn vor vxor vnot vcount } ;
 
 : remove-boolean-words ( alist -- alist' )
-    boolean-ops '[ drop _ member? ] assoc-reject ;
+    boolean-ops '[ _ member? ] reject-keys ;
 
 : ops-to-check ( elt-class -- alist )
     [ vector-words >alist ] dip

--- a/basis/oauth1/oauth1.factor
+++ b/basis/oauth1/oauth1.factor
@@ -60,21 +60,22 @@ nonce ;
         ] bi
     ] H{ } make ; inline
 
-! Checksum all the params but only return the oauth_ params for use in the auth header.
+! Checksum all the params but only return the oauth_ params for
+! use in the auth header.
 ! See https://github.com/factor/factor/issues/2487
 :: sign-params ( url request-method consumer-token request-token params -- oauth-params )
     params sort-keys :> params
     url request-method params signature-base-string :> sbs
-    consumer-token secret>> request-token dup [ secret>> ] when hmac-key :> key
+    consumer-token secret>> request-token dup [ secret>> ] when
+    hmac-key :> key
     sbs key sha1 hmac-bytes >base64 >string :> signature
     params { "oauth_signature" signature } prefix
-    [ drop "oauth_" head? ] assoc-filter ;
+    [ "oauth_" head? ] filter-keys ;
 
 : extract-user-data ( assoc -- assoc' )
     [
-        drop
         { "oauth_token" "oauth_token_secret" } member? not
-    ] assoc-filter ;
+    ] filter-keys ;
 
 : parse-token ( response data -- token )
     nip

--- a/basis/regexp/dfa/dfa.factor
+++ b/basis/regexp/dfa/dfa.factor
@@ -13,7 +13,7 @@ IN: regexp.dfa
     new-question old-value = [
         new-question state table set-at
         state nfa transitions>> at
-        [ drop tagged-epsilon? ] assoc-filter
+        [ tagged-epsilon? ] filter-keys
         [| trans to |
             to [
                 table nfa

--- a/basis/regexp/disambiguate/disambiguate.factor
+++ b/basis/regexp/disambiguate/disambiguate.factor
@@ -58,7 +58,7 @@ TUPLE: parts in out ;
                 _ swap '[ _ get-transitions ] assoc-map
                 harvest-values
             ] [
-                [ drop tagged-epsilon? ] assoc-filter
+                [ tagged-epsilon? ] filter-keys
             ] bi H{ } assoc-union-as
         ] assoc-map
     ] change-transitions ;

--- a/basis/regexp/minimize/minimize.factor
+++ b/basis/regexp/minimize/minimize.factor
@@ -63,7 +63,7 @@ IN: regexp.minimize
     '[ dup _ at =  ] swap '[ _ at has-conditions? ] bi or ;
 
 : delete-duplicates ( transitions state-classes -- new-transitions )
-    dupd '[ drop _ _ canonical-state? ] assoc-filter ;
+    dupd '[ _ _ canonical-state? ] filter-keys ;
 
 : combine-states ( table -- smaller-table )
     dup state-classes

--- a/basis/smtp/smtp-tests.factor
+++ b/basis/smtp/smtp-tests.factor
@@ -79,8 +79,8 @@ IN: smtp.tests
         {
             [
                 email>headers sort-keys [
-                    drop { "Date" "Message-Id" } member? not
-                ] assoc-filter
+                    { "Date" "Message-Id" } member? not
+                ] filter-keys
             ]
             [ to>> [ extract-email ] map ]
             [ from>> extract-email ]

--- a/basis/tools/coverage/coverage.factor
+++ b/basis/tools/coverage/coverage.factor
@@ -86,7 +86,7 @@ M: string coverage
 
 M: word coverage
     "coverage" word-prop
-    [ drop executed?>> ] assoc-reject values ;
+    [ executed?>> ] reject-keys values ;
 
 GENERIC: coverage. ( object -- )
 

--- a/basis/tools/deploy/shaker/shaker.factor
+++ b/basis/tools/deploy/shaker/shaker.factor
@@ -123,7 +123,7 @@ IN: tools.deploy.shaker
     "Stripping word properties" show
     swap '[
         [
-            [ drop _ member? ] assoc-reject sift-values
+            [ _ member? ] reject-keys sift-values
             >alist f like
         ] change-props drop
     ] each ;
@@ -257,7 +257,7 @@ IN: tools.deploy.shaker
                 dup array? [
                     [
                         2 group
-                        [ drop _ in? ] assoc-reject
+                        [ _ in? ] reject-keys
                         concat
                     ] map
                 ] when

--- a/basis/tools/deprecation/deprecation.factor
+++ b/basis/tools/deprecation/deprecation.factor
@@ -65,7 +65,7 @@ SINGLETON: deprecation-observer
 
 : initialize-deprecation-notes ( -- )
     [
-        get-crossref [ drop deprecated? ] assoc-filter
+        get-crossref [ deprecated? ] filter-keys
         values [ members [ check-deprecations ] each ] each
     ] with-null-writer ;
 

--- a/basis/tools/profiler/sampling/sampling.factor
+++ b/basis/tools/profiler/sampling/sampling.factor
@@ -158,7 +158,7 @@ PRIVATE>
     [ total-time>> ] same? ;
 
 : trim-flat ( root-node -- root-node' )
-    dup '[ [ nip _ redundant-flat-node? ] assoc-reject ] change-children ;
+    dup '[ [ _ redundant-flat-node? ] reject-values ] change-children ;
 
 PRIVATE>
 

--- a/basis/ui/gadgets/panes/panes.factor
+++ b/basis/ui/gadgets/panes/panes.factor
@@ -303,10 +303,10 @@ MEMO:: specified-font ( name style size foreground background -- font )
 
 : remove-paragraph-styles ( style -- style' )
     [
-        drop HS{
+        HS{
             wrap-margin border-color page-color inset presented
         } in?
-    ] assoc-reject ;
+    ] reject-keys ;
 
 TUPLE: styled-pane < pane style ;
 

--- a/basis/unicode/data/data.factor
+++ b/basis/unicode/data/data.factor
@@ -132,7 +132,7 @@ PRIVATE>
 : process-combining ( data -- hash )
     3 swap (process-data)
     [ string>number ] assoc-map
-    [ nip zero? ] assoc-reject
+    [ zero? ] reject-values
     >hashtable ;
 
 ! the maximum unicode char in the first 3 planes

--- a/basis/windows/user32/user32.factor
+++ b/basis/windows/user32/user32.factor
@@ -2367,7 +2367,7 @@ FUNCTION: BOOL IsValidDpiAwarenessContext (
 
 ! DPI_AWARENESS_CONTEXT experimentally:
 ! USE: ranges -100 1000 [a..b] [ <alien> IsValidDpiAwarenessContext ] zip-with
-! [ nip 0 > ] assoc-filter keys .
+! [ 0 > ] filter-values keys .
 ! { -5 -4 -3 -2 -1 17 18 34 273 529 785 }
 
 ! -4 <alien> 34 <alien> AreDpiAwarenessContextsEqual . ! t

--- a/core/alien/alien.factor
+++ b/core/alien/alien.factor
@@ -124,7 +124,7 @@ TUPLE: expiry-check object alien ;
     [ alien>> expired? ] [ t ] if* ;
 
 : delete-values ( value assoc -- )
-    [ rot drop = ] with assoc-reject! drop ;
+    [ nipd = ] with assoc-reject! drop ;
 
 PRIVATE>
 

--- a/core/assocs/assocs.factor
+++ b/core/assocs/assocs.factor
@@ -335,3 +335,46 @@ M: enumerated length seq>> length ; inline
 M: enumerated nth-unsafe dupd seq>> nth-unsafe 2array ; inline
 
 INSTANCE: enumerated immutable-sequence
+
+: any-key? ( ... assoc quot: ( ... key -- ... ? ) -- ... ? )
+    [ drop ] prepose assoc-find 2nip ; inline
+
+: any-value? ( ... assoc quot: ( ... value -- ... ? ) -- ... ? )
+    [ nip ] prepose assoc-find 2nip ; inline
+
+: all-keys? ( ... assoc quot: ( ... key -- ... ? ) -- ... ? )
+    [ not ] compose any-key? not ; inline
+
+: all-values? ( ... assoc quot: ( ... value -- ... ? ) -- ... ? )
+    [ not ] compose any-value? not ; inline
+
+: assoc-reduce ( ... assoc identity quot: ( ... prev key value -- next ) -- ... result )
+    [ >alist ] 2dip [ first2 ] prepose reduce ; inline
+
+: reduce-keys ( ... assoc identity quot: ( ... prev elt -- ... next ) -- ... result )
+    [ drop ] prepose assoc-reduce ; inline
+
+: reduce-values ( ... assoc identity quot: ( ... prev elt -- ... next ) -- ... result )
+    [ nip ] prepose assoc-reduce ; inline
+
+: sum-keys ( assoc -- n ) 0 [ + ] reduce-keys ; inline
+
+: sum-values ( assoc -- n ) 0 [ + ] reduce-values ; inline
+
+: map-keys ( assoc quot: ( key -- key' ) -- assoc )
+    '[ _ dip ] assoc-map ; inline
+
+: map-values ( assoc quot: ( value -- value' ) -- assoc )
+    '[ swap _ dip swap ] assoc-map ; inline
+
+: filter-keys ( assoc quot: ( key -- ? ) -- assoc' )
+    '[ drop @ ] assoc-filter ; inline
+
+: filter-values ( assoc quot: ( value -- ? ) -- assoc' )
+    '[ nip @ ] assoc-filter ; inline
+
+: reject-keys ( assoc quot: ( key -- ? ) -- assoc' )
+    '[ drop @ ] assoc-reject ; inline
+
+: reject-values ( assoc quot: ( value -- ? ) -- assoc' )
+    '[ nip @ ] assoc-reject ; inline

--- a/core/generic/single/single.factor
+++ b/core/generic/single/single.factor
@@ -90,7 +90,7 @@ C: <predicate-engine> predicate-engine
 ! 2. Convert methods
 : split-methods ( assoc class -- first second )
     [ [ nip class<= ] curry assoc-reject ]
-    [ [ nip class<=     ] curry assoc-filter ] 2bi ;
+    [ [ nip class<= ] curry assoc-filter ] 2bi ;
 
 : convert-methods ( assoc class word -- assoc' )
     over [ split-methods ] 2dip pick assoc-empty?

--- a/core/hash-sets/hash-sets.factor
+++ b/core/hash-sets/hash-sets.factor
@@ -23,7 +23,7 @@ TUPLE: hash-set
     [ 3dup swap array-nth ] dip over +empty+ eq?
     [ 4drop no-key ] [
         [ = ] dip swap
-        [ drop rot drop t ]
+        [ roll 2drop t ]
         [ probe (key@) ]
         if
     ] if ; inline recursive

--- a/core/hashtables/hashtables.factor
+++ b/core/hashtables/hashtables.factor
@@ -26,7 +26,7 @@ TUPLE: hashtable
     [ 3dup swap array-nth ] dip over +empty+ eq?
     [ 4drop no-key ] [
         [ = ] dip swap
-        [ drop rot drop t ]
+        [ roll 2drop t ]
         [ probe (key@) ]
         if
     ] if ; inline recursive

--- a/core/vocabs/parser/parser.factor
+++ b/core/vocabs/parser/parser.factor
@@ -248,7 +248,7 @@ PRIVATE>
 GENERIC: update ( search-path-elt -- valid? )
 
 : trim-forgotten ( qualified-vocab -- valid? )
-    [ [ nip "forgotten" word-prop ] assoc-reject ] change-words
+    [ [ "forgotten" word-prop ] reject-values ] change-words
     words>> assoc-empty? not ;
 
 M: from update trim-forgotten ;

--- a/extra/anagrams/anagrams.factor
+++ b/extra/anagrams/anagrams.factor
@@ -8,7 +8,7 @@ IN: anagrams
 : make-anagram-hash ( strings -- assoc )
     [ sort ] collect-by
     [ members ] assoc-map
-    [ nip length 1 > ] assoc-filter ;
+    [ length 1 > ] filter-values ;
 
 MEMO: dict-words ( -- seq )
     "/usr/share/dict/words" ascii file-lines [ >lower ] map ;

--- a/extra/assocs/extras/extras.factor
+++ b/extra/assocs/extras/extras.factor
@@ -11,7 +11,8 @@ IN: assocs.extras
 
 : of+ ( assoc key n -- assoc ) '[ 0 or _ + ] change-of ; inline
 
-: of+* ( assoc key n -- assoc old new ) '[ [ 0 or _ + ] keep swap dup ] change-of ; inline
+: of+* ( assoc key n -- assoc old new )
+    '[ [ 0 or _ + ] keep swap dup ] change-of ; inline
 
 : delete-of ( assoc key -- assoc ) over delete-at ; inline
 
@@ -58,37 +59,6 @@ IN: assocs.extras
 
 : substitute! ( seq assoc -- seq )
     substituter map! ;
-
-: assoc-reduce ( ... assoc identity quot: ( ... prev key value -- next ) -- ... result )
-    [ >alist ] 2dip [ first2 ] prepose reduce ; inline
-
-: reduce-keys ( ... assoc identity quot: ( ... prev elt -- ... next ) -- ... result )
-    [ drop ] prepose assoc-reduce ; inline
-
-: reduce-values ( ... assoc identity quot: ( ... prev elt -- ... next ) -- ... result )
-    [ nip ] prepose assoc-reduce ; inline
-
-: sum-keys ( assoc -- n ) 0 [ + ] reduce-keys ; inline
-
-: sum-values ( assoc -- n ) 0 [ + ] reduce-values ; inline
-
-: map-keys ( assoc quot: ( key -- key' ) -- assoc )
-    '[ _ dip ] assoc-map ; inline
-
-: map-values ( assoc quot: ( value -- value' ) -- assoc )
-    '[ swap _ dip swap ] assoc-map ; inline
-
-: filter-keys ( assoc quot: ( key -- ? ) -- assoc' )
-    '[ drop @ ] assoc-filter ; inline
-
-: filter-values ( assoc quot: ( value -- ? ) -- assoc' )
-    '[ nip @ ] assoc-filter ; inline
-
-: reject-keys ( assoc quot: ( key -- ? ) -- assoc' )
-    '[ drop @ ] assoc-reject ; inline
-
-: reject-values ( assoc quot: ( value -- ? ) -- assoc' )
-    '[ nip @ ] assoc-reject ; inline
 
 : rekey-new-assoc ( assoc keys -- newassoc )
     [ tuck of ] with H{ } map>assoc ; inline
@@ -244,23 +214,9 @@ PRIVATE>
 : expand-values-push ( assoc -- sequence )
     V{ } expand-values-push-as ; inline
 
-: assoc-any-key? ( ... assoc quot: ( ... key -- ... ? ) -- ... ? )
-    [ drop ] prepose assoc-find 2nip ; inline
+: any-multi-key? ( assoc -- ? ) [ sequence? ] any-key? ;
 
-: assoc-any-value? ( ... assoc quot: ( ... value -- ... ? ) -- ... ? )
-    [ nip ] prepose assoc-find 2nip ; inline
-
-: assoc-all-key? ( ... assoc quot: ( ... key -- ... ? ) -- ... ? )
-    [ not ] compose assoc-any-key? not ; inline
-
-: assoc-all-value? ( ... assoc quot: ( ... value -- ... ? ) -- ... ? )
-    [ not ] compose assoc-any-value? not ; inline
-
-: any-multi-key? ( assoc -- ? )
-    [ sequence? ] assoc-any-key? ;
-
-: any-multi-value? ( assoc -- ? )
-    [ sequence? ] assoc-any-value? ;
+: any-multi-value? ( assoc -- ? ) [ sequence? ] any-value? ;
 
 : flatten-keys ( assoc -- assoc' )
     dup any-multi-key? [ expand-keys-set-at flatten-keys ] when ;

--- a/extra/calendar/holidays/holidays.factor
+++ b/extra/calendar/holidays/holidays.factor
@@ -45,7 +45,7 @@ M: all holidays drop (holidays) ;
     [
         [ clone ] dip
         [ drop ] [ holiday-assoc ] 2bi swap
-        '[ drop _ same-day? ] assoc-filter values
+        '[ _ same-day? ] filter-keys values
     ] keep '[ _ swap "holiday" word-prop at ] map ;
 
 HOLIDAY: armistice-day november 11 >>day ;

--- a/extra/cgi/cgi.factor
+++ b/extra/cgi/cgi.factor
@@ -10,7 +10,7 @@ IN: cgi
 <PRIVATE
 
 : query-string ( string -- assoc )
-    query>assoc [ nip ] assoc-filter [
+    query>assoc sift-values [
         [ [ CHAR: \s = ] trim ]
         [ dup string? [ 1array ] when ] bi*
     ] assoc-map ;

--- a/extra/crypto/rsa/rsa.factor
+++ b/extra/crypto/rsa/rsa.factor
@@ -27,11 +27,7 @@ CONSTANT: public-key 65537
     ! Loop until phi is not divisible by the public key.
     dup rsa-primes [ * ] 2keep
     [ 1 - ] bi@ *
-    dup public-key coprime? [
-        rot drop
-    ] [
-        2drop modulus-phi
-    ] if ;
+    dup public-key coprime? [ nipd ] [ 2drop modulus-phi ] if ;
 
 PRIVATE>
 

--- a/extra/git/git.factor
+++ b/extra/git/git.factor
@@ -427,7 +427,7 @@ ERROR: repeated-parent-hash hash ;
     ] with-variable ;
 
 : filter-git-remotes ( seq -- seq' )
-    [ drop "remote" head? ] assoc-filter ;
+    [ "remote" head? ] filter-keys ;
 
 : github-git-remote? ( hash -- ? )
     "url" of [ CHAR: / = ] trim-tail "git@github.com:" head? ;
@@ -454,10 +454,10 @@ ERROR: repeated-parent-hash hash ;
     git-config-path utf8 file-contents string>ini >alist ;
 
 : has-any-git-at-urls? ( git-ini -- ? )
-    [ nip github-git-remote? ] assoc-any? ;
+    [ github-git-remote? ] any-value? ;
 
 : has-remote-repo? ( git-ini owner repo -- ? )
-    '[ nip _ _ git-remote-matches? ] assoc-filter f like ;
+    '[ _ _ git-remote-matches? ] filter-values f like ;
 
 : write-git-config ( seq -- )
     ini>string git-config-path utf8 set-file-contents ;

--- a/extra/koszul/koszul.factor
+++ b/extra/koszul/koszul.factor
@@ -18,8 +18,7 @@ IN: koszul
         [ 1array >alt ]
     } cond ;
 
-: canonicalize ( assoc -- assoc' )
-    [ nip zero? ] assoc-reject ;
+: canonicalize ( assoc -- assoc' ) [ zero? ] reject-values ;
 
 SYMBOL: terms
 

--- a/extra/lint/lint.factor
+++ b/extra/lint/lint.factor
@@ -32,6 +32,7 @@ CONSTANT: manual-substitutions
         { spin [ swap rot ] }
         { >boolean [ f = not ] }
         { keep [ over [ call ] dip ] }
+        { nipd [ rot drop ] }
     }
 
 CONSTANT: trivial-defs
@@ -248,7 +249,7 @@ SYMBOL: lint-definitions-keys
     [ keys lint-definitions-keys set-global ] bi ;
 
 : find-duplicates ( -- seq )
-    lint-definitions get-global [ nip length 1 > ] assoc-filter ;
+    lint-definitions get-global [ length 1 > ] filter-values ;
 
 GENERIC: lint ( obj -- seq )
 
@@ -284,9 +285,9 @@ GENERIC: run-lint ( obj -- obj )
 
 : filter-symbols ( alist -- alist )
     [
-        nip first dup lint-definitions get-global at
+        first dup lint-definitions get-global at
         [ first ] bi@ literalize = not
-    ] assoc-filter ;
+    ] filter-values ;
 
 M: sequence run-lint ( seq -- seq )
     [ lint ] zip-with trim-self

--- a/extra/lint/vocabs/vocabs.factor
+++ b/extra/lint/vocabs/vocabs.factor
@@ -198,11 +198,8 @@ DEFER: next-token
 : no-vocab-found ( name -- empty )
     { } 2array ;
 
-: [is-used?] ( hash-set  -- quot )
-    '[ nip [ _ in? ] any? ] ; inline
-
 : reject-unused-vocabs ( assoc hash-set -- seq )
-    [is-used?] assoc-reject keys ;
+    '[ [ _ in? ] any? ] reject-values keys ;
 
 :: print-new-header ( seq -- )
     "Use the following header to remove unused imports: " print

--- a/extra/managed-server/managed-server.factor
+++ b/extra/managed-server/managed-server.factor
@@ -28,7 +28,7 @@ M: managed-server handle-client-disconnect ;
 : client-streams ( -- assoc ) clients values ;
 : username ( -- string ) client username>> ;
 : everyone-else ( -- assoc )
-    clients [ drop username = ] assoc-reject ;
+    clients [ username = ] reject-keys ;
 : everyone-else-streams ( -- assoc ) everyone-else values ;
 
 ERROR: no-such-client username ;

--- a/extra/modern/modern.factor
+++ b/extra/modern/modern.factor
@@ -485,7 +485,7 @@ ERROR: compound-syntax-disallowed n seq obj ;
 : lex-vocabs ( vocabs -- assoc )
     [ [ vocab>literals ] [ nip ] recover ] zip-with ;
 
-: failed-lexing ( assoc -- assoc' ) [ nip array? ] assoc-reject ;
+: failed-lexing ( assoc -- assoc' ) [ array? ] reject-values ;
 
 : rewrite-file ( path encoding quot: ( str -- str' ) -- )
     '[ file-contents @ ] 2keep set-file-contents ; inline

--- a/extra/multi-methods/multi-methods.factor
+++ b/extra/multi-methods/multi-methods.factor
@@ -114,7 +114,7 @@ SYMBOL: total
 : multi-predicate ( classes -- quot )
     dup length <iota> <reversed>
     [ picker 2array ] 2map
-    [ drop object eq? ] assoc-reject
+    [ object eq? ] reject-keys
     [ [ t ] ] [
         [ (multi-predicate) ] { } assoc>map
         unclip [ swap [ f ] \ if 3array [ ] append-as ] reduce

--- a/extra/npm/npm.factor
+++ b/extra/npm/npm.factor
@@ -46,6 +46,6 @@ M: f dev-deps drop { } ;
     ?github-package-json [
         [ "dependencies" of ] [ "devDependencies" of ] bi 2array [
             [ over npm-latest-version "version" of 2array ] parallel-assoc-map
-            [ nip first2 = not ] assoc-filter
+            [ first2 = not ] filter-values
         ] map
     ] transmute ;

--- a/extra/project-euler/061/061.factor
+++ b/extra/project-euler/061/061.factor
@@ -77,6 +77,6 @@ IN: project-euler.061
 : euler061 ( -- n )
     4-digit-polygons dup [ 8 = ] filter-keys [
         1array 6 find-cycle
-    ] with map-find drop values sum ;
+    ] with map-find drop sum-values ;
 
 SOLUTION: euler061

--- a/extra/project-euler/164/164.factor
+++ b/extra/project-euler/164/164.factor
@@ -32,7 +32,7 @@ IN: project-euler.164
 PRIVATE>
 
 : euler164 ( -- answer )
-    init-table 19 [ next-table ] times values sum ;
+    init-table 19 [ next-table ] times sum-values ;
 
 ! [ euler164 ] 100 ave-time
 ! 7 ms ave run time - 1.23 SD (100 trials)

--- a/extra/rosetta-code/anagrams-deranged/anagrams-deranged.factor
+++ b/extra/rosetta-code/anagrams-deranged/anagrams-deranged.factor
@@ -32,8 +32,7 @@ IN: rosettacode.anagrams-deranged
         ] each
     ] keep ;
 
-: anagrams ( hash -- seq )
-    [ nip length 1 > ] assoc-filter values ;
+: anagrams ( hash -- seq ) [ length 1 > ] filter-values values ;
 
 : deranged-anagrams ( path -- seq )
     parse-dict-file anagrams [ derangements ] map concat ;

--- a/extra/sequences/abbrev/abbrev.factor
+++ b/extra/sequences/abbrev/abbrev.factor
@@ -16,4 +16,4 @@ PRIVATE>
     ] keep ;
 
 : unique-abbrev ( seqs -- assoc )
-    abbrev [ nip length 1 = ] assoc-filter ;
+    abbrev [ length 1 = ] filter-values ;

--- a/extra/sequences/extras/extras.factor
+++ b/extra/sequences/extras/extras.factor
@@ -5,7 +5,7 @@ sorting splitting vectors ;
 IN: sequences.extras
 
 : find-all ( ... seq quot: ( ... elt -- ... ? ) -- ... elts )
-    [ <enumerated> ] dip '[ nip @ ] assoc-filter ; inline
+    [ <enumerated> ] dip '[ @ ] filter-values ; inline
 
 :: subseq* ( from to seq -- subseq )
     seq length :> len

--- a/extra/smalltalk/compiler/compiler.factor
+++ b/extra/smalltalk/compiler/compiler.factor
@@ -71,7 +71,7 @@ M: ast-return compile-ast
         dup dup _ in? [ <local-reader> ] [ <local> ] if
     ] H{ } map>assoc
     dup
-    [ nip local-reader? ] assoc-filter
+    [ local-reader? ] filter-values
     [ <local-writer> ] assoc-map
     <lexenv> swap >>local-writers swap >>local-readers ;
 

--- a/extra/tools/image-analyzer/gc-info/gc-info-tests.factor
+++ b/extra/tools/image-analyzer/gc-info/gc-info-tests.factor
@@ -50,7 +50,7 @@ QUALIFIED: opencl
 : base-pointer-groups-decoded ( word -- seq )
     word>gc-maps [
         second second [ swap 2array ] map-index
-        [ nip -1 = ] assoc-reject
+        [ -1 = ] reject-values
     ] map ;
 
 ! byte-array>bit-array

--- a/extra/zealot/help-lint/help-lint.factor
+++ b/extra/zealot/help-lint/help-lint.factor
@@ -14,7 +14,7 @@ CONSTANT: ignored-resources {
 }
 
 : filter-flaky-resources ( seq -- seq' )
-    [ drop unparse ignored-resources member? ] assoc-reject ;
+    [ unparse ignored-resources member? ] reject-keys ;
 
 ! Allow testing without calling exit
 : zealot-help-lint ( exit? -- )


### PR DESCRIPTION
* Move assoc-reduce, {filter,reject,map,reduce,sum}-{keys,values}, assoc-any-{key,value}, assoc-all-{keys,values} to assocs
* Rename assoc-all-{key,value} to assoc-all-{keys,values}
* Use moved words

* Substitute `rot drop` => `nipd`, `drop rot drop` => `roll 2drop`
* Add lint for `rot drop` = `nipd`