### PR TITLE
Refactor virtual sequences

### DIFF
--- a/basis/circular/circular.factor
+++ b/basis/circular/circular.factor
@@ -3,7 +3,7 @@
 USING: accessors arrays kernel math sequences strings ;
 IN: circular
 
-TUPLE: circular { seq read-only } { start integer } ;
+TUPLE: circular < sequence-view { start integer } ;
 
 : <circular> ( seq -- circular )
     0 circular boa ; inline
@@ -16,11 +16,9 @@ TUPLE: circular { seq read-only } { start integer } ;
 
 PRIVATE>
 
-M: circular length seq>> length ; inline
 
 M: circular virtual@ circular-wrap seq>> ; inline
 
-M: circular virtual-exemplar seq>> ; inline
 
 : change-circular-start ( n circular -- )
     ! change start to (start + n) mod length
@@ -35,7 +33,6 @@ M: circular virtual-exemplar seq>> ; inline
 : <circular-string> ( n -- circular )
     0 <string> <circular> ; inline
 
-INSTANCE: circular virtual-sequence
 
 TUPLE: growing-circular < circular { length integer } ;
 

--- a/basis/circular/circular.factor
+++ b/basis/circular/circular.factor
@@ -16,9 +16,7 @@ TUPLE: circular < sequence-view { start integer } ;
 
 PRIVATE>
 
-
 M: circular virtual@ circular-wrap seq>> ; inline
-
 
 : change-circular-start ( n circular -- )
     ! change start to (start + n) mod length
@@ -32,7 +30,6 @@ M: circular virtual@ circular-wrap seq>> ; inline
 
 : <circular-string> ( n -- circular )
     0 <string> <circular> ; inline
-
 
 TUPLE: growing-circular < circular { length integer } ;
 

--- a/basis/columns/columns.factor
+++ b/basis/columns/columns.factor
@@ -4,15 +4,11 @@ USING: sequences kernel accessors ;
 IN: columns
 
 ! A column of a matrix
-TUPLE: column seq col ;
+TUPLE: column < sequence-view col ;
 
 C: <column> column
 
-M: column virtual-exemplar seq>> ;
 M: column virtual@ [ col>> swap ] [ seq>> ] bi nth bounds-check ;
-M: column length seq>> length ;
-
-INSTANCE: column virtual-sequence
 
 : <flipped> ( seq -- seq' )
     dup empty? [ dup first length [ <column> ] with map-integers ] unless ;

--- a/basis/grouping/grouping.factor
+++ b/basis/grouping/grouping.factor
@@ -90,15 +90,13 @@ TUPLE: circular-slice
     { to integer read-only }
     { seq read-only } ;
 
-INSTANCE: circular-slice virtual-sequence
+INSTANCE: circular-slice wrapped-sequence
 
 M: circular-slice equal? over circular-slice? [ sequence= ] [ 2drop f ] if ;
 
 M: circular-slice hashcode* [ sequence-hashcode ] recursive-hashcode ;
 
 M: circular-slice length [ to>> ] [ from>> ] bi - ; inline
-
-M: circular-slice virtual-exemplar seq>> ; inline
 
 M: circular-slice virtual@
     [ from>> + ] [ seq>> ] bi [ length rem ] keep ; inline

--- a/core/classes/tuple/tuple-tests.factor
+++ b/core/classes/tuple/tuple-tests.factor
@@ -195,7 +195,8 @@ M: string silly "t" ;
 
 M: vector silly "z" ;
 
-{ "zz" } [ 123 <reversed> silly nip ] unit-test
+[ 123 <reversed> ] must-fail
+{ "zz" } [ { 123 } <reversed> silly nip ] unit-test
 
 ! Typo
 SYMBOL: not-a-tuple-class
@@ -624,9 +625,9 @@ must-fail-with
 ] unit-test
 
 
-{ } [
-    "IN: sequences TUPLE: reversed { seq read-only } ;" eval( -- )
-] unit-test
+! { } [
+!     "IN: sequences TUPLE: reversed { seq read-only } ;" eval( -- )
+! ] unit-test
 
 
 TUPLE: bogus-hashcode-1 x ;

--- a/core/classes/tuple/tuple-tests.factor
+++ b/core/classes/tuple/tuple-tests.factor
@@ -625,9 +625,9 @@ must-fail-with
 ] unit-test
 
 
-! { } [
-!     "IN: sequences TUPLE: reversed { seq read-only } ;" eval( -- )
-! ] unit-test
+{ } [
+     "IN: sequences TUPLE: reversed < sequence-view ;" eval( -- )
+] unit-test
 
 
 TUPLE: bogus-hashcode-1 x ;

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -255,8 +255,6 @@ PRIVATE>
 : <slice> ( from to seq -- slice )
     check-slice <slice-unsafe> ; inline
 
-M: slice virtual-exemplar seq>> ; inline
-
 M: slice virtual@ [ from>> + ] [ seq>> ] bi ; inline
 
 M: slice length [ to>> ] [ from>> ] bi - ; inline
@@ -273,7 +271,7 @@ M: slice length [ to>> ] [ from>> ] bi - ; inline
 
 : but-last-slice ( seq -- slice ) 1 head-slice* ; inline
 
-INSTANCE: slice virtual-sequence
+INSTANCE: slice wrapped-sequence
 
 ! One element repeated many times
 TUPLE: repetition

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -210,11 +210,12 @@ M: virtual-sequence new-sequence virtual-exemplar new-sequence ; inline
 INSTANCE: virtual-sequence sequence
 
 TUPLE: sequence-view { seq read-only } ;
-INSTANCE: sequence-view virtual-sequence
 
 M: sequence-view virtual-exemplar seq>> ; inline
 M: sequence-view virtual@ seq>> ; inline
 M: sequence-view length seq>> length ; inline
+
+INSTANCE: sequence-view virtual-sequence
 
 ! A reversal of an underlying sequence.
 TUPLE: reversed < sequence-view ;

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -209,7 +209,6 @@ M: virtual-sequence new-sequence virtual-exemplar new-sequence ; inline
 
 INSTANCE: virtual-sequence sequence
 
-! TUPLE: sequence-view { seq sequence read-only } ;
 TUPLE: sequence-view { seq read-only } ;
 INSTANCE: sequence-view virtual-sequence
 
@@ -218,15 +217,11 @@ M: sequence-view virtual@ seq>> ; inline
 M: sequence-view length seq>> length ; inline
 
 ! A reversal of an underlying sequence.
-TUPLE: reversed { seq read-only } ;
+TUPLE: reversed < sequence-view ;
 
 C: <reversed> reversed
 
-M: reversed virtual-exemplar seq>> ; inline
 M: reversed virtual@ seq>> [ length swap - 1 - ] keep ; inline
-M: reversed length seq>> length ; inline
-
-INSTANCE: reversed virtual-sequence
 
 ! A slice of another sequence.
 TUPLE: slice

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -215,8 +215,8 @@ M: wrapped-sequence virtual-exemplar seq>> ; inline
 M: wrapped-sequence virtual@ seq>> ; inline
 M: wrapped-sequence length seq>> length ; inline
 INSTANCE: wrapped-sequence virtual-sequence
-TUPLE: sequence-view { seq sequence read-only } ;
 
+TUPLE: sequence-view { seq sequence read-only } ;
 INSTANCE: sequence-view wrapped-sequence
 
 ! A reversal of an underlying sequence.

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -209,7 +209,7 @@ M: virtual-sequence new-sequence virtual-exemplar new-sequence ; inline
 
 INSTANCE: virtual-sequence sequence
 
-TUPLE: sequence-view { seq read-only } ;
+TUPLE: sequence-view { seq sequence read-only } ;
 
 M: sequence-view virtual-exemplar seq>> ; inline
 M: sequence-view virtual@ seq>> ; inline

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -217,11 +217,7 @@ M: wrapped-sequence length seq>> length ; inline
 INSTANCE: wrapped-sequence virtual-sequence
 TUPLE: sequence-view { seq sequence read-only } ;
 
-M: sequence-view virtual-exemplar seq>> ; inline
-M: sequence-view virtual@ seq>> ; inline
-M: sequence-view length seq>> length ; inline
-
-INSTANCE: sequence-view virtual-sequence
+INSTANCE: sequence-view wrapped-sequence
 
 ! A reversal of an underlying sequence.
 TUPLE: reversed < sequence-view ;

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -209,6 +209,14 @@ M: virtual-sequence new-sequence virtual-exemplar new-sequence ; inline
 
 INSTANCE: virtual-sequence sequence
 
+! TUPLE: sequence-view { seq sequence read-only } ;
+TUPLE: sequence-view { seq read-only } ;
+INSTANCE: sequence-view virtual-sequence
+
+M: sequence-view virtual-exemplar seq>> ; inline
+M: sequence-view virtual@ seq>> ; inline
+M: sequence-view length seq>> length ; inline
+
 ! A reversal of an underlying sequence.
 TUPLE: reversed { seq read-only } ;
 

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -209,6 +209,12 @@ M: virtual-sequence new-sequence virtual-exemplar new-sequence ; inline
 
 INSTANCE: virtual-sequence sequence
 
+! all wrapped-sequence instances need to define a slot `seq` that is a sequence
+MIXIN: wrapped-sequence
+M: wrapped-sequence virtual-exemplar seq>> ; inline
+M: wrapped-sequence virtual@ seq>> ; inline
+M: wrapped-sequence length seq>> length ; inline
+INSTANCE: wrapped-sequence virtual-sequence
 TUPLE: sequence-view { seq sequence read-only } ;
 
 M: sequence-view virtual-exemplar seq>> ; inline

--- a/extra/gap-buffer/gap-buffer.factor
+++ b/extra/gap-buffer/gap-buffer.factor
@@ -74,9 +74,7 @@ ERROR: index-out-of-bounds index gap-buffer ;
 
 M: gb virtual@ ( n gb -- n seq ) [ position>index ] keep seq>> ;
 
-M: gb virtual-exemplar seq>> ;
-
-INSTANCE: gb virtual-sequence
+INSTANCE: gb wrapped-sequence
 
 ! ------------- moving the gap -------------------------------
 

--- a/extra/sequences/extras/extras.factor
+++ b/extra/sequences/extras/extras.factor
@@ -579,7 +579,7 @@ PRIVATE>
 : 2map-index ( ... seq1 seq2 quot: ( ... elt1 elt2 index -- ... newelt ) -- ... newseq )
     pick [ 2sequence-index-iterator ] dip map-integers-as ; inline
 
-TUPLE: evens { seq read-only } ;
+TUPLE: evens < sequence-view ;
 
 C: <evens> evens
 
@@ -587,21 +587,13 @@ M: evens length seq>> length 1 + 2/ ; inline
 
 M: evens virtual@ [ 2 * ] [ seq>> ] bi* ; inline
 
-M: evens virtual-exemplar seq>> ; inline
-
-INSTANCE: evens virtual-sequence
-
-TUPLE: odds { seq read-only } ;
+TUPLE: odds < sequence-view ;
 
 C: <odds> odds
 
 M: odds length seq>> length 2/ ; inline
 
 M: odds virtual@ [ 2 * 1 + ] [ seq>> ] bi* ; inline
-
-M: odds virtual-exemplar seq>> ; inline
-
-INSTANCE: odds virtual-sequence
 
 : until-empty ( seq quot -- )
     [ dup empty? ] swap until drop ; inline

--- a/extra/sequences/extras/extras.factor
+++ b/extra/sequences/extras/extras.factor
@@ -1046,8 +1046,6 @@ TUPLE: step-slice
     seq dup slice? [ collapse-slice ] when
     step step-slice boa ;
 
-M: step-slice virtual-exemplar seq>> ; inline
-
 M: step-slice virtual@
     [ step>> * ] [ from>> + ] [ seq>> ] tri ; inline
 
@@ -1056,7 +1054,7 @@ M: step-slice length
     dup 0 < [ [ neg 0 max ] dip neg ] when /mod
     zero? [ 1 + ] unless ; inline
 
-INSTANCE: step-slice virtual-sequence
+INSTANCE: step-slice wrapped-sequence
 
 : 2nested-each* ( seq1 seq-quot: ( n -- seq ) quot: ( a b -- ) -- )
     '[

--- a/extra/sequences/frozen/frozen.factor
+++ b/extra/sequences/frozen/frozen.factor
@@ -3,16 +3,8 @@
 USING: accessors sequences ;
 IN: sequences.frozen
 
-TUPLE: frozen { seq read-only } ;
+TUPLE: frozen < sequence-view ;
 
 C: <frozen> frozen
-
-M: frozen virtual@ seq>> ;
-
-M: frozen virtual-exemplar seq>> ;
-
-M: frozen length seq>> length ;
-
-INSTANCE: frozen virtual-sequence
 
 INSTANCE: frozen immutable-sequence

--- a/extra/sequences/repeating/repeating.factor
+++ b/extra/sequences/repeating/repeating.factor
@@ -27,8 +27,7 @@ M: cycles virtual-exemplar circular>> ;
 
 INSTANCE: cycles virtual-sequence
 
-TUPLE: element-repeats
-{ seq sequence read-only }
+TUPLE: element-repeats < sequence-view
 { times integer read-only } ;
 
 C: <element-repeats> element-repeats
@@ -37,11 +36,7 @@ M: element-repeats length [ seq>> length ] [ times>> ] bi * ;
 
 M: element-repeats virtual@ [ times>> /i ] [ seq>> ] bi ;
 
-M: element-repeats virtual-exemplar seq>> ;
-
 INSTANCE: element-repeats immutable-sequence
-
-INSTANCE: element-repeats virtual-sequence
 
 : repeat-elements ( seq times -- new-seq )
     dupd <element-repeats> swap like ;

--- a/extra/sequences/rotated/rotated.factor
+++ b/extra/sequences/rotated/rotated.factor
@@ -3,13 +3,10 @@
 USING: accessors kernel math sequences ;
 IN: sequences.rotated
 
-TUPLE: rotated
-{ seq read-only }
+TUPLE: rotated < sequence-view
 { n integer read-only } ;
 
 C: <rotated> rotated
-
-M: rotated length seq>> length ;
 
 M: rotated virtual@
     [ n>> + ] [ seq>> ] bi [
@@ -17,10 +14,6 @@ M: rotated virtual@
             2dup >= [ - ] [ drop ] if
         ] if
     ] keep ;
-
-M: rotated virtual-exemplar seq>> ;
-
-INSTANCE: rotated virtual-sequence
 
 : all-rotations ( seq -- seq' )
     dup length <iota> [ <rotated> ] with map ;

--- a/extra/sequences/snipped/snipped.factor
+++ b/extra/sequences/snipped/snipped.factor
@@ -3,8 +3,7 @@
 USING: accessors kernel math math.order sequences ;
 IN: sequences.snipped
 
-TUPLE: snipped
-{ seq sequence read-only }
+TUPLE: snipped < sequence-view
 { from integer read-only }
 { length integer read-only } ;
 
@@ -19,7 +18,3 @@ M: snipped length [ seq>> length ] [ length>> ] bi [-] ;
 M: snipped virtual@
     [ [ from>> dupd >= ] keep [ length>> + ] curry when ]
     [ seq>> ] bi ;
-
-M: snipped virtual-exemplar seq>> ;
-
-INSTANCE: snipped virtual-sequence


### PR DESCRIPTION
Refactored all applicable instances of `virtual-sequence` with `wrapped-sequence` and `sequence-view`. Leads to identical code when viewed with `optimized.`. All applicable unit-tests pass (didn't run `test-all` locally because it takes forever).

Result is significantly less use of boilerplate code. After the refactor, no more obvious candidates for refactoring remain.

__*Needs new boot image*__ because of changes in `sequences`.

