### PR TITLE
Fix: correct gl-function loading

### DIFF
--- a/basis/opengl/gl/extensions/extensions.factor
+++ b/basis/opengl/gl/extensions/extensions.factor
@@ -53,6 +53,7 @@ reset-gl-function-number-counter
 SYNTAX: GL-FUNCTION:
     gl-function-calling-convention
     scan-function-name
-    "{" expect "}" parse-tokens over suffix
+    "{" expect "}" parse-tokens over prefix
     gl-function-counter '[ _ _ gl-function-pointer ]
     scan-c-args define-indirect ;
+


### PR DESCRIPTION
suffix appends the "modern" function at the end, which makes it so the old deprecated opengl1 function gets loaded which are not part of the opengl standard anymore and make usage of shader debugger like renderdoc impossible. This fixes it and should also preserve functionality on old hardware.