### PR TITLE
calendar: do not call day-of-week twice in weekday?

### DIFF
--- a/basis/calendar/calendar-tests.factor
+++ b/basis/calendar/calendar-tests.factor
@@ -287,6 +287,12 @@ IN: calendar
 { 151 } [ 2014 1 10 <date>  2014 8 9 <date>  weekdays-between ] unit-test
 { 151 } [ 2014 1 10 <date>  2014 8 10 <date>  weekdays-between ] unit-test
 
+{ t } [ 2014 1 10 <date> weekday? ] unit-test
+{ f } [ 2014 1 10 <date> weekend? ] unit-test
+
+{ t } [ 2014 1 11 <date> weekend? ] unit-test
+{ f } [ 2014 1 11 <date> weekday? ] unit-test
+
 
 { t } [
     2014 1 1 <date-gmt>

--- a/basis/calendar/calendar.factor
+++ b/basis/calendar/calendar.factor
@@ -738,7 +738,7 @@ ALIAS: last-day-of-week saturday
 : december? ( timestamp -- ? ) month>> 12 = ;
 
 : weekend? ( timestamp -- ? ) day-of-week { 0 6 } member? ;
-: weekday? ( timestamp -- ? ) day-of-week weekend? not ;
+: weekday? ( timestamp -- ? ) weekend? not ;
 
 : same-or-next-business-day ( timestamp -- timestamp' )
     dup day-of-week {


### PR DESCRIPTION
Calling `today weekday?` fails with 

```
Generic word year>> does not define a method for the fixnum class.
Dispatching on object: 3
```

Sorry for not including the tests, didn't have the time to figure how to do that yet.