### PR TITLE
farkup: revent literal from being modified

### DIFF
--- a/basis/farkup/farkup.factor
+++ b/basis/farkup/farkup.factor
@@ -223,7 +223,7 @@ CONSTANT: invalid-url "javascript:alert('Invalid URL in farkup');"
 GENERIC: (write-farkup) ( farkup -- xml )
 
 : farkup-inside ( farkup name -- xml )
-    <simple-name> swap T{ attrs } swap
+    <simple-name> swap T{ attrs } clone swap
     child>> (write-farkup) 1array <tag> ;
 
 M: heading1 (write-farkup) "h1" farkup-inside ;


### PR DESCRIPTION
Found a bug while doing some post-processing on the generated XML from Farkup. All tags generated by Farkup share the same `attrs` object. This make modifying this attribute after the fact hazardous.

This PR fixes that.