### PR TITLE
misc: Add new dict for multiline comments

### DIFF
--- a/misc/Factor.tmbundle/Syntaxes/Factor.tmLanguage
+++ b/misc/Factor.tmbundle/Syntaxes/Factor.tmLanguage
@@ -372,6 +372,14 @@
 			<string>comment.parens.factor</string>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>\/\*((?=\s))</string>
+			<key>end</key>
+			<string>(^|(?&lt;=\s))\*\/</string>
+			<key>name</key>
+			<string>comment.block.factor</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\b[^\s]+:\s+[^\s]+(\s|$)</string>
 			<key>name</key>


### PR DESCRIPTION
Hello. This PR adds a new entry to the Factor grammar, which highlights the block comments `/* Comment */` provided by the `multiline` vocabulary. Previously this was not the case, leading to results like this:

![image](https://github.com/factor/factor/assets/38614982/203e3819-f7dc-4181-a5b6-8f4aaf4871fe)

I can testify that the new dict works:

![image](https://github.com/factor/factor/assets/38614982/76410d63-74b1-4dba-ac82-95ce936ca241)
(I appended block comments to a random snippet from Rosetta Code in order to quickly test them)

Feel free to test the grammar yourself using [NovaLightshow](https://novalightshow.netlify.app/).

If there are any problems with this PR that I should address, please do not hestitate to inform me. This is my first time contributing to Factor (or to any programming language for that matter). I have read the contribution guidelines and believe that all of the guidelines are accounted for, but I might be mistaken; please let me know if I am.

To whoever looks over this PR, I hope you will have a good day!