### PR TITLE
 Range methods

### DIFF
--- a/basis/math/vectors/vectors-tests.factor
+++ b/basis/math/vectors/vectors-tests.factor
@@ -1,5 +1,5 @@
 USING: math.vectors tools.test kernel specialized-arrays compiler
-kernel.private alien.c-types math.functions ;
+kernel.private alien.c-types math.functions ranges arrays ;
 SPECIALIZED-ARRAY: int
 
 { { 10 20 30 } } [ 10 { 1 2 3 } n*v ] unit-test
@@ -57,3 +57,16 @@ SPECIALIZED-ARRAY: int
 { { 0.0 -0.707 0.707 } } [ { 1.0 0.0 0.0 } { 0.0 0.707 0.707 } cross ] unit-test
 { { 0 -2 2 } } [ { -1 -1 -1 } { 1 -1 -1 } cross ] unit-test
 { { 1 0 0 } } [ { 1 1 0 } { 1 0 0 } proj ] unit-test
+
+{ { 3 12 21 30 } } [ 3 1 10 3 <range> n*v >array ] unit-test
+{ { 3 12 21 30  } } [ 1 10 3 <range> 3 v*n >array ] unit-test
+{ { 4 7 10 13 } } [ 3 1 10 3 <range> n+v >array ] unit-test
+{ { 4 7 10 13 } } [ 1 10 3 <range> 3 v+n >array ] unit-test
+{ { 2 -1 -4 -7 } } [ 3 1 10 3 <range> n-v >array ] unit-test
+{ { -2 1 4 7 } } [ 1 10 3 <range> 3 v-n >array ] unit-test
+{ { 1/3 4/3 7/3 10/3 } } [ 1 10 3 <range> 3 v/n >array ] unit-test
+{ { 6 11 16 21 } } [ 1 10 3 <range> 5 20 2 <range> v+ >array ] unit-test
+{ { -4 -3 -2 -1 } } [ 1 10 3 <range> 5 20 2 <range> v- >array ] unit-test
+
+{ { 3 11/2 8 21/2 } } [ 1 10 3 <range> 5 20 2 <range> vavg >array ] unit-test
+{ { -1 -4 -7 -10 } } [ 1 10 3 <range> vneg >array ] unit-test

--- a/basis/math/vectors/vectors.factor
+++ b/basis/math/vectors/vectors.factor
@@ -1,42 +1,56 @@
 ! Copyright (C) 2005, 2010 Slava Pestov, Joe Groff.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: arrays assocs combinators grouping kernel math
-math.functions math.libm math.order sequences ;
+USING: accessors arrays assocs combinators grouping kernel math
+math.functions math.libm math.order ranges sequences ;
 QUALIFIED-WITH: alien.c-types c
 IN: math.vectors
 
 GENERIC: vneg ( v -- w )
 M: object vneg [ neg ] map ; inline
+M: range vneg >range< [ neg ] tri@ <range> ;
 
 GENERIC#: v+n 1 ( v n -- w )
 M: object v+n [ + ] curry map ; inline
+M: range v+n [ >range< ] dip '[ [ _ + ] bi@ ] dip <range> ;
 
 GENERIC: n+v ( n v -- w )
 M: object n+v [ + ] with map ; inline
+M: range n+v swap v+n ;
 
 GENERIC#: v-n 1 ( v n -- w )
 M: object v-n [ - ] curry map ; inline
+M: range v-n neg v+n ;
 
 GENERIC: n-v ( n v -- w )
 M: object n-v [ - ] with map ; inline
+M: range n-v >range< roll '[ [ _ swap - ] bi@ ] dip neg <range> ;
 
 GENERIC#: v*n 1 ( v n -- w )
 M: object v*n [ * ] curry map ; inline
+M: range v*n [ >range< ] dip '[ _ * ] tri@ <range> ;
 
 GENERIC: n*v ( n v -- w )
 M: object n*v [ * ] with map ; inline
+M: range n*v swap v*n ;
 
 GENERIC#: v/n 1 ( v n -- w )
 M: object v/n [ / ] curry map ; inline
+M: range v/n recip v*n ;
 
 GENERIC: n/v ( n v -- w )
 M: object n/v [ / ] with map ; inline
 
 GENERIC: v+ ( u v -- w )
 M: object v+ [ + ] 2map ; inline
+M: range v+ over range? [
+        [ [ from>> ] bi@ + ]
+        [ [ length>> ] bi@ min ]
+        [ [ step>> ] bi@ + ] 2tri \ range boa
+    ] [ call-next-method ] if ;
 
 GENERIC: v- ( u v -- w )
 M: object v- [ - ] 2map ; inline
+M: range v- >range< [ neg ] tri@ <range> v+ ;
 
 GENERIC: [v-] ( u v -- w )
 M: object [v-] [ [-] ] 2map ; inline
@@ -67,6 +81,9 @@ M: object n^v [ ^ ] with map ; inline
 
 GENERIC: vavg ( u v -- w )
 M: object vavg [ + 2 / ] 2map ; inline
+M: range vavg over range?
+    [ v+ 2 v/n ]
+    [ call-next-method ] if ;
 
 GENERIC: vmax ( u v -- w )
 M: object vmax [ max ] 2map ; inline

--- a/core/ranges/ranges.factor
+++ b/core/ranges/ranges.factor
@@ -21,6 +21,9 @@ PRIVATE>
     [ sign/mod 0 < [ 1 + ] unless 0 max ] keep
     range boa ; inline
 
+: >range< ( range -- start stop step )
+    [ from>> ] [ length>> ] [ step>> ] tri [ swap 1 - * over + ] keep ;
+
 M: range length length>> ; inline
 
 M: range nth-unsafe
@@ -73,9 +76,6 @@ PRIVATE>
 ! Some methods can be much faster for ranges
 
 <PRIVATE
-
-: >range< ( range -- start stop step )
-    [ from>> ] [ length>> ] [ step>> ] tri [ swap 1 - * over + ] keep ;
 
 : >forward-range< ( range -- start stop step )
     >range< dup neg? [ abs swapd ] when ;


### PR DESCRIPTION
Added more efficient vector methods to ranges. I added them in `math.vectors` due to it being in basis. Review, edit, changes, are of course all welcome.