### PR TITLE
math.combinatorics: fix <k-permutations> for k=0

### DIFF
--- a/basis/math/combinatorics/combinatorics-tests.factor
+++ b/basis/math/combinatorics/combinatorics-tests.factor
@@ -112,3 +112,15 @@ math.combinatorics.private tools.test sequences sets ;
 
 { { "as" "ad" "af" "sa" "sd" "sf" "da" "ds" "df" "fa" "fs" "fd" } }
 [ "asdf" 2 <k-permutations> >array ] unit-test
+
+{ { "" } } [
+    "asdf" 0 <k-permutations> >array
+] unit-test
+
+{ { } } [
+    "" 10 <k-permutations>
+] unit-test
+
+{ { "" } } [
+    "" 0 <k-permutations> >array
+] unit-test

--- a/basis/math/combinatorics/combinatorics.factor
+++ b/basis/math/combinatorics/combinatorics.factor
@@ -78,7 +78,7 @@ TUPLE: k-permutations length skip k seq ;
     seq length :> n
     n k nPk :> len
     {
-        { [ len k [ zero? ] either? ] [ { } ] }
+        { [ len zero? ] [ { } ] }
         { [ n k = ] [ seq <permutations> ] }
         [ len n factorial over /i k seq k-permutations boa ]
     } cond ;


### PR DESCRIPTION
There is always one 0-permutation, the empty permutation. Previous code produced no permutations for k=0. I removed the check that broke that case.

`load-all \ <k-permutations> usage` tells me that this word isn't used in any definitions.