### PR TITLE
A couple of documentation fixes

### DIFF
--- a/basis/grouping/grouping-docs.factor
+++ b/basis/grouping/grouping-docs.factor
@@ -172,7 +172,7 @@ HELP: monotonic?
     "Testing if a sequence is non-decreasing:"
     { $example "USING: grouping math prettyprint ;" "{ 1 1 2 } [ <= ] monotonic? ." "t" }
     "Testing if a sequence is decreasing:"
-    { $example "USING: grouping math prettyprint ;" "{ 9 8 6 7 } [ < ] monotonic? ." "f" }
+    { $example "USING: grouping math prettyprint ;" "{ 9 8 6 7 } [ > ] monotonic? ." "f" }
 } ;
 
 HELP: all-equal?

--- a/basis/splitting/monotonic/monotonic-docs.factor
+++ b/basis/splitting/monotonic/monotonic-docs.factor
@@ -60,7 +60,7 @@ HELP: upward-slices
     { "seq" sequence }
     { "slices" "a sequence of upward-slices" }
 }
-{ $description "Returns an array of monotonically increasing slices of type " { $link downward-slice } ". Slices of one element are discarded." } ;
+{ $description "Returns an array of monotonically increasing slices of type " { $link upward-slice } ". Slices of one element are discarded." } ;
 
 HELP: trends
 { $values


### PR DESCRIPTION
The problem in the `grouping-docs` code example is that the code returns `f` even if the array is fixed to be in decreasing order. The comparison operation is wrong. So, funny enough, it correctly fails, but for the wrong reason.