### PR TITLE
grouping.extras: group-by docs: note consecutive behavior and link collect-by

### DIFF
--- a/extra/grouping/extras/extras-docs.factor
+++ b/extra/grouping/extras/extras-docs.factor
@@ -4,14 +4,21 @@ IN: grouping.extras
 
 HELP: group-by
 { $values { "seq" sequence } { "quot" { $quotation ( elt -- key ) } } { "groups" "a new assoc" } }
-{ $description "Groups the elements by the key received by applying quot to each element in the sequence." }
+{ $description "Groups consecutive elements by the key received by applying quot to each element in the sequence." }
 { $examples
   { $example
     "USING: grouping.extras unicode.data prettyprint sequences strings ;"
     "\"THis String Has  CasE!\" [ category ] group-by [ last >string ] { } map-as ."
     "{ \"TH\" \"is\" \" \" \"S\" \"tring\" \" \" \"H\" \"as\" \"  \" \"C\" \"as\" \"E\" \"!\" }"
   }
+  { $example
+    "USING: grouping.extras prettyprint sequences strings ;"
+    "{ \"apple\" \"anchovy\" \"banana\" \"anise\" \"bagel\" \"bratwurst\" } [ first 1string ] group-by ."
+    "V{\n    { \"a\" V{ \"apple\" \"anchovy\" } }\n    { \"b\" V{ \"banana\" } }\n    { \"a\" V{ \"anise\" } }\n    { \"b\" V{ \"bagel\" \"bratwurst\" } }\n}"
+  }
 } ;
+
+{ group-by collect-by } related-words
 
 HELP: <n-groups>
 { $values


### PR DESCRIPTION
A small change to the `group-by` docs, as it wasn't obvious to me that only consecutive elements are grouped.

I was unable to build (and test) locally, with `algorithm` not found:

```
/usr/bin/clang++ -c -x c++-header -Wall -Wextra -pedantic -DFACTOR_VERSION="0.100" -DFACTOR_GIT_LABEL="heads/feature/group-by-docs-plusplus-163800a44ce3b70b9e1f18f3f21b24b6b8eba4ff" -m64 -O3 -std=c++11 -o vm/master.hpp.gch vm/master.hpp
vm/master.hpp:26:10: fatal error: 'algorithm' file not found
#include <algorithm>
         ^~~~~~~~~~~
```

So hopefully someone else can test if this renders as I hope it does.