### PR TITLE
discord: fix interaction create, add interaction edit

### DIFF
--- a/extra/discord/discord.factor
+++ b/extra/discord/discord.factor
@@ -73,6 +73,8 @@ TUPLE: discord-bot
     discord-post-request json-request ;
 : discord-post-json ( payload route -- json )
     [ >json ] dip discord-post-request add-json-header json-request ;
+: discord-post-json-no-resp ( payload route -- )
+    [ >json ] dip discord-post-request add-json-header http-request 2drop ;
 : discord-patch-json ( payload route -- json )
     [ >json ] dip discord-patch-request add-json-header json-request ;
 : discord-delete-json ( route -- json )
@@ -104,13 +106,12 @@ TUPLE: discord-bot
 : delete-discord-application-guild-command ( application-id -- json )
     "/applications/%s/commands" sprintf discord-delete-json ;
 
-: create-interaction-response ( interaction-id interaction-token -- json )
-    [ H{ { "type" 4 } { "data" "pang" } } clone ] 2dip
-    "/webhooks/%s/%s/messages/callback" sprintf discord-post ;
-
+: create-interaction-response ( json interaction-id interaction-token -- )
+    "/interactions/%s/%s/callback" sprintf discord-post-json-no-resp ;
 : get-original-interaction-response ( application-id interaction-token -- json )
     "/webhooks/%s/%s/messages/@original" sprintf discord-get ;
-
+: edit-interaction-response ( json application-id interaction-token -- json )
+    "/webhooks/%s/%s/messages/@original" sprintf discord-patch-json ;
 
 
 : send-message* ( string channel-id -- json )


### PR DESCRIPTION
Some improvements that I needed to patch while working on https://github.com/booniepepper/dt-discord-bot for @booniepepper:

- `create-interaction-response` that isn't fixed to respond "pang" :D and is the right endpoint for calling when responding to a websocket notification, not a webhook
- `edit-interaction-response` as there's a very quick first response deadline and we needed to run code, which could take a second, so we edit that response after execution is done

Not included: I also needed to patch `gateway-identify-json` to use `"intents": 1` to make it work with a bot key that has very limited (interaction only) permissions; I'm not sure what would be the best way to handle this, but it would be nice if there was a convenient way to tell the library which permissions are needed.