### PR TITLE
Add breadcrumbs to vocabulary links in documentation

### DIFF
--- a/basis/help/markup/markup.factor
+++ b/basis/help/markup/markup.factor
@@ -198,6 +198,10 @@ M: word link-long-text
 
 : topic-span ( topic quot -- ) [ >topic ] dip ($span) ; inline
 
+! Turns "foo.bar" into { { "foo" } { "foo" "bar" } }
+: vocab-breadcrumbs ( vocab -- vocab-list )
+    "." split { } [ suffix ] accumulate* ;
+
 ERROR: number-of-arguments found required ;
 
 : check-first ( seq -- first )
@@ -245,8 +249,15 @@ PRIVATE>
 : $subsection ( element -- )
     check-first $subsection* ;
 
+: ($vocab-breadcrumb-links) ( vocab -- )
+    vocab-breadcrumbs
+    [ "." write ] [ [ last ] [ "." join ] bi >vocab-link write-link ]
+    interleave ;
+
 : ($vocab-link) ( text vocab -- )
-    >vocab-link write-link ;
+    ! If the link text is just the vocabulary name, split it into
+    ! separate links for each parent vocabulary.
+    2dup = [ drop ($vocab-breadcrumb-links) ] [ >vocab-link write-link ] if ;
 
 : $vocab-subsection ( element -- )
     [

--- a/basis/help/vocabs/vocabs.factor
+++ b/basis/help/vocabs/vocabs.factor
@@ -246,10 +246,12 @@ C: <vocab-author> vocab-author
 
 : describe-metadata ( vocab -- )
     [
-        [ vocab-tags [ "Tags:" swap \ $tags prefix 2array , ] unless-empty ]
-        [ vocab-authors [ "Authors:" swap \ $authors prefix 2array , ] unless-empty ]
-        [ vocab-platforms [ "Platforms:" swap \ $links prefix 2array , ] unless-empty ]
-        tri
+        {
+            [ "." split1-last [ '[ { "Parents:" { $vocab-link _ } } ] call , ] [ drop ] if ]
+            [ vocab-tags [ "Tags:" swap \ $tags prefix 2array , ] unless-empty ]
+            [ vocab-authors [ "Authors:" swap \ $authors prefix 2array , ] unless-empty ]
+            [ vocab-platforms [ "Platforms:" swap \ $links prefix 2array , ] unless-empty ]
+        } cleave
     ] { } make
     [ "Metadata" $heading $table ] unless-empty ;
 


### PR DESCRIPTION
The **Vocabulary** section in word-level documentation, and inline vocabulary links in articles that use `$vocab-link`, are split into breadcrumbs so that any hierarchy level of the linked vocabulary can be accessed. Vocabulary-level documentation has similar breadcrumbs added to the **Metadata** section (as `Parents:`) if it has any parent vocabularies.

Examples:
- [breadcrumbed inline link in article](https://ancilla.ancilla.ca/share/t5IIWTca2SA5NdGO1lPD3ADjUJvX21vv5hL9CVFHCKE=/article-alien.endian.html)
- [parent links in vocab docs](https://ancilla.ancilla.ca/share/t5IIWTca2SA5NdGO1lPD3ADjUJvX21vv5hL9CVFHCKE=/vocab-math.functions.private.html)
- [breadcrumbs in word docs](https://ancilla.ancilla.ca/share/t5IIWTca2SA5NdGO1lPD3ADjUJvX21vv5hL9CVFHCKE=/word-assoc-operator%2Cassocs.private.html)
