### PR TITLE
test(msgpack): demonstrate eof handling

### DIFF
--- a/basis/msgpack/msgpack-tests.factor
+++ b/basis/msgpack/msgpack-tests.factor
@@ -52,3 +52,7 @@ tools.test ;
 ] unit-test
 
 [ 64 2^ >msgpack ] [ cannot-convert? ] must-fail-with
+
+! this failure makes it impossible to reliably detect eof when
+! reading an msgpack object from a stream
+[ "" [ read-msgpack ] with-string-reader ] must-fail


### PR DESCRIPTION
Reading from an input stream raises an error. This makes it difficult to read all msgpack objects from a stream until exhaustion.

Given that `f` is a valid msgpack value, it is annoying that we can't return false.

I suppose that one simple work around would be to take a quotation that will be called if the eof is reached. Another work around would be to return 2 values on the stack.