### PR TITLE
completion: allow space to be part of search, and use TAB for completion

### DIFF
--- a/basis/ui/tools/listener/completion/completion.factor
+++ b/basis/ui/tools/listener/completion/completion.factor
@@ -166,7 +166,6 @@ GENERIC#: accept-completion-hook 1 ( item popup -- )
 
 completion-popup H{
     { T{ key-down f f "TAB" } [ table>> row-action ] }
-    { T{ key-down f f " " } [ table>> row-action ] }
 } set-gestures
 
 : show-completion-popup ( interactor mode -- )


### PR DESCRIPTION
Recent investigation into `CTRL-R` shows that SPACE will cancel the search, whereas it can be part of a command in command history. It's better to just use `TAB` for completion, and let `SPACE` be a search character.