### PR TITLE
Allow non-singleton as first variant member

### DIFF
--- a/extra/variants/variants-tests.factor
+++ b/extra/variants/variants-tests.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2009 Joe Groff.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: kernel math tools.test variants slots ;
+USING: eval kernel math tools.test variants slots ;
 IN: variants.tests
 
 VARIANT: list
@@ -39,3 +39,12 @@ VARIANT-MEMBER: list2 cons2: { { first object } { rest list2 } } ;
 
 { 4 }
 [ 5 6 7 8 nil2 <cons2> <cons2> <cons2> <cons2> list2-length ] unit-test
+
+{ t } [ "
+USE: variants
+IN: foo
+VARIANT: tree
+    node: { val }
+    branch: { { left tree } { right tree } }
+    ;
+3 <node> tree?" eval( -- x ) ] unit-test

--- a/extra/variants/variants.factor
+++ b/extra/variants/variants.factor
@@ -9,9 +9,7 @@ IN: variants
 PREDICATE: variant-class < mixin-class "variant?" word-prop ;
 
 M: variant-class initial-value*
-    class-members [ f f ] [
-        first dup singleton-class? [ t ] [ initial-value* ] if
-    ] if-empty ;
+    class-members [ f f ] [ first initial-value* ] if-empty ;
 
 : define-tuple-class-and-boa-word ( class superclass slots -- )
     pick [ define-tuple-class ] dip

--- a/extra/variants/variants.factor
+++ b/extra/variants/variants.factor
@@ -10,7 +10,7 @@ PREDICATE: variant-class < mixin-class "variant?" word-prop ;
 
 M: variant-class initial-value*
     class-members [ f f ] [
-        first dup word? [ t ] [ initial-value* ] if
+        first dup singleton-class? [ t ] [ initial-value* ] if
     ] if-empty ;
 
 : define-tuple-class-and-boa-word ( class superclass slots -- )


### PR DESCRIPTION
Previously, variants without a singleton class as first member which had recursive slots, such as:
```
VARIANT: tree
    node { val }
    branch { { left tree } { right tree } }
    ;
```
would throw an error, due to `f` not being a valid initial value for the `tree` slot in `branch`. Now it will find a reasonable initial value (here it would be `T{ node f f }`) to use, allowing this kind of construct.

The tests use `eval` because I was not sure how best to write a test for a potential parse-time error. The added test fails for the previous code, and passes for the new code.