### PR TITLE
Terminfo overhaul

### DIFF
--- a/basis/io/files/info/info-docs.factor
+++ b/basis/io/files/info/info-docs.factor
@@ -23,7 +23,7 @@ HELP: regular-file?
 
 HELP: symbolic-link?
 { $values { "path/info" { $or "a pathname string" file-info-tuple } } { "?" boolean } }
-{ $description "Tests if " { $snippet "path/info" } " is a symbolic link." } ;
+{ $description "Tests if " { $snippet "path/info" } " is a symbolic link. Unlike other type predicates in this vocabulary, does not dereference links when passed a path, so it is possible for both this and another type predicate to be true for the same path." } ;
 
 HELP: file-systems
 { $values { "array" array } }
@@ -63,27 +63,32 @@ HELP: file-executable?
 { $errors "Throws an error if the file does not exist." } ;
 
 ARTICLE: "io.files.info" "File system metadata"
+"These are words for querying the metadata of filesystems and filesystem objects. " { $link file-info } " and " { $link link-info } " can be used to get detailed information on a file in the manner of stat(2) or lstat(2). Type predicates like " { $link directory? } " can be used on both " { $link file-info-tuple } "s returned by " { $link file-info } " et al, and on paths. In the former case only the tuple itself is inspected; in the latter, the filesystem is queried and links are dereferenced. Note that in the case of symlinks, both " { $link symbolic-link? } ", and the predicate matching the object the link points to, will return true."
+{ $nl f }
 "File metadata:"
 { $subsections
+    file-info-tuple
     file-info
     link-info
     file-exists?
+}
+"File types:"
+{ $subsections
+    "file-types"
     directory?
     regular-file?
     symbolic-link?
-}
-"File types:"
-{ $subsections "file-types" }
-"File system metadata:"
-{ $subsections
-    file-system-info
-    file-systems
 }
 "File permissions:"
 { $subsections
     file-readable?
     file-writable?
     file-executable?
+}
+"File system metadata:"
+{ $subsections
+    file-system-info
+    file-systems
 } ;
 
 ABOUT: "io.files.info"

--- a/basis/io/files/info/info.factor
+++ b/basis/io/files/info/info.factor
@@ -24,6 +24,9 @@ HOOK: link-info os ( path -- info )
 : >file-info ( path/info -- info )
     dup { [ string? ] [ pathname? ] } 1|| [ file-info ] when ;
 
+: >link-info ( path/info -- info )
+    dup { [ string? ] [ pathname? ] } 1|| [ link-info ] when ;
+
 PRIVATE>
 
 : directory? ( path/info -- ? )
@@ -32,9 +35,14 @@ PRIVATE>
 : regular-file? ( path/info -- ? )
     [ >file-info type>> +regular-file+ = ] ?call ;
 
+! Use link-info here so we don't dereference the link. Otherwise we always
+! return f (or throw).
 : symbolic-link? ( path/info -- ? )
-    [ >file-info type>> +symbolic-link+ = ] ?call ;
+    [ >link-info type>> +symbolic-link+ = ] ?call ;
 
+! TODO: this will return t on compressed filesystems, even if the file is
+! dense, and may incorrectly return f on sparse files stored on filesystems
+! with replication.
 : sparse-file? ( path/info -- ? )
     [ >file-info [ size-on-disk>> ] [ size>> ] bi < ] ?call ;
 

--- a/extra/terminfo/terminfo-docs.factor
+++ b/extra/terminfo/terminfo-docs.factor
@@ -1,0 +1,51 @@
+USING: help.markup help.syntax assocs terminfo.private ;
+IN: terminfo
+
+HELP: my-terminfo
+{ $values
+    terminfo/f: { $maybe assoc }
+}
+{ $description
+    As \ name>terminfo , but gets the name from { $snippet "$TERM" } , thus retrieving the capabilities for the current terminal.
+}
+{ $errors
+    Throws \ bad-magic if a database entry is found but the header isn't recognized.
+} ;
+
+HELP: name>terminfo
+{ $values
+    name: { "a terminal name string" }
+    terminfo/f: { $maybe assoc }
+}
+{ $description
+    Returns the terminfo for the named terminal, or \ f if no entry for it is found in the database.
+}
+{ $errors
+    Throws \ bad-magic if a database entry is found but the header isn't recognized.
+} ;
+
+ARTICLE: "terminfo" "Terminfo Databases"
+    The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals.
+
+Terminfo capability descriptions are returned as assocs, where the keys are capability names; see { $snippet "terminfo(5)" } for a list of standardized capability names and their meanings. Capabilities that are disabled or absent are not present in the assoc and can be assumed to be \ f . In addition, all of the terminal's names are returned in the { $snippet "\".names\"" } pseudocapability, in the same order they appear in the terminfo file.
+
+Words for getting terminal information:
+{ $subsections
+    my-terminfo
+    name>terminfo
+    file>terminfo
+    bytes>terminfo
+}
+{ $heading "Limitations" }
+    The database search behaviour is not a perfect match for the behaviour implemented in Curses. In particular, setting the { $snippet "$TERMINFO" } environment variable does not disable searching the system-wide database as well, and the compiled-in search paths are not guaranteed to match the ones compiled into libcurses (although they should be correct on the vast majority of systems).
+
+Curses 5 user-defined capabilities are not supported and will be skipped in files that contain them (the rest of the file will load normally).
+
+Curses 6.1 terminfo files are not supported and cannot be loaded.
+
+BerkeleyDB { "\"hashed database\"" } format is not supported and BDB terminfo databases will be ignored.
+
+{ $heading "External References" }
+{ $snippet "terminfo(5)" } for information about terminfo capabilities and how to use them; { $snippet "term(5)" } for information about the on-disk database format; and { $snippet "term(7)" } for information about terminal naming conventions. ;
+
+ABOUT: "terminfo"

--- a/extra/terminfo/terminfo-docs.factor
+++ b/extra/terminfo/terminfo-docs.factor
@@ -25,7 +25,7 @@ HELP: name>terminfo
 } ;
 
 ARTICLE: "terminfo" "Terminfo Databases"
-    The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals. It supports both SysV { "(\"Legacy\")" } and Curses 6.1 { "(\"Extended Number\")" } formats, and automatically selects the appropriate format depending on the file header.
+    The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals. It supports both SysV { "(\"Legacy\")" } and Curses 6.1 { "(\"Extended Number\")" } formats, and automatically selects the appropriate format depending on the file header. It also supports Curses 5 user-defined { "(\"Extended\")" } capabilities.
 
 Terminfo capability descriptions are returned as assocs, where the keys are capability names; see { $snippet "terminfo(5)" } for a list of standardized capability names and their meanings. Capabilities that are disabled or absent are not present in the assoc and can be assumed to be \ f . In addition, all of the terminal's names are returned in the { $snippet "\".names\"" } pseudocapability, in the same order they appear in the terminfo file.
 
@@ -39,11 +39,9 @@ Words for getting terminal information:
 { $heading "Limitations" }
     The database search behaviour is not a perfect match for the behaviour implemented in Curses. In particular, setting the { $snippet "$TERMINFO" } environment variable does not disable searching the system-wide database as well, and the compiled-in search paths are not guaranteed to match the ones compiled into libcurses (although they should be correct on the vast majority of systems).
 
-Curses 5 user-defined capabilities are not supported and will be skipped in files that contain them (the rest of the file will load normally).
-
 BerkeleyDB { "\"hashed database\"" } format is not supported and BDB terminfo databases will be ignored.
 
 { $heading "External References" }
-{ $snippet "terminfo(5)" } for information about terminfo capabilities and how to use them; { $snippet "term(5)" } for information about the on-disk database format; and { $snippet "term(7)" } for information about terminal naming conventions. ;
+{ $snippet "terminfo(5)" } for information about terminfo capabilities and how to use them; { $snippet "term(5)" } for information about the on-disk database format; and { $snippet "term(7)" } for information about terminal naming conventions. I also found https://github.com/mauke/unibilium/blob/master/secret/terminfo.pod useful for clarifying some aspects of the Curses 5 format which are not clear in the man page. ;
 
 ABOUT: "terminfo"

--- a/extra/terminfo/terminfo-docs.factor
+++ b/extra/terminfo/terminfo-docs.factor
@@ -25,7 +25,7 @@ HELP: name>terminfo
 } ;
 
 ARTICLE: "terminfo" "Terminfo Databases"
-    The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals.
+    The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals. It supports both SysV { "(\"Legacy\")" } and Curses 6.1 { "(\"Extended Number\")" } formats, and automatically selects the appropriate format depending on the file header.
 
 Terminfo capability descriptions are returned as assocs, where the keys are capability names; see { $snippet "terminfo(5)" } for a list of standardized capability names and their meanings. Capabilities that are disabled or absent are not present in the assoc and can be assumed to be \ f . In addition, all of the terminal's names are returned in the { $snippet "\".names\"" } pseudocapability, in the same order they appear in the terminfo file.
 
@@ -40,8 +40,6 @@ Words for getting terminal information:
     The database search behaviour is not a perfect match for the behaviour implemented in Curses. In particular, setting the { $snippet "$TERMINFO" } environment variable does not disable searching the system-wide database as well, and the compiled-in search paths are not guaranteed to match the ones compiled into libcurses (although they should be correct on the vast majority of systems).
 
 Curses 5 user-defined capabilities are not supported and will be skipped in files that contain them (the rest of the file will load normally).
-
-Curses 6.1 terminfo files are not supported and cannot be loaded.
 
 BerkeleyDB { "\"hashed database\"" } format is not supported and BDB terminfo databases will be ignored.
 

--- a/extra/terminfo/terminfo-tests.factor
+++ b/extra/terminfo/terminfo-tests.factor
@@ -1,9 +1,85 @@
-USING: sequences strings terminfo tools.test ;
+USING: assocs hex-strings io.streams.string kernel sequences
+strings terminfo tools.test ;
 
+IN: terminfo.tests
+
+! This is based on the LSI ADM-3 terminfo file given as an example in the
+! term(5) man page, with some fields removed to make it more compact.
+! Linebreaks are added to denote boundaries between sections: header,
+! names, booleans, ints, strings, and the string table.
+: test-terminfo-sysv ( -- bytes )
+   "1a 01 10 00 02 00 03 00  18 00 31 00
+                                         61 64 6d 33
+    61 7c 6c 73 69 20 61 64  6d 33 61 00
+                                         00 01
+                                               50 00
+    ff ff 18 00
+                ff ff 00 00  02 00 ff ff ff ff 04 00
+    ff ff ff ff ff ff ff ff  0a 00 25 00 27 00 ff ff
+    29 00 ff ff ff ff 2b 00  ff ff 2d 00 ff ff ff ff
+    ff ff ff ff
+                07 00 0d 00  1a 24 3c 31 3e 00 1b 3d
+    25 70 31 25 7b 33 32 7d  25 2b 25 63 25 70 32 25
+    7b 33 32 7d 25 2b 25 63  00 0a 00 1e 00 08 00 0c
+    00 0b 00 0a 00"
+    [ hex-digit? ] filter hex-string>bytes ;
+
+! The same terminfo file, but in Curses 6.1 "extended
+! numeric format".
+: test-terminfo-32bit ( -- bytes )
+   "1e 02 10 00 02 00 03 00  18 00 31 00
+                                         61 64 6d 33
+    61 7c 6c 73 69 20 61 64  6d 33 61 00
+                                         00 01
+                                               50 00
+    00 00 ff ff ff ff 18 00  00 00
+                ff ff 00 00  02 00 ff ff ff ff 04 00
+    ff ff ff ff ff ff ff ff  0a 00 25 00 27 00 ff ff
+    29 00 ff ff ff ff 2b 00  ff ff 2d 00 ff ff ff ff
+    ff ff ff ff
+                07 00 0d 00  1a 24 3c 31 3e 00 1b 3d
+    25 70 31 25 7b 33 32 7d  25 2b 25 63 25 70 32 25
+    7b 33 32 7d 25 2b 25 63  00 0a 00 1e 00 08 00 0c
+    00 0b 00 0a 00"
+    [ hex-digit? ] filter hex-string>bytes ;
+
+CONSTANT: ADM3-TERMINFO {
+    H{
+        { ".names" { "adm3a" "lsi adm3a" } }
+        { "auto_right_margin" t }
+        { "columns" 80 }
+        { "lines" 24 }
+        { "cursor_down" "\n" }
+        { "cursor_up" "\v" }
+        { "cursor_left" "\b" }
+        { "cursor_right" "\f" }
+        { "cursor_home" "\x1e" }
+        { "carriage_return" "\r" }
+        { "bell" "\a" }
+        { "clear_screen" "\x1a$<1>" }
+        { "cursor_address" "\e=%p1%{32}%+%c%p2%{32}%+%c" }
+    }
+}
+
+! TODO: these aren't hermetic -- they assume the host system has a terminfo
+! database with a vt102 entry. Which is probably a pretty safe assumption,
+! but it's untidy.
 { t } [
     "vt102" terminfo-names member?
 ] unit-test
 
 { t } [
     "vt102" terminfo-path string?
+] unit-test
+
+ADM3-TERMINFO [
+    test-terminfo-sysv bytes>terminfo
+] unit-test
+
+ADM3-TERMINFO [
+    test-terminfo-32bit bytes>terminfo
+] unit-test
+
+{ t } [
+    test-terminfo-sysv test-terminfo-32bit [ bytes>terminfo ] bi@ =
 ] unit-test

--- a/extra/terminfo/terminfo-tests.factor
+++ b/extra/terminfo/terminfo-tests.factor
@@ -43,6 +43,17 @@ IN: terminfo.tests
     00 0b 00 0a 00"
     [ hex-digit? ] filter hex-string>bytes ;
 
+! The "EMCA with strikeout" terminfo file, which uses curses 5 extensions.
+: test-terminfo-extended ( -- bytes )
+   "1a 01 2d 00 00 00 00 00  00 00 00 00 65 63 6d 61
+    2b 73 74 72 69 6b 65 6f  75 74 7c 45 43 4d 41 2d
+    34 38 20 73 74 72 69 6b  65 6f 75 74 2f 63 72 6f
+    73 73 65 64 2d 6f 75 74  00 00 00 00 00 00 02 00
+    04 00 15 00 00 00 06 00  00 00 05 00 1b 5b 32 39
+    6d 00 1b 5b 39 6d 00 72  6d 78 78 00 73 6d 78 78
+    00"
+    [ hex-digit? ] filter hex-string>bytes ;
+
 CONSTANT: ADM3-TERMINFO {
     H{
         { ".names" { "adm3a" "lsi adm3a" } }
@@ -82,4 +93,11 @@ ADM3-TERMINFO [
 
 { t } [
     test-terminfo-sysv test-terminfo-32bit [ bytes>terminfo ] bi@ =
+] unit-test
+
+
+{
+  H{ { ".names" { "ecma+strikeout" "ECMA-48 strikeout/crossed-out" } } { "rmxx" "\x1B[29m" } { "smxx" "\x1B[9m" } }
+} [
+  test-terminfo-extended bytes>terminfo
 ] unit-test

--- a/extra/terminfo/terminfo.factor
+++ b/extra/terminfo/terminfo.factor
@@ -1,11 +1,11 @@
 ! Copyright (C) 2013 John Benediktsson.
 ! See https://factorcode.org/license.txt for BSD license.
 
-USING: accessors assocs combinators formatting endian fry
+USING: accessors assocs combinators endian formatting fry
 grouping hashtables io io.directories io.encodings.binary
-io.files io.files.types io.pathnames kernel math math.parser
-memoize pack sequences sequences.generalizations splitting
-strings system ;
+io.files io.files.info io.files.types io.pathnames kernel math
+math.parser memoize pack sequences sequences.generalizations
+splitting strings system ;
 
 IN: terminfo
 
@@ -90,9 +90,9 @@ M: linux terminfo-relative-path ( name -- path )
 
 : terminfo-names-for-path ( path -- names )
     [
-        [ type>> +directory+ = ] filter
-        [ name>> directory-files ] map concat
-    ] with-directory-entries ;
+        [ directory? ] filter
+        [ directory-files ] map concat
+    ] with-directory-files ;
 
 MEMO: terminfo-names ( -- names )
     TERMINFO-DIRS [ file-exists? ] filter


### PR DESCRIPTION
tl;dr:
- fix a bug in `io.files.info` needed for terminfo search to work, then fix terminfo search
- use terminfo environment variables to seed the search path
- rework the API to be a bit more flexible and ergonomic
- add support for Curses 5 and Curses 6.1 extensions
- add documentation
- add unit tests for terminfo file decoding

Individual commit messages have more details.