### PR TITLE
test(assoc): assoc-stack with overriding

### DIFF
--- a/core/assocs/assocs-tests.factor
+++ b/core/assocs/assocs-tests.factor
@@ -215,7 +215,7 @@ unit-test
 { 1 } [ "a" { H{ { "a" 1 } } H{ { "b" 2 } } } assoc-stack ] unit-test
 { 2 } [ "b" { H{ { "a" 1 } } H{ { "b" 2 } } } assoc-stack ] unit-test
 { f } [ "c" { H{ { "a" 1 } } H{ { "b" 2 } } } assoc-stack ] unit-test
-
+{ f } [ "c" { H{ { "a" 1 } } H{ { "b" 2 } } H{ { "a" 3 } } } assoc-stack ] unit-test
 
 {
     { { 1 f } }


### PR DESCRIPTION
demonstrate lookups in a stack of assocs where one assoc has keys overriding another