### PR TITLE
build: Apply debug flags to C++ files

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -55,6 +55,7 @@ ifdef CONFIG
 
 	ifneq ($(DEBUG), 0)
 		CFLAGS += -g -DFACTOR_DEBUG
+		CXXFLAGS += -g -DFACTOR_DEBUG
 	else
 		OPTIMIZATION := -O3
 		CFLAGS += $(CC_OPT) $(OPTIMIZATION)


### PR DESCRIPTION
I noticed while attempting some debugging that the debug compiler flags were only set for C files. This adds them to C++ files as well.