### PR TITLE
Fix Clipboard on Windows

### DIFF
--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -131,8 +131,7 @@ PRIVATE>
 
 : with-clipboard ( quot -- )
     f OpenClipboard win32-error=0/f
-    call
-    CloseClipboard win32-error=0/f ; inline
+    [ CloseClipboard win32-error=0/f ] finally ; inline
 
 : paste ( -- str )
     [

--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -142,8 +142,8 @@ PRIVATE>
         ] [
             CF_UNICODETEXT GetClipboardData dup win32-error=0/f
             dup GlobalLock dup win32-error=0/f
-            GlobalUnlock win32-error=0/f
-            alien>native-string
+            [ alien>native-string ]
+            [ swap GlobalUnlock win32-error=0/f ] finally
         ] if
     ] with-clipboard
     crlf>lf ;

--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -135,15 +135,14 @@ PRIVATE>
 
 : paste ( -- str )
     [
-        CF_UNICODETEXT IsClipboardFormatAvailable zero? [
+        CF_UNICODETEXT GetClipboardData [
             ! nothing to paste
             ""
         ] [
-            CF_UNICODETEXT GetClipboardData dup win32-error=0/f
             dup GlobalLock dup win32-error=0/f
             [ alien>native-string ]
             [ swap GlobalUnlock win32-error=0/f ] finally
-        ] if
+        ] if-zero
     ] with-clipboard
     crlf>lf ;
 


### PR DESCRIPTION
Hello!

I have noticed that the `paste` word does dummy `GlobalLock`/`GlobalUnlock` without actually using the locked handle. Then I also noticed there is a race condition between check and use.

So, here are the fixes.