### PR TITLE
vm: Update OS string for macOS

### DIFF
--- a/vm/os-macos.hpp
+++ b/vm/os-macos.hpp
@@ -1,7 +1,7 @@
 namespace factor {
 
 #define VM_C_API extern "C" __attribute__((visibility("default")))
-#define FACTOR_OS_STRING "macosx"
+#define FACTOR_OS_STRING "macos"
 
 void early_init();
 


### PR DESCRIPTION
As a final step for the Mac OS X to macOS rename, this updates the VM OS string to the new value of `macos`. This had to be done separately from the main change so that a boot image could first be prepared that supports both OS strings.