### PR TITLE
Replace image-reliant UI components

### DIFF
--- a/basis/ui/backend/gtk2/gtk2.factor
+++ b/basis/ui/backend/gtk2/gtk2.factor
@@ -117,7 +117,7 @@ CONSTANT: events-mask
     move-hand fire-motion t ;
 
 : on-leave ( win event user-data -- ? )
-    3drop forget-rollover t ;
+    3drop t ;
 
 :: on-button-press ( win event user-data -- ? )
     win window :> world

--- a/basis/ui/backend/gtk2/gtk2.factor
+++ b/basis/ui/backend/gtk2/gtk2.factor
@@ -117,7 +117,7 @@ CONSTANT: events-mask
     move-hand fire-motion t ;
 
 : on-leave ( win event user-data -- ? )
-    3drop t ;
+    3drop forget-rollover t ;
 
 :: on-button-press ( win event user-data -- ? )
     win window :> world

--- a/basis/ui/gadgets/buttons/buttons.factor
+++ b/basis/ui/gadgets/buttons/buttons.factor
@@ -216,17 +216,18 @@ TUPLE: checkbox < button ;
 
 M: checkbox model-changed
     swap value>> >>selected? relayout-1 ;
-
 <PRIVATE
 
+CONSTANT: circle-points 12
 CONSTANT: checkmark-dim/2 $[ $ checkmark-dim 2 / ]
 CONSTANT: checkmark-rhombus { { 0 $ checkmark-dim/2 } { $ checkmark-dim/2 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim/2 } { $ checkmark-dim/2 0 } } 
+CONSTANT: checkmark-circle $[ $ circle-points $ checkmark-dim polygon-circle ]
 : <drawn-radio-pen> ( -- pen )
-    roll-button-rollover-border checkmark-rhombus <polygon>
-    roll-button-rollover-border checkmark-rhombus <polygon>
-    dim-color checkmark-rhombus <polygon>
-    errors-color checkmark-rhombus <polygon>
-    toolbar-button-pressed-background checkmark-rhombus <polygon>
+    roll-button-rollover-border checkmark-circle <polygon>
+    roll-button-rollover-border checkmark-circle <polygon>
+    dim-color checkmark-circle <polygon>
+    errors-color checkmark-circle <polygon>
+    toolbar-button-pressed-background checkmark-circle <polygon>
     <button-pen>
     ;
 

--- a/basis/ui/gadgets/buttons/buttons.factor
+++ b/basis/ui/gadgets/buttons/buttons.factor
@@ -180,10 +180,10 @@ repeat-button H{
 CONSTANT: checkmark-dim 12
 CONSTANT: checkmark-square { { 0 0 } { 0 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim } { $ checkmark-dim 0 } } 
 : <drawn-checkmark-pen> ( -- pen )
-    roll-button-selected-background checkmark-square <polygon>
-    roll-button-selected-background checkmark-square <polygon>
-    selection-color checkmark-square <polygon>
     roll-button-rollover-border checkmark-square <polygon>
+    roll-button-rollover-border checkmark-square <polygon>
+    dim-color checkmark-square <polygon>
+    errors-color checkmark-square <polygon>
     toolbar-button-pressed-background checkmark-square <polygon>
     <button-pen> ;
 
@@ -222,10 +222,10 @@ M: checkbox model-changed
 CONSTANT: checkmark-dim/2 $[ $ checkmark-dim 2 / ]
 CONSTANT: checkmark-rhombus { { 0 $ checkmark-dim/2 } { $ checkmark-dim/2 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim/2 } { $ checkmark-dim/2 0 } } 
 : <drawn-radio-pen> ( -- pen )
-    roll-button-selected-background checkmark-rhombus <polygon>
-    roll-button-selected-background checkmark-rhombus <polygon>
-    selection-color checkmark-rhombus <polygon>
     roll-button-rollover-border checkmark-rhombus <polygon>
+    roll-button-rollover-border checkmark-rhombus <polygon>
+    dim-color checkmark-rhombus <polygon>
+    errors-color checkmark-rhombus <polygon>
     toolbar-button-pressed-background checkmark-rhombus <polygon>
     <button-pen>
     ;

--- a/basis/ui/gadgets/buttons/buttons.factor
+++ b/basis/ui/gadgets/buttons/buttons.factor
@@ -132,8 +132,8 @@ PRIVATE>
     ] 2dip <tile-pen> ;
 
 : <drawn-border-button-pen> ( -- pen )
-    dim-color <solid>
-    dim-color <solid>
+    content-background <solid>
+    toolbar-background <solid>
     selection-color <solid>
     roll-button-rollover-border <solid>
     toolbar-button-pressed-background <solid>

--- a/basis/ui/gadgets/buttons/buttons.factor
+++ b/basis/ui/gadgets/buttons/buttons.factor
@@ -1,11 +1,12 @@
 ! Copyright (C) 2005, 2009 Slava Pestov.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: accessors assocs colors combinators combinators.short-circuit
-combinators.smart fry kernel locals math.vectors memoize models
-namespaces sequences ui.commands ui.gadgets ui.gadgets.borders
-ui.gadgets.labels ui.gadgets.packs ui.theme ui.gadgets.worlds
-ui.gestures ui.pens ui.pens.image ui.pens.solid ui.pens.tile
-ui.theme.images ;
+USING: accessors assocs colors combinators
+combinators.short-circuit combinators.smart fry kernel literals
+locals math math.vectors memoize models namespaces sequences
+ui.commands ui.gadgets ui.gadgets.borders ui.gadgets.labels
+ui.gadgets.packs ui.gadgets.worlds ui.gestures ui.pens
+ui.pens.image ui.pens.polygon ui.pens.solid ui.pens.tile
+ui.theme ui.theme.images ;
 FROM: models => change-model ;
 IN: ui.gadgets.buttons
 
@@ -130,6 +131,15 @@ PRIVATE>
         [ append theme-image ] tri-curry@ tri
     ] 2dip <tile-pen> ;
 
+: <drawn-border-button-pen> ( -- pen )
+    dim-color <solid>
+    dim-color <solid>
+    selection-color <solid>
+    roll-button-rollover-border <solid>
+    toolbar-button-pressed-background <solid>
+    <button-pen>
+    ;
+
 : <border-button-pen> ( -- pen )
     "button" transparent button-text-color
     <border-button-state-pen> dup
@@ -143,7 +153,7 @@ PRIVATE>
 : border-button-theme ( gadget -- gadget )
     dup gadget-child border-button-label-theme
     horizontal >>orientation
-    <border-button-pen> >>interior
+    <drawn-border-button-pen> >>interior
     dup dup interior>> pen-pref-dim >>min-dim
     { 10 0 } >>size ; inline
 
@@ -167,6 +177,16 @@ repeat-button H{
 
 <PRIVATE
 
+CONSTANT: checkmark-dim 12
+CONSTANT: checkmark-square { { 0 0 } { 0 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim } { $ checkmark-dim 0 } } 
+: <drawn-checkmark-pen> ( -- pen )
+    roll-button-selected-background checkmark-square <polygon>
+    roll-button-selected-background checkmark-square <polygon>
+    selection-color checkmark-square <polygon>
+    roll-button-rollover-border checkmark-square <polygon>
+    toolbar-button-pressed-background checkmark-square <polygon>
+    <button-pen> ;
+
 : <checkmark-pen> ( -- pen )
     "checkbox" theme-image <image-pen>
     "checkbox" theme-image <image-pen>
@@ -177,7 +197,7 @@ repeat-button H{
 
 : <checkmark> ( -- gadget )
     <gadget>
-    <checkmark-pen> >>interior
+    <drawn-checkmark-pen> >>interior
     dup dup interior>> pen-pref-dim >>dim ;
 
 : toggle-model ( model -- )
@@ -199,6 +219,17 @@ M: checkbox model-changed
 
 <PRIVATE
 
+CONSTANT: checkmark-dim/2 $[ $ checkmark-dim 2 / ]
+CONSTANT: checkmark-rhombus { { 0 $ checkmark-dim/2 } { $ checkmark-dim/2 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim/2 } { $ checkmark-dim/2 0 } } 
+: <drawn-radio-pen> ( -- pen )
+    roll-button-selected-background checkmark-rhombus <polygon>
+    roll-button-selected-background checkmark-rhombus <polygon>
+    selection-color checkmark-rhombus <polygon>
+    roll-button-rollover-border checkmark-rhombus <polygon>
+    toolbar-button-pressed-background checkmark-rhombus <polygon>
+    <button-pen>
+    ;
+
 : <radio-pen> ( -- pen )
     "radio" theme-image <image-pen>
     "radio" theme-image <image-pen>
@@ -209,7 +240,7 @@ M: checkbox model-changed
 
 : <radio-knob> ( -- gadget )
     <gadget>
-    <radio-pen> >>interior
+    <drawn-radio-pen> >>interior checkmark-rhombus max-dims >>dim
     dup dup interior>> pen-pref-dim >>dim ;
 
 TUPLE: radio-control < button value ;

--- a/basis/ui/gadgets/buttons/buttons.factor
+++ b/basis/ui/gadgets/buttons/buttons.factor
@@ -5,8 +5,7 @@ combinators.short-circuit combinators.smart fry kernel literals
 locals math math.vectors memoize models namespaces sequences
 ui.commands ui.gadgets ui.gadgets.borders ui.gadgets.labels
 ui.gadgets.packs ui.gadgets.worlds ui.gestures ui.pens
-ui.pens.image ui.pens.polygon ui.pens.solid ui.pens.tile
-ui.theme ui.theme.images ;
+ui.pens.polygon ui.pens.solid ui.theme ;
 FROM: models => change-model ;
 IN: ui.gadgets.buttons
 
@@ -125,13 +124,7 @@ PRIVATE>
 
 <PRIVATE
 
-: <border-button-state-pen> ( prefix background foreground -- pen )
-    [
-        "-left" "-middle" "-right"
-        [ append theme-image ] tri-curry@ tri
-    ] 2dip <tile-pen> ;
-
-: <drawn-border-button-pen> ( -- pen )
+: <border-button-pen> ( -- pen )
     content-background <solid>
     toolbar-background <solid>
     selection-color <solid>
@@ -140,20 +133,13 @@ PRIVATE>
     <button-pen>
     ;
 
-: <border-button-pen> ( -- pen )
-    "button" transparent button-text-color
-    <border-button-state-pen> dup
-    "button-clicked" transparent button-clicked-text-color
-    <border-button-state-pen> dup dup
-    <button-pen> ;
-
 : border-button-label-theme ( gadget -- )
     dup label? [ [ clone t >>bold? ] change-font ] when drop ;
 
 : border-button-theme ( gadget -- gadget )
     dup gadget-child border-button-label-theme
     horizontal >>orientation
-    <drawn-border-button-pen> >>interior
+    <border-button-pen> >>interior
     dup dup interior>> pen-pref-dim >>min-dim
     { 10 0 } >>size ; inline
 
@@ -180,7 +166,7 @@ repeat-button H{
 
 CONSTANT: checkmark-dim 12
 CONSTANT: checkmark-square { { 0 0 } { 0 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim } { $ checkmark-dim 0 } } 
-: <drawn-checkmark-pen> ( -- pen )
+: <checkmark-pen> ( -- pen )
     roll-button-rollover-border checkmark-square <polygon>
     roll-button-rollover-border checkmark-square <polygon>
     dim-color checkmark-square <polygon>
@@ -188,17 +174,9 @@ CONSTANT: checkmark-square { { 0 0 } { 0 $ checkmark-dim } { $ checkmark-dim $ c
     toolbar-button-pressed-background checkmark-square <polygon>
     <button-pen> ;
 
-: <checkmark-pen> ( -- pen )
-    "checkbox" theme-image <image-pen>
-    "checkbox" theme-image <image-pen>
-    "checkbox-clicked" theme-image <image-pen>
-    "checkbox-set" theme-image <image-pen>
-    "checkbox-set-clicked" theme-image <image-pen>
-    <button-pen> ;
-
 : <checkmark> ( -- gadget )
     <gadget>
-    <drawn-checkmark-pen> >>interior
+    <checkmark-pen> >>interior
     dup dup interior>> pen-pref-dim >>dim ;
 
 : toggle-model ( model -- )
@@ -223,7 +201,7 @@ CONSTANT: circle-points 12
 CONSTANT: checkmark-dim/2 $[ $ checkmark-dim 2 / ]
 CONSTANT: checkmark-rhombus { { 0 $ checkmark-dim/2 } { $ checkmark-dim/2 $ checkmark-dim } { $ checkmark-dim $ checkmark-dim/2 } { $ checkmark-dim/2 0 } } 
 CONSTANT: checkmark-circle $[ $ circle-points $ checkmark-dim polygon-circle ]
-: <drawn-radio-pen> ( -- pen )
+: <radio-pen> ( -- pen )
     roll-button-rollover-border checkmark-circle <polygon>
     roll-button-rollover-border checkmark-circle <polygon>
     dim-color checkmark-circle <polygon>
@@ -232,17 +210,9 @@ CONSTANT: checkmark-circle $[ $ circle-points $ checkmark-dim polygon-circle ]
     <button-pen>
     ;
 
-: <radio-pen> ( -- pen )
-    "radio" theme-image <image-pen>
-    "radio" theme-image <image-pen>
-    "radio-clicked" theme-image <image-pen>
-    "radio-set" theme-image <image-pen>
-    "radio-set-clicked" theme-image <image-pen>
-    <button-pen> ;
-
 : <radio-knob> ( -- gadget )
     <gadget>
-    <drawn-radio-pen> >>interior checkmark-rhombus max-dims >>dim
+    <radio-pen> >>interior checkmark-circle max-dims >>dim
     dup dup interior>> pen-pref-dim >>dim ;
 
 TUPLE: radio-control < button value ;

--- a/basis/ui/gadgets/buttons/buttons.factor
+++ b/basis/ui/gadgets/buttons/buttons.factor
@@ -160,7 +160,8 @@ PRIVATE>
 PRIVATE>
 
 : <border-button> ( label quot: ( button -- ) -- button )
-    <button> border-button-theme ;
+    <button> border-button-theme { 1 1 } <filled-border>
+    toolbar-button-pressed-background <solid> >>interior ;
 
 TUPLE: repeat-button < button ;
 

--- a/basis/ui/gadgets/sliders/sliders.factor
+++ b/basis/ui/gadgets/sliders/sliders.factor
@@ -234,8 +234,9 @@ M: slider pref-dim*
 TUPLE: drawn-slider < slider ;
 TUPLE: drawn-slider-pen < slider-pen ;
 
+CONSTANT: slider-highlight-color $ dim-color
 : build-drawn-thumb ( thumb -- thumb )
-    <gadget> line-color <solid> >>interior 1/2 track-add ;
+    <gadget> slider-highlight-color <solid> >>interior 1/2 track-add ;
 
 : <drawn-thumb> ( orientation -- thumb )
     thumb new-track
@@ -263,10 +264,11 @@ CONSTANT: up-triangle-points { { 0 $ scroll-arrow-dim } { $ scroll-arrow-dim/2 0
 CONSTANT: left-triangle-points { { 0 $ scroll-arrow-dim/2 } { $ scroll-arrow-dim  0 } { $ scroll-arrow-dim $ scroll-arrow-dim } }
 CONSTANT: down-triangle-points { { 0 0  } { $ scroll-arrow-dim/2 $ scroll-arrow-dim } { $ scroll-arrow-dim 0 } }
 CONSTANT: right-triangle-points { { 0 $ scroll-arrow-dim } { $ scroll-arrow-dim $ scroll-arrow-dim/2 } { 0 0 } }
+
 : <drawn-up-button> ( orientation -- button )
-    -1 left-triangle-points up-triangle-points [ line-color swap <polygon-gadget> ] bi@ <slide-label-button> ;
+    -1 left-triangle-points up-triangle-points [ slider-highlight-color swap <polygon-gadget> ] bi@ <slide-label-button> ;
 : <drawn-down-button> ( orientation -- button )
-    1 right-triangle-points down-triangle-points [ line-color swap <polygon-gadget> ] bi@ <slide-label-button> ;
+    1 right-triangle-points down-triangle-points [ slider-highlight-color swap <polygon-gadget> ] bi@ <slide-label-button> ;
 
 : <drawn-slider-pen> ( -- pen )
     content-background <solid> dim-color <solid> drawn-slider-pen boa ;
@@ -288,9 +290,11 @@ M: drawn-slider pref-dim*
             [ <drawn-thumb> >>thumb ]
             [ <elevator> >>elevator ]
             [ drop dup add-thumb-to-elevator 1 track-add ]
+            [ drop <gadget> { 1 1 } >>dim slider-highlight-color <solid> >>interior f track-add ]
             [ <drawn-up-button> f track-add ]
-            [ drop <gadget> { 1 1 } >>dim f track-add ]
+            [ drop <gadget> { 1 1 } >>dim slider-highlight-color <solid> >>interior f track-add ]
             [ <drawn-down-button> f track-add ]
+            [ drop <gadget> { 1 1 } >>dim slider-highlight-color <solid> >>interior f track-add ]
         } cleave ;
 
 : <tile-image-slider> ( range orientation -- slider )

--- a/basis/ui/gadgets/sliders/sliders.factor
+++ b/basis/ui/gadgets/sliders/sliders.factor
@@ -245,7 +245,7 @@ TUPLE: drawn-slider-pen < slider-pen ;
         t >>root? ;
 
 : <slide-label-button-pen> ( -- pen )
-    toolbar-background <solid> dup
+    content-background <solid> dup
     toolbar-button-pressed-background <solid> dup dup
     <button-pen> ;
 

--- a/basis/ui/gadgets/sliders/sliders.factor
+++ b/basis/ui/gadgets/sliders/sliders.factor
@@ -257,7 +257,7 @@ TUPLE: drawn-slider-pen < slider-pen ;
 : <labelled-up-button> ( orientation -- button ) -1 "<" "^" <slide-label-button> ;
 : <labelled-down-button> ( orientation -- button ) 1 ">" "v" <slide-label-button> ;
 
-CONSTANT: scroll-arrow-dim 6
+CONSTANT: scroll-arrow-dim 10
 CONSTANT: scroll-arrow-dim/2 $[ $ scroll-arrow-dim 2 / ]
 CONSTANT: up-triangle-points { { 0 $ scroll-arrow-dim } { $ scroll-arrow-dim/2 0 } { $ scroll-arrow-dim $ scroll-arrow-dim } }
 CONSTANT: left-triangle-points { { 0 $ scroll-arrow-dim/2 } { $ scroll-arrow-dim  0 } { $ scroll-arrow-dim $ scroll-arrow-dim } }
@@ -273,8 +273,7 @@ CONSTANT: right-triangle-points { { 0 $ scroll-arrow-dim } { $ scroll-arrow-dim 
 
 M: drawn-slider-pen pen-pref-dim 2drop { 2 2 } ;
 : slider-required-width ( slider -- min-dim )
-    ! drop ${ scroll-arrow-dim scroll-arrow-dim } ;
-    children>> [ button? ] filter first pref-dim* ;
+    children>> [ button? ] filter first pref-dim ;
 M: drawn-slider pref-dim*
     [ dup slider-enabled? [ t >>visible? slider-required-width ] [ f >>visible? drop { 0 0 } ] if ]
     [ drop { 100 100 } ]
@@ -294,33 +293,21 @@ M: drawn-slider pref-dim*
             [ <drawn-down-button> f track-add ]
         } cleave ;
 
-: scale-polygon ( button scale -- )
-    '[ [ _ * ] map! drop ] [ gadget-child interior>> [ interior-vertices>> ] [ boundary-vertices>> ] bi ] dip bi@ ;
-: reset-polygon-dims ( button -- )
-    dup gadget-child [ interior>> boundary-vertices>> 2 <groups> max-dims [ >>dim drop ] keep ] keep dim<< ;
-: wider-slider ( drawn-slider -- )
-    children>> [ button? ] filter [ [ 2 scale-polygon ] [ reset-polygon-dims ] [ relayout ] tri ] each ;
-: thinner-slider ( drawn-slider -- )
-    children>> [ button? ] filter [ [ 1/2 scale-polygon ] [ reset-polygon-dims ] [ relayout ] tri ] each ;
+: <tile-image-slider> ( range orientation -- slider )
+    slider new-track
+        swap >>model
+        16 >>line
+        dup orientation>> {
+            [ <slider-pen> >>interior ]
+            [ <thumb> >>thumb ]
+            [ <elevator> >>elevator ]
+            [ drop dup add-thumb-to-elevator 1 track-add ]
+            [ <up-button> f track-add ]
+            [ <down-button> f track-add ]
+            [ drop <gadget> { 1 1 } >>dim f track-add ]
+        } cleave ;
 
-! why does mouse-leave trigger on a button-up condition?
-drawn-slider "expand" f {
-  { mouse-enter wider-slider }
-  { mouse-leave thinner-slider }
-} define-command-map
 PRIVATE>
 
 : <slider> ( range orientation -- slider )
     <drawn-slider> ;
-    ! slider new-track
-    !     swap >>model
-    !     16 >>line
-    !     dup orientation>> {
-    !         [ <slider-pen> >>interior ]
-    !         [ <thumb> >>thumb ]
-    !         [ <elevator> >>elevator ]
-    !         [ drop dup add-thumb-to-elevator 1 track-add ]
-    !         [ <up-button> f track-add ]
-    !         [ <down-button> f track-add ]
-    !         [ drop <gadget> { 1 1 } >>dim f track-add ]
-    !     } cleave ;

--- a/basis/ui/pens/polygon/polygon-docs.factor
+++ b/basis/ui/pens/polygon/polygon-docs.factor
@@ -1,4 +1,4 @@
-USING: colors help.markup help.syntax math ui.pens ;
+USING: colors help.markup help.syntax math math.matrices ui.pens ;
 IN: ui.pens.polygon
 
 HELP: polygon
@@ -14,8 +14,8 @@ HELP: <polygon>
 { $description "Creates a new instance of " { $link polygon } "." } ;
 
 HELP: polygon-circle
-{ $values { "n" { $sequence integer } } { "diameter" { $sequence real } } } 
-{ $description "Approximates the vertices of a circle for a polygon with " { $snippet n } " amount of points." }
+{ $values { "n" integer } { "diameter" real } { "vertices" matrix } }
+{ $description "Approximates the vertices of a circle as a polygon with " { $snippet n } " amount of points." }
 { $code "USING: sequences math.vectors ui.gadgets.grids ui.gadgets.panes ui.theme ;
          9 <iota> 3 v+n [ 20 polygon-circle details-color swap <polygon-gadget> ] map
          1array <grid> gadget." } ;

--- a/basis/ui/pens/polygon/polygon-docs.factor
+++ b/basis/ui/pens/polygon/polygon-docs.factor
@@ -1,4 +1,4 @@
-USING: colors help.markup help.syntax ui.pens ;
+USING: colors help.markup help.syntax math ui.pens ;
 IN: ui.pens.polygon
 
 HELP: polygon
@@ -12,3 +12,10 @@ HELP: polygon
 HELP: <polygon>
 { $values { "color" color } { "points" "a sequence of points" } { "polygon" polygon } }
 { $description "Creates a new instance of " { $link polygon } "." } ;
+
+HELP: polygon-circle
+{ $values { "n" { $sequence integer } } { "diameter" { $sequence real } } } 
+{ $description "Approximates the vertices of a circle for a polygon with " { $snippet n } " amount of points." }
+{ $code "USING: sequences math.vectors ui.gadgets.grids ui.gadgets.panes ui.theme ;
+         9 <iota> 3 v+n [ 20 polygon-circle details-color swap <polygon-gadget> ] map
+         1array <grid> gadget." } ;

--- a/basis/ui/pens/polygon/polygon.factor
+++ b/basis/ui/pens/polygon/polygon.factor
@@ -42,7 +42,7 @@ M: polygon draw-interior
     [ <polygon> ] [ max-dims ] bi
     [ <gadget> ] 2dip [ >>interior ] [ >>dim ] bi* ;
 
-:: polygon-circle ( n diameter -- seq )
+:: polygon-circle ( n diameter -- vertices )
     n 1 + <iota> [ 2 pi * * n / [ sin ] [ cos ] bi 2array ] map
     diameter 2 / '[ [ _ [ * ] [ + ] bi round >fixnum ] map ] map ;
 

--- a/basis/ui/pens/polygon/polygon.factor
+++ b/basis/ui/pens/polygon/polygon.factor
@@ -1,7 +1,9 @@
 ! Copyright (C) 2009 Slava Pestov.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: accessors alien.c-types alien.data kernel opengl
-opengl.gl sequences specialized-arrays ui.gadgets ui.pens ;
+USING: accessors alien.c-types alien.data grouping kernel opengl
+opengl.gl sequences specialized-arrays
+specialized-arrays.instances.alien.c-types.float ui.gadgets
+ui.pens ;
 SPECIALIZED-ARRAY: float
 IN: ui.pens.polygon
 
@@ -11,6 +13,8 @@ interior-vertices
 interior-count
 boundary-vertices
 boundary-count ;
+
+M: polygon pen-pref-dim boundary-vertices>> 2 <groups> max-dims nip ;
 
 : close-path ( points -- points' )
     dup first suffix ;

--- a/basis/ui/pens/polygon/polygon.factor
+++ b/basis/ui/pens/polygon/polygon.factor
@@ -42,8 +42,8 @@ M: polygon draw-interior
     [ <polygon> ] [ max-dims ] bi
     [ <gadget> ] 2dip [ >>interior ] [ >>dim ] bi* ;
 
-: polygon-circle ( n diameter -- seq )
-    [ [ 1 + <iota> ] [ '[ 2 pi * * _ / [ sin ] [ cos ] bi 2array ] map ] bi ]
-    [ 2 / '[ [ _ [ * ] [ + ] bi round ] map ] map ] bi* ;
+:: polygon-circle ( n diameter -- seq )
+    n 1 + <iota> [ 2 pi * * n / [ sin ] [ cos ] bi 2array ] map
+    diameter 2 / '[ [ _ [ * ] [ + ] bi round >fixnum ] map ] map ;
 
 

--- a/basis/ui/pens/polygon/polygon.factor
+++ b/basis/ui/pens/polygon/polygon.factor
@@ -1,10 +1,11 @@
 ! Copyright (C) 2009 Slava Pestov.
 ! See https://factorcode.org/license.txt for BSD license.
-USING: accessors alien.c-types alien.data grouping kernel opengl
-opengl.gl sequences specialized-arrays
+USING: accessors alien.c-types alien.data arrays grouping kernel
+math math.constants math.functions opengl opengl.gl sequences
+specialized-arrays
 specialized-arrays.instances.alien.c-types.float ui.gadgets
 ui.pens ;
-SPECIALIZED-ARRAY: float
+FROM: alien.c-types => float ;
 IN: ui.pens.polygon
 
 ! Polygon pen
@@ -40,3 +41,9 @@ M: polygon draw-interior
 : <polygon-gadget> ( color points -- gadget )
     [ <polygon> ] [ max-dims ] bi
     [ <gadget> ] 2dip [ >>interior ] [ >>dim ] bi* ;
+
+: polygon-circle ( n diameter -- seq )
+    [ [ 1 + <iota> ] [ '[ 2 pi * * _ / [ sin ] [ cos ] bi 2array ] map ] bi ]
+    [ 2 / '[ [ _ [ * ] [ + ] bi round ] map ] map ] bi* ;
+
+

--- a/extra/boids/boids.factor
+++ b/extra/boids/boids.factor
@@ -8,7 +8,7 @@ models.range opengl opengl.demo-support opengl.gl sequences
 threads ui ui.commands ui.gadgets ui.gadgets.borders
 ui.gadgets.buttons ui.gadgets.frames ui.gadgets.grids
 ui.gadgets.labeled ui.gadgets.labels ui.gadgets.packs
-ui.gadgets.sliders ui.render ui.tools.common ;
+ui.gadgets.sliders ui.render ui.theme ui.tools.common ;
 
 QUALIFIED-WITH: models.range mr
 IN: boids
@@ -49,7 +49,7 @@ M: boids-gadget ungraft*
     ] with-translation ;
 
 : draw-boids ( boids -- )
-    0.0 0.0 0.0 0.5 glColor4f
+    details-color >rgba-components drop 0.5 glColor4f
     [ draw-boid ] each ;
 
 M: boids-gadget draw-gadget* ( boids-gadget -- )
@@ -97,7 +97,7 @@ M: range-observer model-changed
 
     { 5 5 } <border> white-interior
 
-    behavior class-of name>> COLOR: gray <framed-labeled-gadget> ;
+    behavior class-of name>> heading-color <framed-labeled-gadget> ;
 
 :: set-population ( n boids-gadget -- )
     boids-gadget [
@@ -145,7 +145,7 @@ PRIVATE>
 
     { 5 5 } <border> add-gadget
 
-    "simulation" COLOR: gray <framed-labeled-gadget> ;
+    "simulation" heading-color <framed-labeled-gadget> ;
 
 TUPLE: boids-frame < pack ;
 
@@ -171,4 +171,4 @@ boids-frame "touchbar" f {
 } define-command-map
 
 MAIN-WINDOW: boids { { title "Boids" } }
-    <boids-frame> >>gadgets ;
+    <boids-frame> white-interior >>gadgets ;


### PR DESCRIPTION
I think it may be nice to change some common use ui.gadgets that rely on images to use opengl drawn gadgets instead -makes them more theme-able and tweakable. So all the .tiff images in basis/ui/theme/images aren't used with the default pens in this change.

The change to the slider is easily viewable via the browser, the changes to checkboxes, radio-buttons and border-buttons are easily viewable by the deploy tool. 

Some problems with this  pull request:
1. the change to `on-leave` in the gtk2 backend
    - Logically it made sense to have `forget-rollover` in there but, using the gesture-logger, it was always causing a mouse-leave gesture after a button-up even though the mouse wasn't leaving the gadget. I don't understand why mouse-leave behaves more appropriately without it. I could remove the width increase on the slider hover (which was behaving awkward due to the erroneous mouse-leave), revert the change to on-leave and continue pretending the quirk doesn't exist, if desired. 
2. I went for some minimal shapes/colours and didn't extensively check themes.
    - can make things (specifically the checkmarks) more obvious by drawing a more unique shape or a size change.

I take no issue with this being declined/altered at will, this is only a suggestion.