### PR TITLE
Bitmap image scaling

### DIFF
--- a/basis/opengl/textures/textures-tests.factor
+++ b/basis/opengl/textures/textures-tests.factor
@@ -37,3 +37,33 @@ ${ GL_RGB9_E5 GL_RGB GL_UNSIGNED_INT_5_9_9_9_REV }
 
 ${ GL_R11F_G11F_B10F GL_RGB GL_UNSIGNED_INT_10F_11F_11F_REV }
 [ BGR float-11-11-10-components (image-format) ] unit-test
+
+! multi-textures are made of a grid of single-textures that, for this example
+! could have dims like the following:
+!  { { 512 512 } { 256 512 } }
+!  { { 512 256 } { 256 256 } }
+! with a total of 768x768 pixels, 
+! to scale each axis of the above image by half (384x384), each single-texture
+! will have a common factor to achieve this
+{
+ { 256 256 }
+}
+[ { 384 384 } { { { 1 1   } { 1/2 1   } }
+                { { 1 1/2 } { 1/2 1/2 } } } normalize-scaling-dims ] unit-test
+! the adapted scaling factor can be multiplied with the normalisation matrix
+{
+  { { { 256 256 } { 128 256 } }
+    { { 256 128 } { 128 128 } } }
+}
+[ { { { 1 1   } { 1/2 1   } }
+    { { 1 1/2 } { 1/2 1/2 } } } { 256 256 } per-texture-scalings-in-grid ] unit-test
+! now each axis has accumulated dimensions adding to a half of the original 768 pixels
+! while maintaining their ratios per single-texture
+{
+  { { { 0 0 } { 256 0 } }
+    { { 0 256 } { 256 256 } } }
+}
+[   { { { 256 256 } { 128 256 } }
+      { { 256 128 } { 128 128 } } } accumulate-divisions-to-grid ] unit-test
+! and new locations of each single texture can be calculated by accumulating along each axis
+

--- a/basis/opengl/textures/textures.factor
+++ b/basis/opengl/textures/textures.factor
@@ -403,7 +403,7 @@ TUPLE: multi-texture < disposable grid display-list loc ;
         dup grid>> make-textured-grid-display-list >>display-list
     ] with-destructors ;
 
-MEMO: normalize-by-first-texture-max-dim ( multi-texture -- norms )
+: normalize-by-first-texture-max-dim ( multi-texture -- norms )
   [ first first dim>> maximum ] [ swap '[ [ dim>> _ v/n ] map ] map ] bi ;
 
 : first-row-xs ( dims -- xs ) first flip first ;

--- a/basis/opengl/textures/textures.factor
+++ b/basis/opengl/textures/textures.factor
@@ -403,7 +403,28 @@ TUPLE: multi-texture < disposable grid display-list loc ;
         dup grid>> make-textured-grid-display-list >>display-list
     ] with-destructors ;
 
-M: multi-texture draw-scaled-texture nip draw-texture ;
+MEMO: normalize-by-first-texture-max-dim ( multi-texture -- norms )
+  [ first first dim>> maximum ] [ swap '[ [ dim>> _ v/n ] map ] map ] bi ;
+
+: first-row-xs ( dims -- xs ) first flip first ;
+: first-col-ys ( dims -- ys ) flip first flip second ; 
+: normalize-scaling-dims ( scaling-dim norms -- scaled-dim )
+  [ first-row-xs sum ] [ first-col-ys sum ] bi 2array v/ ;
+: accumulate-divisions-to-grid ( scaled-dims -- x )
+  [ first-row-xs ] [ first-col-ys ] bi
+  [ 0 [ + ] accumulate nip ] bi@
+  cartesian-product flip ;
+
+: per-texture-scalings-in-grid ( norms scaled-dim -- scaled-dims ) 
+  '[ [ _ v* ] map! ] map! ;
+: shift-loc-offsets ( textures scaled-dims -- )
+  accumulate-divisions-to-grid [ [ >>loc drop ] 2each ] 2each  ;
+
+M: multi-texture draw-scaled-texture
+  grid>>
+  [ normalize-by-first-texture-max-dim [ normalize-scaling-dims ] keep ]
+  [ spin per-texture-scalings-in-grid [ shift-loc-offsets ] keep ]
+  [ [ [ draw-scaled-texture ] 2each ] 2each ] tri ;
 
 M: multi-texture dispose* grid>> [ [ dispose ] each ] each ;
 

--- a/extra/images/viewer/scaling/scaling-docs.factor
+++ b/extra/images/viewer/scaling/scaling-docs.factor
@@ -1,0 +1,44 @@
+USING: help.markup help.syntax ;
+IN: images.viewer.scaling
+
+HELP: scaling-image-gadget
+{
+  $class-description "Allows clicking and dragging on an image with the middle mouse button no resize an image. It will always keep to the original aspet ratio"
+  $nl
+} ;
+
+HELP: autoscaling-image-gadget
+{
+  $class-description "Allows auto-sizing an image to the scale of a root gadget (like a " { $link scroller } " or " { $link world } "."
+  $nl
+  { $slots 
+    {
+      "fill"
+      { "If " { $link f } ", the image will retain original dimenions. If a number from 0 to 1 (can also multiply with numbers above 1 to exceed the visible dimensions of the viewport), the image will contain itself to that fraction of the occupied viewport for the viewports smallest axis (for example, giving the " { $snippet "fill" } " slot a 1 will ensure the image is as large as possible within the viewport without changing its aspect ratio or exceeding the viewport size along either dimension). If a pair, like " { $snippet "{ 0.5 f }" } ", the image will stretch to fill half the width of the viewport while the empty y specification will be stretched according to aspect ratio. " { $snippet "{ f 0.75 }" } " will fill three-quarters of the height of the viewport while the width is given dimensions that maintain aspect ratio. " { $snippet "{ 1 1 }" } " can be given to fill the occupied viewport by stretching the image outside of aspect ratio bounds."
+      }
+    }
+  }
+} ;
+
+ARTICLE: "images.viewer.scaling" "Scaling images in a gadget"
+
+{
+"For a manually resizable image:" 
+{ $subsections scaling-image-gadget }
+
+"For an image that scales depending on the viewport size:"
+{ $subsections autoscaling-image-gadget }
+
+"For a scrollable window of images where at least 1 image is completely viewable, regardless of the window dimensions: " $nl
+  { $code [[ USE: images.viewer.scaling
+{ P" ~/path-to-image-1.png"
+  P" ~/path-to-image-2.png"
+  P" ~/path-to-image-n.png" }
+  [ absolute-path load-image <autoscaling-image-gadget> 1 >>fill ] map
+<pile> 1 >>fill
+[ '[ _ swap add-gadget drop ] each ]
+[ <scroller> ]
+bi "image-scroll" open-window ]] }
+} ;
+
+ABOUT: "images.viewer.scaling"

--- a/extra/images/viewer/scaling/scaling-docs.factor
+++ b/extra/images/viewer/scaling/scaling-docs.factor
@@ -1,20 +1,28 @@
-USING: help.markup help.syntax ;
+USING: help.markup help.syntax multiline ui.gadgets.frames
+ui.gadgets.scrollers ui.gadgets.worlds ;
 IN: images.viewer.scaling
 
 HELP: scaling-image-gadget
 {
-  $class-description "Allows clicking and dragging on an image with the middle mouse button no resize an image. It will always keep to the original aspet ratio"
+  $class-description "Allows clicking and dragging on an image with the right-mouse button to resize an image."
+  " It will always keep to the original aspect ratio"
   $nl
 } ;
 
 HELP: autoscaling-image-gadget
 {
-  $class-description "Allows auto-sizing an image to the scale of a root gadget (like a " { $link scroller } " or " { $link world } "."
+  $class-description "Allows auto-sizing an image to the scale of a root gadget (like a "
+  { $link scroller } " or " { $link world } ")."
   $nl
   { $slots 
     {
       "fill"
-      { "If " { $link f } ", the image will retain original dimenions. If a number from 0 to 1 (can also multiply with numbers above 1 to exceed the visible dimensions of the viewport), the image will contain itself to that fraction of the occupied viewport for the viewports smallest axis (for example, giving the " { $snippet "fill" } " slot a 1 will ensure the image is as large as possible within the viewport without changing its aspect ratio or exceeding the viewport size along either dimension). If a pair, like " { $snippet "{ 0.5 f }" } ", the image will stretch to fill half the width of the viewport while the empty y specification will be stretched according to aspect ratio. " { $snippet "{ f 0.75 }" } " will fill three-quarters of the height of the viewport while the width is given dimensions that maintain aspect ratio. " { $snippet "{ 1 1 }" } " can be given to fill the occupied viewport by stretching the image outside of aspect ratio bounds."
+      { "If " { $link f } ", the image will retain original dimenions. " $nl
+        "If a number from 0 to 1 (can also multiply with numbers above 1 to exceed the visible dimensions of the viewport), the image will contain itself to that fraction of the occupied viewport (for example, giving the " { $snippet "fill" } " slot a 1 will ensure the image is as large as possible within the viewport without changing its aspect ratio or exceeding the viewport size along either dimension). " $nl
+        "If a pair, like " { $snippet "{ 0.5 f }" } ", the image will stretch to fill half the width of the viewport while the empty y scale will be inferred according to aspect ratio. " $nl
+        "Similarly, " { $snippet "{ f 0.75 }" } " will fill three-quarters of the height of the viewport while the width is inferred by aspect ratio. " $nl
+        "A pair with both axes specified will ignore aspect ratio, for example, " { $snippet "{ 1 1 }" } " can be given to fill the occupied viewport by stretching the image outside of aspect ratio bounds. " $nl
+        { $snippet "{ f f }" } " will infer both axes such that the viewport is always covered by the image (exceeding visible bounds where necessary), maintaining aspect ratio." $nl
       }
     }
   }
@@ -29,7 +37,7 @@ ARTICLE: "images.viewer.scaling" "Scaling images in a gadget"
 "For an image that scales depending on the viewport size:"
 { $subsections autoscaling-image-gadget }
 
-"For a scrollable window of images where at least 1 image is completely viewable, regardless of the window dimensions: " $nl
+"For a scrollable window of images where at least 1 image is completely contained and viewable regardless of the window dimensions: " $nl
   { $code [[ USE: images.viewer.scaling
 { P" ~/path-to-image-1.png"
   P" ~/path-to-image-2.png"
@@ -38,7 +46,28 @@ ARTICLE: "images.viewer.scaling" "Scaling images in a gadget"
 <pile> 1 >>fill
 [ '[ _ swap add-gadget drop ] each ]
 [ <scroller> ]
-bi "image-scroll" open-window ]] }
+bi "image-scroll" open-window ]] } $nl
+
+"To instead ensure the image always completely covers the window so there are no empty regions, use " { $snippet "{ f f }" } " in the " { $snippet "fill" } " slot." $nl
+
+"For a scrollable window of images where each image fills 90% of the height of the viewport, with the filename below it: "
+{ $code [[ USE: images.viewer.scaling
+{ P" ~/path-to-image-1.png"
+  P" ~/path-to-image-2.png"
+  P" ~/path-to-image-n.png" }
+  [ absolute-path [ load-image <autoscaling-image-gadget> { f 0.9 } >>fill ]
+  [ <label> ] bi 2array ] map flip
+<grid> <scroller> "image-scroll" open-window ]]
+} $nl
+
+"For a window where an image automatically fills to the width of the parent gadget, wrap it in a viewport. The parent gadget gives the wrapping viewport the available dimensions and the image will stop at this viewport to calculate the scaling required. For example, with " { $link frame } " and its " { $snippet "filled-cell" } " slot:"
+{ $code [[ USE: images.viewer.scaling
+P" ~/path/to/image.jpg" absolute-path
+[ <label> ] [ load-image <autoscaling-image-gadget> 1 >>fill f <viewport> t >>root? ] bi
+1 2 <frame> swap { 0 0 } grid-add swap { 0 1 } grid-add
+<scroller> "image-filling" open-window ]] } $nl
+
+"Wrapping the image in a viewport can also be used to crop and position an image by using the " { $snippet "loc" } " slot of the viewport in conjunction with the scaling options described above."
 } ;
 
 ABOUT: "images.viewer.scaling"

--- a/extra/images/viewer/scaling/scaling.factor
+++ b/extra/images/viewer/scaling/scaling.factor
@@ -1,0 +1,34 @@
+USING: accessors arrays images images.viewer
+images.viewer.private kernel math math.order math.vectors
+opengl.textures opengl.textures.private sequences ui.gadgets
+ui.gestures ui.render ;
+IN: images.viewer.scaling
+
+TUPLE: scaling-image-gadget < image-gadget { scale initial: 1 } saved-scale ;
+
+<PRIVATE
+
+M: scaling-image-gadget pref-dim* dup pref-dim>> [ nip ] [ [ image>> dim>> ] [ scale>> ] bi v*n [ >integer 1 max ] map ] if* ;
+
+M: scaling-image-gadget draw-gadget*
+  dup image>> [
+    [ pref-dim ] [ image-gadget-texture draw-scaled-texture ] bi
+  ] [ drop ] if ;
+    
+PRIVATE>
+
+: <scaling-image-gadget> ( object -- gadget )
+  \ scaling-image-gadget new-image-gadget* ;
+
+: store-reference-scale ( image -- )
+  dup scale>> >>saved-scale drop ;
+
+! increase for a slower scaling change
+CONSTANT: scaling-proportional-factor 100
+: scale-image ( image -- )
+  drag-loc first2 + scaling-proportional-factor /f over saved-scale>> + 0 max >>scale relayout ;
+
+scaling-image-gadget {
+    { T{ button-down { # 2 } } [ store-reference-scale ] }
+    { T{ drag { # 2 } } [ scale-image ] }
+} set-gestures

--- a/extra/images/viewer/scaling/scaling.factor
+++ b/extra/images/viewer/scaling/scaling.factor
@@ -5,6 +5,7 @@ ui.gestures ui.render ;
 IN: images.viewer.scaling
 
 TUPLE: scaling-image-gadget < image-gadget { scale initial: 1 } saved-scale ;
+TUPLE: autoscaling-image-gadget < image-gadget fill ;
 
 <PRIVATE
 
@@ -14,11 +15,47 @@ M: scaling-image-gadget draw-gadget*
   dup image>> [
     [ pref-dim ] [ image-gadget-texture draw-scaled-texture ] bi
   ] [ drop ] if ;
-    
+
+: fill-in-by-aspect-ratio ( image-gadget dim -- dim )
+  dup first2 xor 
+  [ [ image>> dim>> first2 / ] dip first2 [ nip [ * round ] keep ] [ [ swap /f round ] keep swap ] if* 2array ] [ nip ] if ;
+: cover-image ( image-gadget fill -- dim )
+  [ over
+  parent>>
+  [ root?>> ] find-parent
+  dim>> swap [ [ * ] [ drop f ] if* ] 2map fill-in-by-aspect-ratio ] [ image>> dim>> ] if* ;
+:: contain-image ( image-gadget fill -- dim )
+  image-gadget dup [
+  parent>> 
+  [ root?>> ] find-parent
+  dim>> ] [ image>> dim>> ] bi v- first2 < { fill f } { f fill } ? cover-image ;
+: parent-fill-dims ( image-gadget -- dim )
+  dup fill>> dup number? [ contain-image ] [ cover-image ] if ;
+
+: trigger-viewport-relayout ( image-gadget -- )
+  [ dup root?>> [ drop f ] [ forget-pref-dim t ] if ] each-parent drop
+  ;
+
+M: autoscaling-image-gadget layout* pref-dim drop ;
+M: autoscaling-image-gadget pref-dim* dup pref-dim>> [ nip ] [ [ parent-fill-dims [ >integer 1 max ] map dup ] [ model>> ?set-model ] bi ] if* ;
+
+M: autoscaling-image-gadget draw-gadget*
+  dup image>> [
+    [ pref-dim ]
+    [ image-gadget-texture draw-scaled-texture ]
+    [ trigger-viewport-relayout ]
+    tri
+  ] [ drop ] if ;
+M: autoscaling-image-gadget model-changed nip relayout ;
+
+
+
 PRIVATE>
 
 : <scaling-image-gadget> ( object -- gadget )
   \ scaling-image-gadget new-image-gadget* ;
+: <autoscaling-image-gadget> ( object -- gadget )
+  \ autoscaling-image-gadget new-image-gadget* dup image>> dim>> <model> >>model ;
 
 : store-reference-scale ( image -- )
   dup scale>> >>saved-scale drop ;


### PR DESCRIPTION
Specifically enables multi-texture scaling and adds a gadget that makes the functionality easy to try via something like:

```
USE: images.viewer.scaling "/some/path/to/image.png" load-image <scaling-image-gadget> "scaling-image-test" open-window
```