### PR TITLE
FUEL: Add missing fuel.el library

### DIFF
--- a/misc/fuel/fuel.el
+++ b/misc/fuel/fuel.el
@@ -1,0 +1,27 @@
+;;; fuel.el --- Factor's Ultimate Emacs Library. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2008, 2009, 2010 Jose Antonio Ortega Ruiz
+;; See https://factorcode.org/license.txt for BSD license.
+;; SPDX-License-Identifier: BSD-2-Clause
+
+;; Author: Jose Antonio Ortega Ruiz <jao@gnu.org>
+;; Keywords: languages, fuel, factor
+;; Package-Requires: ((cl-lib "0.2") (emacs "24.2"))
+;; Start date: Sat Dec 06, 2008 00:52
+
+;;; Commentary:
+
+;; FUEL provides a complete environment for your Factor coding pleasure
+;; inside Emacs, including source code edition and interaction with a
+;; Factor listener instance running within Emacs.
+
+;; FUEL was started by Jose A Ortega as an extension to Eduardo Cavazos'
+;; original factor.el code. Eduardo is also responsible of naming the
+;; beast.
+
+;;; Code:
+
+(require 'fuel-mode)
+(provide 'fuel)
+
+;;; fuel.el ends here


### PR DESCRIPTION
A package distributed on Melpa must contain a library whose name matches
the name of the package.  This has not been fully enforced in the past.
We alternatively accepted a "fuel-pkg.el" file (with different contents),
but that is about to change.  (Source: I maintain the package used to
create the packages distributed on Melpa.)