### PR TITLE
lists.lazy: Swap arg order for ltake and lazy-take

### DIFF
--- a/basis/lists/lazy/examples/examples-tests.factor
+++ b/basis/lists/lazy/examples/examples-tests.factor
@@ -1,4 +1,4 @@
 USING: lists.lazy.examples lists.lazy lists tools.test ;
 
-{ { 1 3 5 7 } } [ 4 odds ltake list>array ] unit-test
+{ { 1 3 5 7 } } [ odds 4 ltake list>array ] unit-test
 { { 0 1 4 9 16 } } [ first-five-squares ] unit-test

--- a/basis/lists/lazy/examples/examples.factor
+++ b/basis/lists/lazy/examples/examples.factor
@@ -12,4 +12,4 @@ IN: lists.lazy.examples
 : powers-of-2 ( -- list ) 1 [ 2 * ] lfrom-by ;
 : ones ( -- list ) 1 [ ] lfrom-by ;
 : squares ( -- list ) naturals [ dup * ] lmap-lazy ;
-: first-five-squares ( -- list ) 5 squares ltake list>array ;
+: first-five-squares ( -- list ) squares 5 ltake list>array ;

--- a/basis/lists/lazy/lazy-docs.factor
+++ b/basis/lists/lazy/lazy-docs.factor
@@ -90,18 +90,18 @@ HELP: lmap-lazy
 { $examples
     { $example
         "USING: kernel lists lists.lazy math prettyprint ;"
-        "1 lfrom [ 2 * ] lmap-lazy 5 swap ltake list>array ."
+        "1 lfrom [ 2 * ] lmap-lazy 5 ltake list>array ."
         "{ 2 4 6 8 10 }"
     }
 } ;
 
 HELP: ltake
-{ $values { "n" "a non negative integer" } { "list" "a cons object" } { "result" "resulting cons object" } }
+{ $values { "list" "a cons object" } { "n" "a non negative integer" } { "result" "resulting cons object" } }
 { $description "Outputs a lazy list containing the first n items in the list. This is done a lazy manner. No evaluation of the list elements occurs initially but a " { $link lazy-take } " object is returned which conforms to the list protocol. Calling " { $link car } ", " { $link cdr } " or " { $link nil? } " on this will evaluate elements as required." }
 { $examples
     { $example
         "USING: kernel lists lists.lazy prettyprint ;"
-        "1 lfrom 5 swap ltake list>array ."
+        "1 lfrom 5 ltake list>array ."
         "{ 1 2 3 4 5 }"
     }
 } ;
@@ -112,7 +112,7 @@ HELP: lfilter
 { $examples
     { $example
         "USING: kernel lists lists.lazy math prettyprint ;"
-        "1 lfrom [ even? ] lfilter 5 swap ltake list>array ."
+        "1 lfrom [ even? ] lfilter 5 ltake list>array ."
         "{ 2 4 6 8 10 }"
     }
 } ;
@@ -164,7 +164,7 @@ HELP: lzip
 { $examples
     { $example
         "USING: kernel lists lists.lazy math prettyprint ;"
-        "1 lfrom 10 [ 10 + ] lfrom-by lzip 5 swap ltake list>array ."
+        "1 lfrom 10 [ 10 + ] lfrom-by lzip 5 ltake list>array ."
         "{ { 1 10 } { 2 20 } { 3 30 } { 4 40 } { 5 50 } }"
     }
 } ;

--- a/basis/lists/lazy/lazy-tests.factor
+++ b/basis/lists/lazy/lazy-tests.factor
@@ -28,7 +28,7 @@ lists.lazy math sequences tools.test ;
 ] unit-test
 
 { { 1 2 4 8 16 } } [
-  5 1 [ 2 * ] lfrom-by ltake list>array
+  1 [ 2 * ] lfrom-by 5 ltake list>array
 ] unit-test
 
 [ [ ] lmap ] must-infer

--- a/basis/lists/lazy/lazy.factor
+++ b/basis/lists/lazy/lazy.factor
@@ -77,18 +77,18 @@ M: lazy-map cdr
 M: lazy-map nil?
     cons>> nil? ;
 
-TUPLE: lazy-take n cons ;
+TUPLE: lazy-take cons n ;
 
 C: <lazy-take> lazy-take
 
-: ltake ( n list -- result )
-    over zero? [ 2drop nil ] [ <lazy-take> ] if ;
+: ltake ( list n -- result )
+    dup zero? [ 2drop nil ] [ <lazy-take> ] if ;
 
 M: lazy-take car
     cons>> car ;
 
 M: lazy-take cdr
-    [ n>> 1 - ] [ cons>> cdr ltake ] bi ;
+    [ cons>> cdr ] [ n>> 1 - ltake ] bi ;
 
 M: lazy-take nil?
     dup n>> zero? [ drop t ] [ cons>> nil? ] if ;

--- a/extra/lists/circular/circular-tests.factor
+++ b/extra/lists/circular/circular-tests.factor
@@ -3,11 +3,11 @@
 USING: circular lists lists.circular lists.lazy sequences tools.test ;
 
 { { f f "Fizz" f f "Fizz" f f "Fizz" } } [
-    9 { f f "Fizz" } <circular> ltake list>array
+    { f f "Fizz" } <circular> 9 ltake list>array
 ] unit-test
 
 { { f f f f "Buzz" f f f f "Buzz" f f f f "Buzz" } } [
-    15 { f f f f "Buzz" } <circular> ltake list>array
+    { f f f f "Buzz" } <circular> 15 ltake list>array
 ] unit-test
 
 { {
@@ -15,9 +15,8 @@ USING: circular lists lists.circular lists.lazy sequences tools.test ;
     "Fizz" "" "" "Fizz" "Buzz"
     "" "Fizz" "" "" "FizzBuzz"
 } } [
-    15
-        { "" "" "Fizz" } <circular>
-        { "" "" "" "" "Buzz" } <circular>
-        lzip [ first2 append ] lmap-lazy
-    ltake list>array
+    { "" "" "Fizz" } <circular>
+    { "" "" "" "" "Buzz" } <circular>
+    lzip [ first2 append ] lmap-lazy
+    15 ltake list>array
 ] unit-test

--- a/extra/math/primes/lists/lists-tests.factor
+++ b/extra/math/primes/lists/lists-tests.factor
@@ -1,6 +1,6 @@
 USING: lists lists.lazy math.primes.lists tools.test ;
 
-{ { 2 3 5 7 11 13 17 19 23 29 } } [ 10 lprimes ltake list>array ] unit-test
-{ { 101 103 107 109 113 } } [ 5 100 lprimes-from ltake list>array ] unit-test
-{ { 1000117 1000121 } } [ 2 1000100 lprimes-from ltake list>array ] unit-test
-{ { 999983 1000003 } } [ 2 999982 lprimes-from ltake list>array ] unit-test
+{ { 2 3 5 7 11 13 17 19 23 29 } } [ lprimes 10 ltake list>array ] unit-test
+{ { 101 103 107 109 113 } } [ 100 lprimes-from 5 ltake list>array ] unit-test
+{ { 1000117 1000121 } } [ 1000100 lprimes-from 2 ltake list>array ] unit-test
+{ { 999983 1000003 } } [ 999982 lprimes-from 2 ltake list>array ] unit-test

--- a/extra/parser-combinators/parser-combinators.factor
+++ b/extra/parser-combinators/parser-combinators.factor
@@ -273,7 +273,7 @@ LAZY: only-first ( parser -- parser )
 M: only-first-parser parse ( input parser -- list )
     ! Transform a parser into a parser that only yields
     ! the first possibility.
-    p1>> parse 1 swap ltake ;
+    p1>> parse 1 ltake ;
 
 LAZY: <!*> ( parser -- parser )
     ! Like <*> but only return one possible result

--- a/extra/project-euler/065/065.factor
+++ b/extra/project-euler/065/065.factor
@@ -69,7 +69,7 @@ IN: project-euler.065
     ] lmap-lazy ;
 
 : e-frac ( n -- n )
-    1 - (e-frac) ltake list>array reverse 0
+    (e-frac) swap 1 - ltake list>array reverse 0
     [ + recip ] reduce 2 + ;
 
 PRIVATE>


### PR DESCRIPTION
This is a BREAKING change!

I'm not going to push hard for this, but it does seem to me that the current arg order for `ltake` is inconvenient, and wanted to see what this change would look like, so here it is, for discussion or dismissal.

`ltake` isn't used much in the Factor source itself -- mostly in docs and tests.

Shuffle word effects of this PR:

word  |  added  |  removed
---  |  ---  |  ---
swap  |  1  |  5
over  |  0  |  1
dup  |  1  |  0

---

I also am seeing a lot of unrelated test and linting errors locally, so wanted to see this up against the CI -- although, are basis and extra not tested in CI?