### PR TITLE
raylib.live-coding: add new vocabulary

### DIFF
--- a/extra/raylib/live-coding/authors.txt
+++ b/extra/raylib/live-coding/authors.txt
@@ -1,0 +1,1 @@
+Dmitry Matveyev

--- a/extra/raylib/live-coding/glfw/authors.txt
+++ b/extra/raylib/live-coding/glfw/authors.txt
@@ -1,0 +1,1 @@
+Dmitry Matveyev

--- a/extra/raylib/live-coding/glfw/glfw.factor
+++ b/extra/raylib/live-coding/glfw/glfw.factor
@@ -1,0 +1,17 @@
+! Copyright (C) 2024 Dmitry Matveyev.
+! See https://factorcode.org/license.txt for BSD license.
+USING: alien.c-types alien.syntax ;
+IN: raylib.live-coding.glfw
+
+! Raylib statically compiles GLFW into the library and exposes
+! all functions from there. We *MUST* use Raylib's GLFW to
+! manipulate OpenGL context, namely to disable it when listener
+! needs to render its window. Using external GLFW will not
+! affect Raylib's window, this is why here I duplicate a
+! minimal subset of bindings I need instead of using glfw.fii
+! vocabulary, which links external GLFW dynamically.
+
+LIBRARY: glfw
+
+TYPEDEF: void* GLFWwindow
+FUNCTION-ALIAS: make-context-current void glfwMakeContextCurrent ( GLFWwindow* window )

--- a/extra/raylib/live-coding/live-coding.factor
+++ b/extra/raylib/live-coding/live-coding.factor
@@ -1,0 +1,121 @@
+! Copyright (C) 2024 Dmitry Matveyev.
+! See https://factorcode.org/license.txt for BSD license.
+USING: kernel raylib.live-coding.glfw threads calendar
+namespaces vocabs.refresh continuations timers combinators
+accessors concurrency.messaging concurrency.conditions ;
+FROM: raylib => window-should-close is-key-pressed
+    get-window-handle ;
+IN: raylib.live-coding
+
+SYMBOL: lc-listener-thread
+SYMBOL: lc-game-thread
+SYMBOL: lc-sleep-duration
+
+!
+! Common words
+!
+
+<PRIVATE
+SYMBOL: lc-window-should-close?
+ERROR: lc-continue-or-not original ;
+
+: lc-enabled? ( -- ? ) lc-game-thread get ;
+
+: send-to-listener ( message -- ) lc-listener-thread get send ;
+: send-to-game ( message -- ) lc-game-thread get send ;
+
+: set-window-should-close ( -- ) t lc-window-should-close? set ;
+PRIVATE>
+
+!
+! On the game thread
+!
+
+<PRIVATE
+: window-should-close? ( -- ? )
+    window-should-close
+    lc-window-should-close? get or ;
+
+: with-listener-context ( quot -- )
+    f make-context-current
+    call
+    get-window-handle make-context-current ; inline
+
+: yield-to-listener ( -- )
+    [ lc-sleep-duration get sleep ] with-listener-context ;
+
+: with-rescue-to-listener ( quot -- )
+    lc-enabled? [
+        [ [ \ lc-continue-or-not boa send-to-listener
+            "Game: listening to receive" .
+            receive . ] with-listener-context ] recover
+    ] [ call ] if ; inline
+PRIVATE>
+
+: until-window-should-close-with-live-coding ( game-loop-quot -- )
+    '[
+        [ @ ] with-rescue-to-listener
+        lc-enabled? [ yield-to-listener ] when
+        window-should-close? not
+    ] loop ; inline
+
+: on-key-reload-code ( key -- )
+    is-key-pressed [
+        [ refresh-all ] with-listener-context
+    ] when ;
+
+!
+! On the listener thread
+!
+
+<PRIVATE
+SYMBOL: lc-listen-timer
+
+: reset-timer ( -- ) lc-listen-timer get [ stop-timer ] when* ;
+: reset-library-state ( -- )
+    reset-timer
+    f lc-listener-thread set
+    f lc-game-thread set
+    f lc-window-should-close? set
+    1 milliseconds lc-sleep-duration set-global ;
+
+: restarts ( -- seq )
+    { { "Close" t } { "Continue" f } } ;
+
+DEFER: listen-for-messages
+: handle-error ( error -- )
+    original>> restarts rethrow-restarts [
+        set-window-should-close
+        t send-to-game
+    ] [
+        t send-to-game
+        listen-for-messages
+    ] if ;
+
+: handle-message ( message -- )
+    {
+        { [ dup timed-out-error? ] [ drop ] }
+        { [ dup lc-continue-or-not? ] [ handle-error ] }
+    } cond ;
+
+: listen-for-messages ( -- )
+    ! XXX: race condition: if we call reset-timer exactly at the
+    ! moment of execution of the first quotation, it won't
+    ! get reset. It will be reset next time the live coding
+    ! starts, unless in that moment this race condition happens
+    ! once again.
+    [ 1 milliseconds [ lc-continue-or-not? ] receive-if-timeout ]
+    [
+        ! Received timed-out-error
+        [ listen-for-messages ] 1 seconds later
+        lc-listen-timer set
+    ]
+    recover handle-message ;
+PRIVATE>
+
+: with-live-coding ( main-quot -- )
+    reset-library-state
+    self lc-listener-thread set
+    [ [ reset-library-state ] finally ] curry
+    "game" spawn lc-game-thread set
+    listen-for-messages ;


### PR DESCRIPTION
* Unblocks Listener that can be used to directly input commands, mutate memory.
* Catches all errors in the game loop and allows to continue execution or close a game window.

If this code is good, I'd like to add documentation and merge after that. Please let me know what you think.

In order to test, you'll need to download a dll https://github.com/raysan5/raylib/releases/tag/4.5.0, figure out how to make Factor find it, and run the following code. `main` will run it "normally", `dev` will launch a live coding environment.

```factor
USING: continuations kernel namespaces prettyprint raylib
raylib.live-coding ;
IN: raylib-demo

CONSTANT: screen-width 800
CONSTANT: screen-height 640
CONSTANT: FPS 60

SYMBOL: cnt

: dbg. ( obj -- ) unparse LOG_DEBUG swap trace-log ;
: dbg ( obj -- obj ) dup dbg. ;

: make-window ( -- )
    screen-width screen-height "Raylib Demo" init-window
    FPS set-target-fps ;

: clear-window ( -- ) RAYWHITE clear-background ;

: handle-input ( -- )
    ! KEY_F10 on-key-toggle-console
    KEY_F5 on-key-reload-code
;

: update-game ( -- )
    ;

: draw-game ( -- )
    ! "Success!" .
    cnt get 1 = [ "hey" throw ] when

    begin-drawing
    clear-window
    10 10 draw-fps
    ! draw-game-log
    end-drawing ;

: game-loop ( -- )
    ! cnt get info
    cnt inc
    handle-input
    update-game
    draw-game
    ;

: main ( -- )
    0 cnt set
    LOG_DEBUG set-trace-log-level
    ! 100 screen-width screen-height init-game-log
    ! [ "Enabled" "Disabled" ? info ] set-after-active-toggle-hook
    make-window
    [ [ game-loop ] until-window-should-close-with-live-coding ]
    [ close-window ] finally ;

: dev ( -- )
    [ main ] with-live-coding ;

MAIN: main
```