### PR TITLE
tools.deploy.unix: add .out extension to deployed binaries

### DIFF
--- a/basis/tools/deploy/unix/unix.factor
+++ b/basis/tools/deploy/unix/unix.factor
@@ -2,10 +2,13 @@
 ! See https://factorcode.org/license.txt for BSD license.
 USING: combinators io.backend io.directories io.files.info.unix
 io.pathnames kernel namespaces system tools.deploy.backend
-tools.deploy.config tools.deploy.config.editor ;
+tools.deploy.config tools.deploy.config.editor sequences ;
 IN: tools.deploy.unix
 
+CONSTANT: extension ".out"
+
 : create-app-dir ( vocab bundle-name -- vm-path )
+    [ extension append ] dip
     copy-vm dup 0o755 set-file-permissions ;
 
 M: unix deploy*
@@ -21,6 +24,8 @@ M: unix deploy*
 M: unix deploy-path
     deploy-directory get [
         dup deploy-config [
-            deploy-name get swap append-path normalize-path
+            deploy-name get
+            swap extension append append-path
+            normalize-path
         ] with-variables
     ] with-directory ;


### PR DESCRIPTION
This is a workaround for #3077, maybe could be even considered as a solution.

As per suggestion from @mrjbq7 in [discord](https://discord.com/channels/780615045771821076/786055699271909428/1294306017286426666)