### PR TITLE
alient.libraries.finder.linux: don't prepend "lib" to libraries

### DIFF
--- a/basis/alien/libraries/finder/linux/linux.factor
+++ b/basis/alien/libraries/finder/linux/linux.factor
@@ -41,11 +41,11 @@ CONSTANT: mach-map {
     { [ name-matches? ] [ arch-matches? ] } 2&& ;
 
 : find-ldconfig ( name -- path/f )
-    "lib" prepend load-ldconfig-cache
+    load-ldconfig-cache
     [ ldconfig-matches? ] with find nip ?last ;
 
 :: find-ld ( name -- path/f )
-    "lib" name append <process>
+    name <process>
         [
             "ld" , "-t" ,
             "LD_LIBRARY_PATH" os-env ":" split [ "-L" , , ] each


### PR DESCRIPTION
In bindings libraries are specified with a full filename such as libraylib.so. Prepending "lib" to the beginning doesn't make sense in this case.

This is a breaking change.

[Discussion in Discord](https://discord.com/channels/780615045771821076/785087023022211082/1294684611049291874).