### PR TITLE
raylib: fix linting issues with naming in stack effects

### DIFF
--- a/extra/raylib/raylib-docs.factor
+++ b/extra/raylib/raylib-docs.factor
@@ -4505,8 +4505,8 @@ HELP: load-font-data
     fileData: c-string
     dataSize: int
     fontSize: int
-    fontChars: { "a " { $link pointer } " to a " { $link int } }
-    glyphCount: int
+    codepoints: { "a " { $link pointer } " to a " { $link int } }
+    codepointCount: int
     type: FontType
     GlyphInfo*: { "a " { $link pointer } " to " { $link GlyphInfo } } }
 { $description
@@ -4601,8 +4601,8 @@ HELP: draw-text-codepoint
 HELP: draw-text-codepoints
 { $values
     font: Font
-    codepoint: { "a " { $link pointer } " to a " { $link int } }
-    count: int
+    codepoints: { "a " { $link pointer } " to a " { $link int } }
+    codepointCount: int
     position: Vector2
     fontSize: float
     spacing: float

--- a/extra/raylib/raylib.factor
+++ b/extra/raylib/raylib.factor
@@ -1209,7 +1209,7 @@ FUNCTION-ALIAS: load-font-ex Font LoadFontEx ( c-string fileName, int fontSize, 
 FUNCTION-ALIAS: load-font-from-image Font LoadFontFromImage ( Image image, Color key, int firstChar )                ! Load font from Image (XNA style)
 FUNCTION-ALIAS: load-font-from-memory Font LoadFontFromMemory ( c-string fileType, c-string fileData, int dataSize, int fontSize, int* fontChars, int glyphCount )  ! Load font from memory buffer, fileType refers to extension: i.e. '.ttf'
 FUNCTION-ALIAS: is-font-ready bool IsFontReady ( Font font )                                                         ! Check if a font is ready
-FUNCTION-ALIAS: load-font-data GlyphInfo* LoadFontData ( c-string  fileData, int dataSize, int fontSize, int* fontChars, int codepointCount, FontType type )  ! Load font data for further use
+FUNCTION-ALIAS: load-font-data GlyphInfo* LoadFontData ( c-string  fileData, int dataSize, int fontSize, int* codepoints, int codepointCount, FontType type )  ! Load font data for further use
 FUNCTION-ALIAS: gen-image-font-atlas Image GenImageFontAtlas ( GlyphInfo* chars, Rectangle** recs, int glyphCount, int fontSize, int padding, int packMethod )  ! Generate image font atlas using chars info
 FUNCTION-ALIAS: unload-font-data void UnloadFontData ( GlyphInfo* chars, int glyphCount )                            ! Unload font chars info data (RAM)
 FUNCTION-ALIAS: unload-font void UnloadFont ( Font font )                                                            ! Unload Font from GPU memory (VRAM)


### PR DESCRIPTION
Current tests on master fail because of that