### PR TITLE
Try to improve continuations docs

### DIFF
--- a/core/continuations/continuations.factor
+++ b/core/continuations/continuations.factor
@@ -58,7 +58,7 @@ C: <continuation> continuation
 
 PRIVATE>
 
-: ifcc ( capture restore -- )
+: ifcc ( capture restore -- obj )
     [ dummy-1 current-continuation or? ] 2dip [ dummy-2 ] prepose if ; inline
 
 : callcc0 ( quot -- ) [ drop ] ifcc ; inline


### PR DESCRIPTION
Try to be consistent:
- resume a continuation
- continue the execution

Add explanation of the continuation lifetime

Add explanation around how continations can be used

ifcc, callcc0, callcc1, Add docs for what happens when the capture quotation returns, not only for when the continuation is resumed (it is actually the normal use case ! when using exception and no exception occurs !)

fix the stack effect of ifcc (inline word so no effect)
fix the docs of the stack effect of ifcc 

fix the docs of with-return and return, reify -> resume
