### PR TITLE
combinators.syntax: added neat syntax for several combinators

### DIFF
--- a/extra/combinators/syntax/authors.txt
+++ b/extra/combinators/syntax/authors.txt
@@ -1,0 +1,1 @@
+Leo Mehraban

--- a/extra/combinators/syntax/summary.txt
+++ b/extra/combinators/syntax/summary.txt
@@ -1,0 +1,1 @@
+Syntactic sugar for common combinators

--- a/extra/combinators/syntax/syntax-docs.factor
+++ b/extra/combinators/syntax/syntax-docs.factor
@@ -1,0 +1,38 @@
+! Copyright (C) 2024 Your name.
+! See https://factorcode.org/license.txt for BSD license.
+USING: help.markup help.syntax combinators kernel generalizations ;
+IN: combinators.syntax
+
+HELP: &[
+    { $syntax "&[ A | B | C ]"  } 
+    { $description { "Applies quotations (seperated by " { $link \ | } ") to the first value on the stack one by one, restoring the original value to the top of the stack each time"  }  }
+    { $see-also \ cleave \ bi } ;
+
+HELP: *[
+    { $syntax "*[ A | B | C ]"  } 
+    { $description { "Applies quotations (seperated by " { $link \ | } ") to sucessive values on the stack, applying the first quotation to the first value, the second to the second value, and so on" } }
+    { $see-also \ spread \ bi* } ;
+
+HELP: @[
+    { $syntax "N @[ A ]" }
+    { $description "Applies a quotation to the top N values on the stack" }
+    { $see-also \ napply \ bi@ } ;
+
+HELP: n&[
+     { $syntax "N n&[ A | B | C ]" }
+     { $description "Applies quotations (seperated by " { $link \ | } ") to the first N values on the stack, restoring the original values to the top of the stack each time" }
+     { $see-also POSTPONE: &[ \ ncleave \ bi } ;
+
+HELP: n*[
+    { $syntax "N n*[ A | B | C ]" }
+    { $description "Applies quotations (seperated by " { $link \ | } ") to sucessive N sized groups on the stack, applying the first quotation to the first N values, the second to the second N values, and so on" }
+    { $see-also POSTPONE: *[ \ nspread \ bi* } ;
+
+HELP: n@[
+    { $syntax "M N n@[ A ]" }
+    { $description "Applies a quotation to the top N groups of size M on the stack" }
+    { $see-also POSTPONE: @[ \ mnapply \ bi@ } ;
+
+HELP: |
+{ $description "" } ;
+

--- a/extra/combinators/syntax/syntax-tests.factor
+++ b/extra/combinators/syntax/syntax-tests.factor
@@ -1,0 +1,32 @@
+! Copyright (C) 2024 Your name.
+! See https://factorcode.org/license.txt for BSD license.
+USING: tools.test combinators.syntax math kernel  ;
+IN: combinators.syntax.tests
+{ 3 1 } [
+    2 3
+    *[ 1 + | 2 - ]
+] unit-test
+{ 6 7 } [
+    5
+    &[ 1 + | 2 + ]
+] unit-test
+{ 7 7 } [
+    5 2
+    [| x | &[ x + | x + ] ] call
+] unit-test
+{ 3 -1 } [
+    1 2
+    2 n&[ + | - ]
+] unit-test
+{ 7 -1 } [
+    3 4 1 2
+    2 n*[ + | - ]
+] unit-test
+{ 7 -1 } [
+    14 6
+    2 @[ 7 - ]
+] unit-test
+{ 1 2 } [
+    0 1 1 1
+    2 2 n@[ + ]
+] unit-test

--- a/extra/combinators/syntax/syntax.factor
+++ b/extra/combinators/syntax/syntax.factor
@@ -1,0 +1,28 @@
+USING: kernel parser sequences vectors words lexer quotations combinators ;
+IN: combinators.syntax
+
+
+: | ( -- ) ; delimiter
+<PRIVATE
+! unlike normal parse-until, this also pushes the thing that matched the predicate into the accumulator as well 
+: (parse-until-pred) ( acc end-pred -- ... seq ) [
+        ?scan-datum {
+            { [ [ swap call ] 2keep rot ] [ pick push drop f ] }
+            { [ dup not ] [ drop throw-unexpected-eof ] }
+            { [ dup delimiter? ] [ unexpected ] }
+            { [ dup parsing-word? ] [ nip execute-parsing t ] }
+            [ pick push drop t ]
+        } cond
+    ] curry loop ; inline
+
+: parse-until-pred ( end-pred -- seq ) 100 <vector> swap (parse-until-pred) ; inline
+
+: (parse-cleave-like) ( acc -- acc continue? ) [ [ \ | eq? ] [ \ ] eq? ] bi or ] parse-until-pred unclip-last [ >quotation suffix! ] dip \ | eq? ;
+
+: parse-cleave-like ( word acc -- acc ) 100 <vector> [ (parse-cleave-like) ] loop swap [ suffix! ] bi@ ;
+PRIVATE>
+
+SYNTAX: &[ \ cleave parse-cleave-like ;
+
+SYNTAX: *[ \ spread parse-cleave-like ;
+

--- a/extra/combinators/syntax/syntax.factor
+++ b/extra/combinators/syntax/syntax.factor
@@ -1,4 +1,4 @@
-USING: kernel parser sequences vectors words lexer quotations combinators ;
+USING: kernel parser sequences vectors words lexer quotations combinators generalizations  ;
 IN: combinators.syntax
 
 
@@ -19,10 +19,32 @@ IN: combinators.syntax
 
 : (parse-cleave-like) ( acc -- acc continue? ) [ [ \ | eq? ] [ \ ] eq? ] bi or ] parse-until-pred unclip-last [ >quotation suffix! ] dip \ | eq? ;
 
-: parse-cleave-like ( word acc -- acc ) 100 <vector> [ (parse-cleave-like) ] loop swap [ suffix! ] bi@ ;
+: parse-cleave-quotations ( -- quotations ) 100 <vector> [ (parse-cleave-like) ] loop  ;
+
+: parse-cleave-like ( acc word -- acc ) parse-cleave-quotations swap [ suffix! ] bi@ ;
+
+! couldn't think of a better name. napply, nspread, ncleave ect. are all macros that take in numbers as the top parameter on the stack, meaning that you have to do a bit of shuffling around before they work
+: parse-number-macro-input ( acc word parser-quot -- acc  ) [ unclip-last ] [ 1quotation ] [ call( -- quot ) ] tri* -rot 2curry append! ;
+
+: 2parse-number-macro-input ( acc word parser-quot -- acc  ) [ 2 cut* ] 2dip [ suffix! >quotation ] dip call( -- quot ) swap curry append! ;
+
+: parse-ncleave-like ( acc word  -- acc ) [ parse-cleave-quotations ] parse-number-macro-input  ;
+
+: parse-apply ( acc -- acc ) \ napply [ \ ] parse-until >quotation ] parse-number-macro-input ;
+
+: parse-mnapply ( acc -- acc ) \ mnapply [ \ ] parse-until >quotation ] 2parse-number-macro-input ;
+
 PRIVATE>
 
 SYNTAX: &[ \ cleave parse-cleave-like ;
 
 SYNTAX: *[ \ spread parse-cleave-like ;
+
+SYNTAX: n&[ \ ncleave parse-ncleave-like ;
+
+SYNTAX: n*[ \ nspread parse-ncleave-like ;
+
+SYNTAX: @[ parse-apply ;
+
+SYNTAX: n@[ parse-mnapply ;
 


### PR DESCRIPTION
In this pull request, I've added the following syntax words:
`&[ ... | ... ]` : allows for bi, tri and cleave to be written in a much nicer way. For example, `1 &[ 1 + . | 2 + . ]` is equivalent to `1 [ 1 + . ] [ 2 + . ] bi`, and `1 &[ 1 + . | 2 + . | 5 + . | 60 + . ]` is equivalent to `1 { [1 + . ] [ 2 + . ] [ 5 + . ] [ 60 + . ] } cleave`

`*[ ... | ... ]` : allows for bi*, tri*, and spread to be written in a similar syntax to above. For example, `1 2 3 4 *[ 2 + . | 4 - . | 11 * . | 2 - . ]` is equivalent to `1 2 3 4 { [ 2 + . ] [ 4 - . ] [ 11 * . ] [ 2 - . ] } spread`

`N @[ ... ]` : allows for bi@, tri@, and napply to be written in a similar syntax. For example, `2 3 5 7 11 5 @[ 2 * ]` is equivalent to `2 3 5 7 11 [ 2 * ] 5 napply`

The last three syntax words (n&[, n*[, n@[) do similar things for ncleave, nspread, and mnapply. they require a number directly before them to specify that N. For example, `1 2 3 4 2 n*[ + | - ]` is equivalent to `1 2 3 4 [ + ] [ - ] 2bi*` and `1 2 3 4 2 2 n@[ - ]` is equivalent to `1 2 3 4 [ - ] 2bi@`

All of these words are fully documented, and also have some simple unit tests