### PR TITLE
terminfo and ANSI-stream improvements

### DIFF
--- a/extra/io/streams/ansi/ansi-docs.factor
+++ b/extra/io/streams/ansi/ansi-docs.factor
@@ -1,0 +1,16 @@
+USING: help.markup help.syntax io quotations ;
+IN: io.streams.ansi
+
+ABOUT: "io.streams.escape-codes"
+
+HELP: with-ansi
+{ $values
+    quot: quotation
+}
+{ $description
+    Calls { $snippet "quotation" } with \ output-stream wrapped in a formatter that translates text attributes and colours into ANSI escape codes suitable for use on a text terminal.
+
+    The formatter supports all the text attributes implemented in { $vocab-link "io.stream.escape-codes" } , and maps RGB colours to the 16 ANSI and AIXterm colours - "plain" and "bright" versions of black, white, RGB, and CMY. On terminals that report support for "dim" or "half-bright" text, that will be used to produce an additional 8 darker colours for foreground text.
+
+    Note that since the ANSI and AIX palettes, and the exact behaviour of { $snippet "dim" } , are not standardized across terminals, the colour mapping used is an approximation and may not select optimal colours on all terminals.
+} ;

--- a/extra/io/streams/ansi/ansi-tests.factor
+++ b/extra/io/streams/ansi/ansi-tests.factor
@@ -1,0 +1,25 @@
+USING: colors hashtables io.streams.ansi io.streams.string io.styles tools.test ;
+IN: io.streams.ansi.tests
+
+: ansi-unit-test ( expected quot use-dim -- )
+    '[ [ _ _ (with-ansi) ] with-string-writer ] unit-test ; inline
+
+{ "\e[1mbold\e[0m" } [
+    "bold" bold font-style associate format
+] t ansi-unit-test
+
+{ "\e[32mgreen\e[0m" } [
+    "green" 0 1 0 1 <rgba> foreground associate format
+] t ansi-unit-test
+
+{ "\e[96mcyan\e[0m" } [
+    "cyan" 0 1 1 1 <rgba> foreground associate format
+] t ansi-unit-test
+
+{ "\e[31;2mdimred\e[0m" } [
+    "dimred" 0.5 0 0 1 <rgba> foreground associate format
+] t ansi-unit-test
+
+{ "\e[31mdimred\e[0m" } [
+    "dimred" 0.5 0 0 1 <rgba> foreground associate format
+] f ansi-unit-test

--- a/extra/io/streams/ansi/ansi.factor
+++ b/extra/io/streams/ansi/ansi.factor
@@ -3,58 +3,86 @@
 
 USING: accessors arrays assocs destructors formatting io
 io.streams.escape-codes io.streams.string io.styles kernel math
-math.functions math.vectors namespaces sequences strings ;
+math.functions math.vectors namespaces sequences strings
+terminfo ;
 
 IN: io.streams.ansi
 
 <PRIVATE
 
-CONSTANT: colors H{
+! N.b. the contents of the colormap are not standardized across terminals,
+! although the order - KRGYBCMW - is. This map is a best-guess that should
+! give good results on the majority of terminals, but it cannot be exact
+! without adding significant complications to actively query the tty for
+! colormap information.
+CONSTANT: bg-colors
+    H{
+        ! Standard ANSI palette.
+        { {   0   0   0 } { 40 } }
+        { { 2/3   0   0 } { 41 } }
+        { {   0 2/3   0 } { 42 } }
+        { { 2/3 1/3   0 } { 43 } }
+        { {   0   0 2/3 } { 44 } }
+        { { 2/3   0 2/3 } { 45 } }
+        { {   0 2/3 2/3 } { 46 } }
+        { { 2/3 2/3 2/3 } { 47 } }
 
-    ! System colors (8 colors)
-    { {   0   0   0 } 0 }
-    { { 170   0   0 } 1 }
-    { {   0 170   0 } 2 }
-    { { 170  85   0 } 3 }
-    { {   0   0 170 } 4 }
-    { { 170   0 170 } 5 }
-    { {   0 170 170 } 6 }
-    { { 170 170 170 } 7 }
+        ! AIXterm palette; bright versions of the ANSI colours.
+        ! We assume that any colour terminal supports these.
+        { { 1/3 1/3 1/3 } { 100 } }
+        { {   1 1/3 1/3 } { 101 } }
+        { { 1/3   1 1/3 } { 102 } }
+        { {   1   1 1/3 } { 103 } }
+        { { 1/3 1/3   1 } { 104 } }
+        { {   1 1/3   1 } { 105 } }
+        { { 1/3   1   1 } { 106 } }
+        { {   1   1   1 } { 107 } }
+    }
 
-    ! "Bright" version of 8 colors
-    { {  85  85  85 } 8 }
-    { { 255  85  85 } 9 }
-    { {  85 255  85 } 10 }
-    { { 255 255  85 } 11 }
-    { {  85  85 255 } 12 }
-    { { 255  85 255 } 13 }
-    { {  85 255 255 } 14 }
-    { { 255 255 255 } 15 }
-}
+MEMO: fg-colors ( use-dim -- colormap )
+    bg-colors [
+        [ rest ]
+        [ first 10 - ]
+        bi prefix
+    ] map-values swap
+    [
+        H{
+            ! "Halfbright" palette, created by combining SGR2 (dim text)
+            ! with the ANSI palette. Only usable for the foreground.
+            ! If use-dim is enabled, we add these entries to the FG palette
+            ! so we can get closer matches for them.
+            { { 2/5   0   0 } { 31 2 } }
+            { {   0 2/5   0 } { 32 2 } }
+            { { 2/5 1/5   0 } { 33 2 } }
+            { {   0   0 2/5 } { 34 2 } }
+            { { 2/5   0 2/5 } { 35 2 } }
+            { {   0 2/5 2/5 } { 36 2 } }
+            { { 2/5 2/5 2/5 } { 37 2 } }
+        } assoc-union
+    ] when ;
 
 : color>rgb ( color -- rgb )
-    [ red>> ] [ green>> ] [ blue>> ] tri
-    [ 255 * round >integer ] tri@ 3array ;
+    [ red>> ] [ green>> ] [ blue>> ] tri 3array ;
 
-: color>ansi ( color -- ansi bold? )
-    color>rgb '[ _ distance ]
-    colors [ keys swap minimum-by ] [ at ] bi
-    dup 8 >= [ 8 - t ] [ f ] if ;
+: color>ansi ( color palette -- ansi )
+    [ color>rgb '[ _ distance ] ] dip
+    [ keys swap minimum-by ] [ at ] bi
+    [ "%d" sprintf ] map ";" join "\e[" "m" surround ;
 
-MEMO: color>foreground ( color -- string )
-    color>ansi [ 30 + ] [ "m" ";1m" ? ] bi* "\e[%d%s" sprintf ;
-
-MEMO: color>background ( color -- string )
-    color>ansi [ 40 + ] [ "m" ";1m" ? ] bi* "\e[%d%s" sprintf ;
-
-TUPLE: ansi < filter-writer ;
+TUPLE: ansi < filter-writer fg bg ;
 
 C: <ansi> ansi
 
+MEMO: color>foreground ( color stream -- string )
+    fg>> color>ansi ;
+
+MEMO: color>background ( color stream -- string )
+    bg>> color>ansi ;
+
 M:: ansi stream-format ( str style stream -- )
     stream stream>> :> out
-    style foreground of [ color>foreground out stream-write t ] [ f ] if*
-    style background of [ color>background out stream-write drop t ] when*
+    style foreground of [ stream color>foreground out stream-write t ] [ f ] if*
+    style background of [ stream color>background out stream-write drop t ] when*
     style font-style of [ ansi-font-style out stream-write drop t ] when*
     str out stream-write
     [ "\e[0m" out stream-write ] when ;
@@ -73,11 +101,17 @@ M: ansi stream-write-table
     ] with-output-stream* ;
 
 M: ansi make-cell-stream
-    2drop <string-writer> <ansi> ;
+    nip [ drop <string-writer> ] [ fg>> ] [ bg>> ] tri <ansi> ;
 
 M: ansi dispose drop ;
 
 PRIVATE>
 
+: (with-ansi) ( quot use-dim -- )
+    [ output-stream get ] dip fg-colors bg-colors <ansi> swap with-output-stream* ; inline
+
+! We gate the use of the dim attribute on whether the tty supports it. Note
+! however that some terminals (such as kmscon) claim to support this attribute
+! but do not.
 : with-ansi ( quot -- )
-    output-stream get <ansi> swap with-output-stream* ; inline
+    tty-supports-dim? (with-ansi) ; inline

--- a/extra/io/streams/ansi/authors.txt
+++ b/extra/io/streams/ansi/authors.txt
@@ -1,1 +1,2 @@
 John Benediktsson
+Rebecca Kelly

--- a/extra/io/streams/ansi/summary.txt
+++ b/extra/io/streams/ansi/summary.txt
@@ -1,1 +1,1 @@
-ANSI color implementation of formatted stream protocol
+Formatted stream protocol for terminals that support ANSI+AIXterm color

--- a/extra/io/streams/escape-codes/authors.txt
+++ b/extra/io/streams/escape-codes/authors.txt
@@ -1,1 +1,2 @@
 Doug Coleman
+Rebecca Kelly

--- a/extra/io/streams/escape-codes/escape-codes-docs.factor
+++ b/extra/io/streams/escape-codes/escape-codes-docs.factor
@@ -1,0 +1,55 @@
+USING: help help.markup help.syntax io.streams.256color
+io.streams.ansi kernel sequences strings terminfo ;
+IN: io.streams.escape-codes
+
+DEFER: with-ansi
+DEFER: with-256color
+
+HELP: ansi-font-style
+{ $values
+    { "font-style" "a style or sequence of styles" }
+    { "string" string }
+}
+{ $description
+    Returns a string containing one or more ANSI escape sequences implementing the given style(s).
+} ;
+
+HELP: strip-ansi-escapes
+{ $values
+    str: string
+    str': string
+}
+{ $description
+    Returns a copy of { $snippet "str" } with all ANSI escape sequences stripped out.
+} ;
+
+ARTICLE: "io.streams.escape-codes" "Formatted TTY Output"
+In addition to HTML and GUI output, Factor has facilities for displaying formatted text -- such as that produced by \ help -- on terminals that support text attributes and colours.
+
+The { $vocab-link "io.streams.escape-codes" } vocabulary provides words for generating ANSI escape codes from text attributes, and is not typically useful to end users. The { $vocab-link "io.streams.ansi" } and { $vocab-link "io.streams.256color" } vocabularies, however, provide output streams suitable for displaying formatted text on 16- and 256-color terminals, respectively. In deciding which one to use, you may also want to use { $vocab-link "terminfo" } to query the capabilities of your controlling terminal.
+
+{ $heading "Limitations" }
+These vocabularies do not attempt to query the terminal to figure out what features they support; it's assumed that the caller has done so, if necessary.
+
+Similarly, it assumes the terminal it's talking to supports ECMA/ISO escape sequences rather than querying terminfo to find out if it uses nonstandard sequences. This may change in the future, but this is sufficient for compatibility with the most commonly used terminal emulators.
+
+Palettes are not standardized across terminals, and even across different installs of the same terminal, individual users may have set up custom palettes. These vocabularies do not attempt to read palette information from the terminal; instead, they use builtin palettes that should closely approximate the default configurations for a wide range of terminals.
+
+Formatted output:
+{ $subsections
+    with-ansi
+    with-256color
+}
+
+Querying terminal capabilities:
+{ $subsections
+    tty-supports-ansicolor?
+    tty-supports-256color?
+    tty-supports-rgbcolor?
+    tty-supports-attributes?
+}
+
+{ $see-also "terminfo" }
+;
+
+ABOUT: "io.streams.escape-codes"

--- a/extra/io/streams/escape-codes/escape-codes-tests.factor
+++ b/extra/io/streams/escape-codes/escape-codes-tests.factor
@@ -1,3 +1,7 @@
-USING: io.streams.escape-codes tools.test ;
+USING: io.streams.escape-codes io.styles tools.test ;
 
 { "Hello" } [ "\e[4mHello\e[0m" strip-ansi-escapes ] unit-test
+{ "\e[1m\e[3m" } [ { bold italic } ansi-font-style ] unit-test
+{ { "-a- b" "\e[1mA\e[0m   B" } } [
+  { { "-a-" "b" } { "\e[1mA\e[0m" "B" } } format-ansi-table
+] unit-test

--- a/extra/io/streams/escape-codes/escape-codes.factor
+++ b/extra/io/streams/escape-codes/escape-codes.factor
@@ -16,7 +16,6 @@ CONSTANT: ansi-font-styles H{
 }
 PRIVATE>
 
-
 : ansi-font-style ( font-style -- string )
     dup sequence? [
         [ ansi-font-styles at ] map concat

--- a/extra/io/streams/escape-codes/summary.txt
+++ b/extra/io/streams/escape-codes/summary.txt
@@ -1,0 +1,1 @@
+Text attributes and table formatting using ANSI escapes

--- a/extra/terminfo/authors.txt
+++ b/extra/terminfo/authors.txt
@@ -1,1 +1,2 @@
 John Benediktsson
+Rebecca Kelly

--- a/extra/terminfo/terminfo-docs.factor
+++ b/extra/terminfo/terminfo-docs.factor
@@ -1,4 +1,4 @@
-USING: help.markup help.syntax assocs terminfo.private ;
+USING: help.markup help.syntax assocs terminfo.private kernel ;
 IN: terminfo
 
 HELP: my-terminfo
@@ -24,8 +24,82 @@ HELP: name>terminfo
     Throws \ bad-magic if a database entry is found but the header isn't recognized.
 } ;
 
+HELP: tty-supports-attributes?
+{ $values ?: boolean }
+{ $description
+    Outputs \ t if the current terminal (based on { $snippet "$TERM" } ) supports text attributes such as bold or underline. If you need to know specifically what attributes are supported, you will need to inspect the terminfo; that said, most modern terminals support at least bold, dim, inverse, and underline, and support for italics and strikethrough is increasingly common.
+
+    { $see-also tty-supports-ansicolor? tty-supports-256color? tty-supports-rgbcolor? "terminfo" }
+} ;
+
+HELP: tty-supports-dim?
+{ $values ?: boolean }
+{ $description
+    Outputs \ t if the terminal identified by { $snippet "$TERM" } supports dim { " (aka \"faint\" or \"half-bright\") " } text. The exact behaviour varies by terminal, unfortunately; common approaches are to have a separate, user-configured palette for dim colours (e.g. Konsole), or to generate dim colours on the fly by multiplying the current colour by some scaling factor, typically in the 0.4-0.6 range.
+
+    { $see-also tty-supports-attributes? tty-supports-ansicolor? tty-supports-256color? tty-supports-rgbcolor? "terminfo" }
+} ;
+
+HELP: tty-supports-rgbcolor?
+{ $values ?: boolean }
+{ $description
+    Outputs \ t if the current terminal (based on { $snippet "$TERM" } and { $snippet "$COLORTERM" } ) supports RGB color output, aka " \"direct colour\"" . On modern terminals this is typically an 8-bit-per-channel RGB mode which either displays the colour as given, or automatically maps it to the perceptually closest colour available in an internal palette.
+
+    If { $snippet "$NO_COLOR" } is set, unconditionally returns \ f regardless of the terminal's underlying capabilities.
+
+    In principle, foreground colour is selected using the sequence { $snippet "SGR 38:2:0:r:g:b" } , and background colour with { $snippet "SGR 48:2:0:r:g:b" } , where { $snippet "r:g:b" } are the channel values in the range 0-255. In practice, there is some disagreement about this; see below.
+
+    { $heading "Caveats" }
+    Autodetection of RGB support is a hot mess and false negatives are common. In particular, { $snippet "$COLORTERM" } is not usually propagated across ssh connections unless the user takes extra steps to do so, and while { $snippet "$TERM" } is, many terminfo files do not properly report RGB support.
+
+    Like 256 colour mode (see \ tty-supports-256color? ), there is disagreement across terminals on whether to use { $snippet ":" } or { $snippet ";" } as the argument separator. Additionally, the always-zero second argument is mandatory in some terminals, optional in others, and some may reject it entirely. The standard uses { $snippet ":" } and requires the zero (which is nominally a colourspace ID, and in practice, ignored), and following that format will give you the best out-of-the-box compatibility. For maximum portability, however, you must consult the { $snippet "\"set_a_foreground\"" } and { $snippet "\"set_a_background\"" } terminfo capabilities.
+
+    { $see-also tty-supports-attributes? tty-supports-ansicolor? tty-supports-256color? "terminfo" }
+} ;
+
+HELP: tty-supports-256color?
+{ $values ?: boolean }
+{ $description
+    Outputs \ t if the current terminal (based on { $snippet "$TERM" } ) supports 256-color output. This is an indexed mode, consisting of the ANSI and AIXterm palettes in indexes 0-15 (see \ tty-supports-ansicolor? ), an RGB colour cube in indexes 16-231, and a 24-step greyscale ramp in indexes 232-255.
+
+    If { $snippet "$NO_COLOR" } is set, unconditionally returns \ f regardless of the terminal's underlying capabilities.
+
+    Foreground colour is selected using the sequence { $snippet "SGR 38:5:c" } , and background colour with { $snippet "SGR 48:5:c" } , where { $snippet "c" } is the colour index.
+
+    { $heading "Caveats" }
+    The standard documents { $snippet ":" } as the separator between arguments to these SGRs. Some terminals support { $snippet ";" } as well, for backwards compatibility with older, non-standards-compliant software; a few insist on { $snippet ";" } and will not understand { $snippet ":" } . Consult the { $snippet "\"set_a_foreground\"" } and { $snippet "\"set_a_background\"" } terminfo capabilities to be sure. If you're winging it, prefer { $snippet ":" } .
+
+    { $see-also tty-supports-attributes? tty-supports-ansicolor? tty-supports-rgbcolor? "terminfo" }
+} ;
+
+HELP: tty-supports-ansicolor?
+{ $values ?: boolean }
+{ $description
+    Outputs \ t if the current terminal (based on { $snippet "$TERM" } ) supports ANSI 8-color output. This uses a predefined palette, containing black, red, green, yellow/brown, blue, magenta, cyan, and white, typically at about 70% of full brightness, which can be used for both foreground and background.
+
+    If { $snippet "$NO_COLOR" } is set, unconditionally returns \ f regardless of the terminal's underlying capabilities.
+
+    While this is nominally an 8-colour mode, support for ANSI colour often comes with support for an additional 8-16 colors:
+    { $list
+        { "The \"AIXterm colours\" are an additional eight-colour palette, traditionally containing lighter versions of the ANSI colours. These can be used for both foreground and background." }
+        { "Using dim text in conjunction with ANSI colours (see " { $link tty-supports-dim? } ") will produce darker colours. This can only be used to affect the foreground colour." }
+    }
+
+    It is almost universally the case in modern terminals that ANSI colours are selected with { $snippet "SGR" } values 30-37 (foreground) and 40-47 (background), and AIXterm colours, if available, with 90-97 and 100-107. The corresponding terminfo capabilities are { $snippet "\"set_a_foreground\"" } and { $snippet "\"set_a_background\"" } .
+
+    { $heading "Caveats" }
+    The palette contents are not standardized across terminal emulators; furthermore, most terminal emulators allow these colours to be configured by the user and/or remapped at runtime by software. Thus, while you can be mostly confident that (e.g.) colour 2 is green, figuring out { $emphasis "which" } green is difficult.
+
+    Dim text is sometimes created on the fly by reducing the foreground lightness, and is sometimes a separate palette. In the latter case, combining dim text with AIXterm colours or other colour modes may not work at all, or may not do what you expect.
+
+    Some terminals render bold text with increased lightness in addition to, or instead of, increased font weight. In some cases (e.g. Konsole) this is user-configurable.
+
+    { $see-also tty-supports-attributes? tty-supports-256color? tty-supports-rgbcolor? "terminfo" }
+} ;
+
+
 ARTICLE: "terminfo" "Terminfo Databases"
-    The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals. It supports both SysV { "(\"Legacy\")" } and Curses 6.1 { "(\"Extended Number\")" } formats, and automatically selects the appropriate format depending on the file header. It also supports Curses 5 user-defined { "(\"Extended\")" } capabilities.
+The { $vocab-link "terminfo" } vocabulary contains words for querying the terminfo database, which contains low-level information about the capabilities and protocols of different terminals. It supports both SysV { "(\"Legacy\")" } and Curses 6.1 { "(\"Extended Number\")" } formats, and automatically selects the appropriate format depending on the file header. It also supports Curses 5 user-defined { "(\"Extended\")" } capabilities.
 
 Terminfo capability descriptions are returned as assocs, where the keys are capability names; see { $snippet "terminfo(5)" } for a list of standardized capability names and their meanings. Capabilities that are disabled or absent are not present in the assoc and can be assumed to be \ f . In addition, all of the terminal's names are returned in the { $snippet "\".names\"" } pseudocapability, in the same order they appear in the terminfo file.
 
@@ -36,12 +110,22 @@ Words for getting terminal information:
     file>terminfo
     bytes>terminfo
 }
+
+Words for querying specific capabilities of the current terminal:
+{ $subsections
+    tty-supports-attributes?
+    tty-supports-dim?
+    tty-supports-ansicolor?
+    tty-supports-256color?
+    tty-supports-rgbcolor?
+}
+
 { $heading "Limitations" }
     The database search behaviour is not a perfect match for the behaviour implemented in Curses. In particular, setting the { $snippet "$TERMINFO" } environment variable does not disable searching the system-wide database as well, and the compiled-in search paths are not guaranteed to match the ones compiled into libcurses (although they should be correct on the vast majority of systems).
 
 BerkeleyDB { "\"hashed database\"" } format is not supported and BDB terminfo databases will be ignored.
 
 { $heading "External References" }
-{ $snippet "terminfo(5)" } for information about terminfo capabilities and how to use them; { $snippet "term(5)" } for information about the on-disk database format; and { $snippet "term(7)" } for information about terminal naming conventions. I also found https://github.com/mauke/unibilium/blob/master/secret/terminfo.pod useful for clarifying some aspects of the Curses 5 format which are not clear in the man page. ;
+{ $snippet "terminfo(5)" } for information about terminfo capabilities and how to use them; { $snippet "term(5)" } for information about the on-disk database format; and { $snippet "term(7)" } for information about terminal naming conventions. I also found { $url "https://github.com/mauke/unibilium/blob/master/secret/terminfo.pod" } useful for clarifying some aspects of the Curses 5 format which are not clear in the man page. ;
 
 ABOUT: "terminfo"

--- a/extra/terminfo/terminfo.factor
+++ b/extra/terminfo/terminfo.factor
@@ -1,12 +1,12 @@
 ! Copyright (C) 2013 John Benediktsson.
 ! See https://factorcode.org/license.txt for BSD license.
 
-USING: accessors assocs combinators endian environment
-formatting fry grouping hashtables io io.directories
-io.encodings.binary io.files io.files.info io.files.types
-io.pathnames io.streams.byte-array kernel make math math.parser
-memoize namespaces pack sequences sequences.generalizations
-splitting strings system ;
+USING: accessors assocs combinators combinators.short-circuit
+endian environment formatting fry grouping hashtables io
+io.directories io.encodings.binary io.files io.files.info
+io.files.types io.pathnames io.streams.byte-array kernel make
+math math.parser memoize namespaces pack sequences
+sequences.generalizations splitting strings system ;
 
 IN: terminfo
 
@@ -339,5 +339,38 @@ PRIVATE>
 : name>terminfo ( name -- terminfo/f )
     terminfo-path [ file>terminfo ] [ f ] if* ;
 
-: my-terminfo ( -- terminfo/f )
+MEMO: my-terminfo ( -- terminfo/f )
     "TERM" os-env name>terminfo ;
+
+! We make the simplifying assumption here that terminals that do not support
+! SGR attributes also do not support SGR0, and that all terminals that *do*
+! support SGR support SGR0.
+: tty-supports-attributes? ( -- ? )
+    "exit_attribute_mode" my-terminfo key? ;
+
+: tty-supports-dim? ( -- ? )
+    "enter_dim_mode" my-terminfo key? ;
+
+: tty-supports-rgbcolor? ( -- ? )
+    {
+        [ "COLORTERM" os-env empty? not ]
+        [ "TERM" os-env "-direct" tail? ]
+        [ "RGB" my-terminfo at empty? not ]
+        [ "max_colors" my-terminfo at 0 or 24 2^ >= ]
+    } 0||
+    "NO_COLOR" os-env empty? and ;
+
+: tty-supports-256color? ( -- ? )
+    {
+        [ "TERM" os-env "-256color" tail? ]
+        [ "max_colors" my-terminfo at 0 or 256 >= ]
+    } 0||
+    "NO_COLOR" os-env empty? and ;
+
+: tty-supports-ansicolor? ( -- ? )
+    {
+        [ tty-supports-256color? ]
+        [ "TERM" os-env "-color" tail? ]
+        [ "max_colors" my-terminfo at 0 or 8 >= ]
+    } 0||
+    "NO_COLOR" os-env empty? and ;


### PR DESCRIPTION
The `terminfo` vocabulary gains convenience words for querying support for specific capabilities: SGR, dim, and 8/256/rgb-colour support.

The `io.streams.escape-codes` vocabulary gets a few extra tests, documentation, and an overview article on formatted TTY output.

The `io.streams.ansi` vocabulary gets documentation, tests, and some significant refactoring, which brings with it support for the dim attribute to get an extra 7 colours on ttys that support it.