### PR TITLE
discord: handle network disconnects smoother

### DIFF
--- a/extra/discord/authors.txt
+++ b/extra/discord/authors.txt
@@ -1,1 +1,2 @@
 Doug Coleman
+Aleksander "olus2000" Sabak

--- a/extra/discord/discord.factor
+++ b/extra/discord/discord.factor
@@ -3,7 +3,7 @@
 USING: accessors alien.syntax arrays assocs byte-arrays calendar
 combinators combinators.short-circuit concurrency.mailboxes
 continuations destructors formatting hashtables help http
-http.client http.websockets io io.encodings.string
+http.client http.json http.websockets io io.encodings.string
 io.encodings.utf8 io.sockets io.streams.string json kernel
 literals math multiline namespaces prettyprint
 prettyprint.sections random sequences sets splitting strings
@@ -21,7 +21,7 @@ TUPLE: discord-bot-config
     permissions intents
     user-callback obey-names
     metadata
-    { reconnect-time initial: $[ 2 minutes ] }
+    { reconnect-time initial: $[ 2 seconds ] }
     discord-bot mailbox connect-thread ;
 
 TUPLE: discord-bot < disposable
@@ -50,8 +50,7 @@ TUPLE: discord-bot < disposable
 : add-json-header ( request -- request )
     "application/json" "Content-Type" set-header ;
 
-: json-request-headers ( request -- headers json ) http-request utf8 decode json> ;
-: json-request ( request -- json ) json-request-headers nip ;
+: json-request ( request -- json ) http-request-json nip ;
 : gwrite ( string -- ) [ write ] with-global ;
 : gprint ( string -- ) [ print ] with-global ;
 : gprint-flush ( string -- ) [ print flush ] with-global ;
@@ -426,7 +425,6 @@ M: TYPING_START dispatch-message drop
 : stopping-discord-bot ( -- )
     discord-bot get t >>stop? drop ;
 
-DEFER: discord-reconnect
 : handle-discord-websocket ( obj opcode -- )
     "opcode: " gwrite dup g. over dup byte-array? [ utf8 decode json> ] when g... gflush
     {


### PR DESCRIPTION
Currently when a discord bot using `discord` vocab loses internet access it will get a DNS error when attempting to reconnect. This change catches and ignores this error, and adds a wait of a configurable amount of time (2 seconds by default) to every reconnect attempt.

To prevent future deadlocks the reconnect thread now puts a message in the mailbox in the exit handler.

Also includes some minor cleanup like replacing `json-request-headers` with `http-request-json` from the new `http.json` vocab.