### PR TITLE
help.tour: fix some typos/grammar

### DIFF
--- a/basis/help/tour/tour.factor
+++ b/basis/help/tour/tour.factor
@@ -46,7 +46,7 @@ the semantics of the language can be implemented more efficiently by mutating a 
 
 ARTICLE: "tour-stack" "Playing with the stack"
 
-Let us start looking what Factor actually feels like. Our first words will be literals, like { $snippet "3" } , { $snippet "12.58" } or 
+Let us start looking at what Factor actually feels like. Our first words will be literals, like { $snippet "3" } , { $snippet "12.58" } or 
 { $snippet "\"Chuck Norris\"" } . Literals can be thought as functions that push themselves on the stack. Try writing { $snippet "5" } in the listener and 
 then press enter to confirm. You will see that the stack, initially empty, now looks like
 
@@ -191,7 +191,7 @@ If you've been paying close attention so far, you will realize that you have bee
 These are { $strong "parsing words" }  and they behave differently from ordinary words like { $snippet "5" } , { $link [1..b] } or { $link drop } . We will cover 
 these in more detail when we talk about metaprogramming, but for now it is enough to know that parsing words are special.
 
-They are not defined using the { $link POSTPONE: : } word, but with the word { $link POSTPONE: SYNTAX: } instead. When a parsing words is encountered, it 
+They are not defined using the { $link POSTPONE: : } word, but with the word { $link POSTPONE: SYNTAX: } instead. When a parsing word is encountered, it 
 can interact with the parser using a well-defined API to influence how successive words are parsed. For instance { $link POSTPONE: : } 
 asks for the next token from the parser until { $link POSTPONE: ; } is found and tries to compile that stream of tokens into a word 
 definition.
@@ -520,7 +520,7 @@ objects. As a result, fairly complex systems can evolve from the cooperation of 
 each other's internals.
 
 To be fair, Factor is very different from Smalltalk, but still there is the concept of classes, and generic words can 
-defined having different implementations on different classes.
+be defined having different implementations on different classes.
 
 Some classes are builtin in Factor, such as { $link string } , { $link boolean } , { $link fixnum } or { $link word } . Next, the most common way to 
 define a class is as a { $strong "tuple" } . Tuples are defined with the { $link POSTPONE: TUPLE: } parsing word, followed by the tuple name and the 
@@ -557,7 +557,7 @@ define a most common constructor called { $snippet "<movie>" } , which in our ca
 { $code "
 : <movie> ( title director actors -- movie ) movie boa ;
 " }
-In fact, boa constructor are so common, that the above line can be shortened to
+In fact, boa constructors are so common, that the above line can be shortened to
 
 { $code "
 C: <movie> movie
@@ -566,7 +566,7 @@ C: <movie> movie
 In other cases, you may want to use some defaults, or compute some fields.
 
 The functional minded will be worried about the mutability of tuples. Actually, slots can be declared to be " read-only "
-with { $snippet "{ slot-name read-only } " } . In this case, the field setter will not be generated, and the value must be set a the 
+with { $snippet "{ slot-name read-only } " } . In this case, the field setter will not be generated, and the value must be set at the 
 beginning with a boa constructor. Other valid slot modifiers are { $link POSTPONE: initial: } - to declare a default value - and a class word
 , such as { $snippet "integer" } , to restrict the values that can be inserted.
 
@@ -1013,7 +1013,10 @@ Factor defines many more words for input/output, which cover many more cases, su
 We will end this section investigating some words to walk the filesystem. Our aim is a very minimal implementation of the { $snippet "ls" } command.
 
 The word { $link directory-entries } lists the contents of a directory, giving a list of tuple elements, each one having the 
-slots { $snippet "name" } and { $snippet "type" } . You can see this by trying { $snippet "\"/home\" directory-entries [ name>> ] map" } . If you inspect the 
+slots { $snippet "name" } and { $snippet "type" } . You can see this by trying 
+
+{ $code "\"/home\" directory-entries [ name>> ] map" } 
+If you inspect the 
 directory entries, you will see that the type is either { $link +directory+ } or { $link +regular-file+ } (well, there are symlinks as well, 
 but we will ignore them for simplicity). Hence we can define a word that lists files and directories with
 


### PR DESCRIPTION
This is mostly just a few typos/missing words in the Guided Tour help section. The one vaguely significant change is a change from a `$snippet` to a `$code`, aimed at allowing for sending the sentence to the listener.