### PR TITLE
shell.nix: Update package name, use same naming for helper as Nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,8 +37,8 @@ in
     # Defined in gdk-pixbuf setup hook
     findGdkPixbufLoaders "${pkgs.librsvg}"
 
-    wrapFactor () {
-    [ -n "$1" ] || { printf "Usage: wrapFactor <factor-root>" ; return; }
+    wrapLocalFactor () {
+    [ -n "$1" ] || { printf "Usage: wrapLocalFactor <factor-root>" ; return; }
     local root="$(realpath $1)"
     local binary="''${root}/factor"
     local wrapped="''${root}/.factor-wrapped"


### PR DESCRIPTION
This is a small update, renaming the helper to wrap a factor image/executable in NixOS to the name that is used in the nixpkgs repo itself.