### PR TITLE
persistent.hashtables: Use vocabularies that define needed behavior

### DIFF
--- a/basis/persistent/hashtables/hashtables.factor
+++ b/basis/persistent/hashtables/hashtables.factor
@@ -4,6 +4,14 @@ USING: accessors assocs combinators kernel make math
 parser persistent.assocs persistent.hashtables.nodes
 prettyprint.custom ;
 
+! Use these explicitly because they define needed methods which are not loaded
+! otherwise
+USE: persistent.hashtables.nodes.empty
+USE: persistent.hashtables.nodes.leaf
+USE: persistent.hashtables.nodes.full
+USE: persistent.hashtables.nodes.bitmap
+USE: persistent.hashtables.nodes.collision
+
 IN: persistent.hashtables
 
 TUPLE: persistent-hash


### PR DESCRIPTION
If these are not loaded, methods are undefined when actually using persistent hashtables.

These were removed during a cleanup in 6aa8f640c8b2c268c27e72ffc5991c864fafed19, i suspect that was because no undefined words from these vocabs are actually referenced directly.