### PR TITLE
math.runge-kutta: Add adaptive step size, allow butcher tableau spec

### DIFF
--- a/extra/math/runge-kutta/examples/examples.factor
+++ b/extra/math/runge-kutta/examples/examples.factor
@@ -3,51 +3,72 @@ math.runge-kutta sequences ui.gadgets ui.gadgets.charts
 ui.gadgets.charts.lines ui.gadgets.panes ui.theme ;
 IN: math.runge-kutta.examples
 
-: lorenz-dx/dt ( tx..n -- dx )
-    rest first2
-    swap - 10 * ;
+: lorenz-dx/dt ( x..nt -- dx )
+    first2 swap - 10 * ;
 
-: lorenz-dy/dt ( tx..n -- dy )
-    rest first3
-    28 swap - swapd * swap - ;
+: lorenz-dy/dt ( x..nt -- dy )
+    first3 28 swap - swapd * swap - ;
 
-: lorenz-dz/dt ( tx..n -- dz )
-    rest first3
-    [ * ] dip 8/3 * - ;
+: lorenz-dz/dt ( x..nt -- dz )
+    first3 [ * ] dip 2.666 * - ;
 
-: <lorenz> ( -- dx..n/dt delta tx..n t-limit )
-    { [ lorenz-dx/dt ] [ lorenz-dy/dt ] [ lorenz-dz/dt ] } 0.01 { 0 0 1 21/20 } 150 ;
+: <lorenz> ( -- delta dx..n/dt x..nt t-limit )
+    0.01 { [ lorenz-dx/dt ] [ lorenz-dy/dt ] [ lorenz-dz/dt ] } { 2.0 1.0 1.0 0.0 } 150 ;
 
 
-: lorenz. ( -- )
-    chart new { { -20 20 } { -20 20 } } >>axes
-    line new link-color >>color
-             <lorenz> <runge-kutta-4> { 0 3 } cols-except >>data
-    add-gadget
-    gadget. ;
+! : lorenz. ( -- )
+!     chart new { { -20 20 } { -20 20 } } >>axes
+!     line new link-color >>color
+!              <lorenz> <runge-kutta> { 0 3 } cols-except >>data
+!     add-gadget
+!     gadget. ; 
 
 
-:: rf-dx/dt ( tx..n gamma -- dx )
-    tx..n rest first3 :> ( x y z )
+:: rf-dx/dt ( x..nt gamma -- dx )
+    x..nt first3 :> ( x y z )
     y z 1 - x sq + * gamma x * + ;
 
-:: rf-dy/dt ( tx..n gamma -- dy )
-    tx..n rest first3 :> ( x y z )
+:: rf-dy/dt ( x..nt gamma -- dy )
+    x..nt first3 :> ( x y z )
     x 3 z * 1 + x sq - * gamma y * + ;
 
-:: rf-dz/dt ( tx..n alpha -- dz )
-    tx..n rest first3 :> ( x y z )
+:: rf-dz/dt ( x..nt alpha -- dz )
+    x..nt first3 :> ( x y z )
     -2 z * alpha x y * + * ;
 
-:: <rabinovich-fabrikant> ( gamma alpha -- dx..n/dt delta tx..n t-limit )
-    gamma '[ _ rf-dx/dt ] gamma '[ _ rf-dy/dt ] alpha '[ _ rf-dz/dt ]
-    3array
-    0.01 { 0 -1 0 0.5 } 150 ;
+:: <rabinovich-fabrikant> ( gamma alpha -- delta dx..n/dt x..nt t-limit )
+    0.01
+    { [ gamma rf-dx/dt ] [ gamma rf-dy/dt ] [ alpha rf-dz/dt ] }
+    { -1 0 0.5 0 } 1000 ;
 
 
-: rabinovich-fabrikant. ( -- )
-    chart new { { -2 2 } { -2 2 } } >>axes
-    line new link-color >>color
-             0.1 0.14 <rabinovich-fabrikant> <runge-kutta-4> { 0 3 } cols-except >>data
-             add-gadget
-    gadget. ;
+! : rabinovich-fabrikant. ( -- )
+!     chart new { { -2 2 } { -2 2 } } >>axes
+!     line new link-color >>color
+!              0.1 0.14 <rabinovich-fabrikant> <runge-kutta> { 0 3 } cols-except >>data
+!              add-gadget
+!     gadget. ;
+
+CONSTANT: cyclically-symmetric-b 0.208186 ! >1 is stable, =1 is pitchfork bifurcation, <1 weird stuff
+
+: cyclically-symmetric-dx/dt ( x..nt -- dx )
+    first2 sin swap cyclically-symmetric-b * - ;
+
+: cyclically-symmetric-dy/dt ( x..nt -- dy )
+    rest first2 sin swap cyclically-symmetric-b * - ;
+
+: cyclically-symmetric-dz/dt ( x..nt -- dz )
+    first3 nip swap sin swap cyclically-symmetric-b * - ;
+
+: <cyclically-symmetric> ( -- delta dx..n/dt x..nt t-limit )
+    0.01
+    { [ cyclically-symmetric-dx/dt ] [ cyclically-symmetric-dy/dt ] [ cyclically-symmetric-dz/dt ] }
+    { 2.0 1.0 1.0 0.0 } 1000 ;
+
+! : cyclically-symmetric. ( -- )
+!     chart new { { -4 4 } { -4 4 } } >>axes
+!     line new link-color >>color
+!              <cyclically-symmetric> <runge-kutta> { 0 3 } cols-except >>data
+!              add-gadget
+!     gadget. ;
+

--- a/extra/math/runge-kutta/runge-kutta-docs.factor
+++ b/extra/math/runge-kutta/runge-kutta-docs.factor
@@ -1,7 +1,7 @@
 USING: help.markup help.syntax kernel ;
 IN: math.runge-kutta 
 
-HELP: <runge-kutta-4>
+HELP: <runge-kutta>
 { $values { "dxn..n/dt" object } { "delta" object } { "initial-state" object } { "t-limit" object } { "seq" object } }
 { $description "Simple runge-kutta implementation for generating 4th-order approximated solutions for a set of first order differential equations" }
 { $examples

--- a/extra/math/runge-kutta/runge-kutta-tests.factor
+++ b/extra/math/runge-kutta/runge-kutta-tests.factor
@@ -1,23 +1,25 @@
 USING: math math.runge-kutta sequences tools.test ;
+IN: runge-kutta.tests
 
-! 1-dimensional exponential increase of x with t
-! initial state at { t x } of { 0 1 } with time step of 1
-! x is always increasing by x so dx/dt is just the x value from the initial state
-! gradient at beginning of interval
-{ { 1 } } [ { 0 1 } 1 { [ second ] } (runge-kutta) ] unit-test
-! gradient at midpoint of interval using previous estimation
-{ { 3 } } [ { 1 } { 0 1 } 1 runge-kutta-2-transform { [ second ] } (runge-kutta) ] unit-test
-! again gradient at midpoint of interval using previous estimation
-{ { 5 } } [ { 3 } { 0 1 } 1 runge-kutta-3-transform { [ second ] } (runge-kutta) ] unit-test
-! gradient at end of interval using previous estimation
-{ { 6 } } [ { 5 } { 0 1 } 1 runge-kutta-4-transform { [ second ] } (runge-kutta) ] unit-test
+{
+V{
+    { 1 2 3 } ! unchanged
+    { 1+1/4 2+1/2 3+3/4 } ! addition of the previous with product of each change and the next butcher tableau row
+    { 1+57/128 2+57/64 4+43/128 } ! above again for the next row and so on
+    { 2+1280/2197 5+363/2197 7+1643/2197 }
+    { 2+271/312 5+115/156 8+63/104 }
+    { 1+489/832 3+73/416 4+635/832 }
+}
+}
+[ 1 { [ first ] [ second ] [ third ] } { 1 2 3 0 } runge-kutta-stages ] unit-test
 
-! the summation of vectors for each stage, divided by 6, added to inital
-{ 7/2 } [ { 6 5 3 1 } 0 [ + ] reduce 6 / 1 + ] unit-test
-{ { 1 7/2 } } [ { [ second ] } 1 { 0 1 } (runge-kutta-4) ] unit-test
-
-! alters time dimension by delta
-{ { 1 1 2 3 } } [ 1 { 0 1 2 3 } increment-time ] unit-test
-
-! alters spatial dimensions by approximation
-{ { 1 3/2 7/3 13/4 } } [ { 1/2 1/3 1/4 } { 1 1 2 3 } increment-state-by-approximation ] unit-test
+{
+    ! multiplies each axis by the corresponding coefficents, then sums each axis
+    { 10+619453/843648 21+197629/421824 32+57021/281216 }
+}
+[ V{ { 1 2 3 }
+    { 1+1/4 2+1/2 3+3/4 }
+    { 1+57/128 2+57/64 4+43/128 }
+    { 2+1280/2197 5+363/2197 7+1643/2197 }
+    { 2+271/312 5+115/156 8+63/104 }
+    { 1+489/832 3+73/416 4+635/832 } } { 1 1 1 1 1 1 } (rk) ] unit-test

--- a/extra/math/runge-kutta/runge-kutta.factor
+++ b/extra/math/runge-kutta/runge-kutta.factor
@@ -2,64 +2,77 @@ USING: kernel accessors combinators sequences sequences.generalizations
 arrays math math.vectors ;
 IN: math.runge-kutta
 
-: runge-kutta-2-transform ( rk1 tx..n delta -- tx..n' delta )
-    [ swap [ [ v*n ] keep prefix 1/2 v*n ] dip v+ 2 v*n ] keep ;
+CONSTANT: absolute-epsilon 0.0000001
 
-: runge-kutta-3-transform ( rk2 tx..n delta -- tx..n' delta )
-    runge-kutta-2-transform ;
+CONSTANT: butcher-tableau
+    ! rk4(5) fehlberg method
+    { { 0 }
+    { 1/4 1/4 }
+    { 3/8 3/32 9/32 }
+    { 12/13 1932/2197 -7200/2197 7296/2197 }
+    { 1 439/216 -8 3680/513 -845/4104 }
+    { 1/2 -8/27 2 -3544/2565 1859/4104 -11/40 } }
+CONSTANT: n-order-coefficients { 16/135 0 6656/12825 28561/56430 -9/50 2/55 } 
+CONSTANT: n-1-order-coefficients { 25/216 0 1408/2565 2197/4104 -1/5 0 }
 
-: runge-kutta-4-transform ( rk3 tx..n delta -- tx..n' delta )
-    [ swapd [ v*n ] keep prefix v+ ] keep ;
+! : butcher-tableau ( -- seq )
+!     ! rk1(2) fehlberg method
+!     { { 0 }
+!     { 1/2 1/2 }
+!     { 1 1/256 255/256 } } ;
+! : n-order-coefficients ( -- seq )
+!     { 1/512 255/256 1/512 } ;
+! : n-1-order-coefficients ( -- seq )
+!     { 1/256 255/256 0 } ; 
 
-: (runge-kutta) ( delta tx..n dx..n/dt -- rk )
-    swapd dup length>> [ cleave ] dip narray swap v*n
-    ; inline
+: rk-order ( -- n ) butcher-tableau length 2 - ;
 
-: runge-kutta-differentials ( dx..n/dt -- seq )
-    '[ _ (runge-kutta) ] ;
+: coefficients-and-k-values-product ( k-seq butcher-row -- k*B_i )
+    [ [ * ] with map ] 2map flip [ sum ] map ;
+: (approximation-increment) ( k-seq butcher-row dt -- k*B_i A*h )
+    [ unclip ]
+    ! acc Bs A dt
+    [ [ swap rest coefficients-and-k-values-product ] [ * ] 2bi* ] bi* ;
+: approximation-increment ( k*B_i A*h x..nt -- x..nt' )
+    [ but-last swap [ v+ ] unless-empty ] [ last + ] bi-curry bi* suffix ; 
+: runge-kutta-stage-n ( accumulation butcher-row dt x..nt -- x..nt' )
+    [ (approximation-increment) ] [ approximation-increment ] bi* ;
+: retry-with-adapted-stepsize? ( n -- ? ) absolute-epsilon > ;
+: (adapt-stepsize) ( n -- n' ) absolute-epsilon swap /f 1 rk-order 1 + /f ^ 0.84 * ;
+: adapt-stepsize ( dt dx..n error -- dt' ) 
+    ! leaving relative tolerance unimplemented for now, so ignoring dx..n
+    nip (adapt-stepsize) * ;
+: (rk) ( k-seq coefficients -- rkn )
+    [ flip ] [ '[ _ [ * ] 2map-sum ] map ] bi* ;
+: rk ( k-seq -- rkn-1 rkn )
+    [ n-1-order-coefficients (rk) ] [ n-order-coefficients (rk) ] bi ;
+: higher-order-error ( rkn rkn-1 stepsize -- e )
+    spin v- vabs maximum * ;
 
-: runge-kutta-transforms ( tx..n delta dx..n/dt -- seq )
-    spin
-    [ { [ ]
-      [ runge-kutta-2-transform ]
-      [ runge-kutta-3-transform ]
-      [ runge-kutta-4-transform ] } ] dip
-    '[ _ runge-kutta-differentials compose ] map
-    [ 2curry ] 2with map ;
+! executes the differential equations for each of the stages of approximation
+:: runge-kutta-stages ( dt dx..n/dt x..nt -- k-seq )
+    butcher-tableau V{ { } } [
+      [ dt x..nt runge-kutta-stage-n dx..n/dt cleave-array dt v*n ]
+      [ drop swap suffix ] 2bi
+    ] accumulate* last rest ; inline
+: step-change-and-error ( dt dx..nt/dt x..nt -- dx..dn error )
+    '[ _ _ runge-kutta-stages ] [ [ rk over ] [ higher-order-error ] bi* ] bi ; inline
 
-: increment-time ( delta tx..n -- t+dtx..n )
-    [ swap [ 0 ] 2dip '[ _ + ] change-nth ] keep ; inline
+! repeatedly approximates with adadptig stepsize until within tolerence
+: (runge-kutta) ( dt dx..n/dt x..nt -- dx..dn' dt' )
+    '[
+        dup _ _ step-change-and-error
+        [ adapt-stepsize ] [ retry-with-adapted-stepsize? ] 2bi
+        dup [ nip ] when ! only leave dx..t on stack if leaving loop
+    ] loop ; inline
+: runge-kutta-step ( dx..n' dt' x..nt -- x..nt+1 )
+    [ suffix ] [ v+ ] bi* ;
+: runge-kutta ( dt dx..n/dt x..nt -- dt' x..nt' )
+    [ (runge-kutta) ] [ overd runge-kutta-step ] bi ; inline
 
-: increment-state-by-approximation ( rk4 t+dtx..n -- t+dtx'..n' )
-    swap 0 prefix v+ ;
+: time-limit-predicate ( t-limit -- quot: ( x..nt -- ? ) )
+    '[ dup last _ <= ] ; inline
 
-: (runge-kutta-4) ( dx..n/dt delta tx..n -- tx..n' )
-    [
-        ! set up the set of 4 equations
-        ! NOTE differential functions and timestep are curried
-        runge-kutta-transforms [ [ dup ] compose ] map
+: <runge-kutta> ( initial-delta dxn..n/dt initial-x..nt t-limit -- seq )
+    time-limit-predicate [ [ runge-kutta ] [ 3drop f ] if ] compose with follow ; inline
 
-        ! using concat instead causes slow down by an order of magnitude
-        [ ] [ compose ] reduce
-
-        ! this will always produce 4 outputs with a duplication of the last result
-        ! NOTE the dup is kept in the transform so that function
-        ! can be used in higher-order estimation
-        call( -- rk1 rk2 rk3 rk4 rk4 ) drop 4array 
-
-        ! make array of zeroes of appropriate length to reduce into
-        dup first length>> 0 <array>
-
-        ! reduce the results to the estimated change for the timestep
-        [ v+ ] reduce
-        1/6 v*n
-    ] 2keep
-    increment-time
-    increment-state-by-approximation
-    ;
-
-: time-limit-predicate ( t-limit -- quot: ( tx..n -- ? ) )
-    '[ dup first _ <= ] ; inline
-
-: <runge-kutta-4> ( dxn..n/dt delta initial-state t-limit -- seq )
-    time-limit-predicate [ [ (runge-kutta-4) ] [ 3drop f ] if ] compose 2with follow ; inline


### PR DESCRIPTION
I was doing something with this and wanted it to be faster/more accurate/more flexible.

In changing it, I used cleave-array which seems to make the example charting functions (`lorenz.` `rabinovich-fabrikant.` and `cyclically-symmetric.` ) not want to compile - I assume because  factor can't resolve the expected stack effects for the cleave.
The function contents work fine when pasted into the listener. I ask because I suspect misunderstanding the use of `inline` and there might be a magically simple solution. Is there a word to specify the call stack effect for a cleave or something?