### PR TITLE
html.templates.chloe.compiler: HTML-compliant rendering of raw text elements.

### DIFF
--- a/basis/html/templates/chloe/chloe-docs.factor
+++ b/basis/html/templates/chloe/chloe-docs.factor
@@ -112,7 +112,7 @@ ARTICLE: "html.templates.chloe.tags.control" "Control-flow Chloe tags"
 ARTICLE: "html.templates.chloe.tags.form" "Chloe link and form tags"
 "The following tags are only available if the " { $vocab-link "furnace.chloe-tags" } " vocabulary is loaded."
 { $table
-    { { $snippet "t:a" } { "Renders a link; extends the standard XHTML " { $snippet "a" } " tag by providing some integration with other web framework features. The following attributes are supported:"
+    { { $snippet "t:a" } { "Renders a link; extends the standard HTML " { $snippet "a" } " tag by providing some integration with other web framework features. The following attributes are supported:"
         { $list
             { { $snippet "href" } " - a URL. If it begins with " { $snippet "$" } ", then it is interpreted as a responder-relative path." }
             { { $snippet "rest" } " - a value to add at the end of the URL." }
@@ -139,7 +139,7 @@ ARTICLE: "html.templates.chloe.tags.form" "Chloe link and form tags"
     } }
     { { $snippet "t:base" } { "Outputs an HTML " { $snippet "<base>" } " tag. The attributes are interpreted in the same manner as the attributes of " { $snippet "t:a" } "." } }
     { { $snippet "t:form" } {
-        "Renders a form; extends the standard XHTML " { $snippet "form" } " tag by providing some integration with other web framework features, for example by adding hidden fields for authentication credentials and session management allowing those features to work with form submission transparently. The following attributes are supported:"
+        "Renders a form; extends the standard HTML " { $snippet "form" } " tag by providing some integration with other web framework features, for example by adding hidden fields for authentication credentials and session management allowing those features to work with form submission transparently. The following attributes are supported:"
         { $list
             { { $snippet "t:method" } " - just like the " { $snippet "method" } " attribute of an HTML " { $snippet "form" } " tag, this can equal " { $snippet "get" } " or " { $snippet "post" } ". Unlike the HTML tag, the default is " { $snippet "post" } "." }
             { { $snippet "t:action" } " - a URL. If it begins with " { $snippet "$" } ", then it is interpreted as a responder-relative path." }
@@ -166,9 +166,9 @@ ARTICLE: "html.templates.chloe.tags.form" "Chloe link and form tags"
 } ;
 
 ARTICLE: "html.templates.chloe.tags" "Standard Chloe tags"
-"A Chloe template is an XML file with a mix of standard XHTML and Chloe tags."
+"A Chloe template is an XML file with a mix of standard HTML and Chloe tags."
 $nl
-"XHTML tags are rendered verbatim, except attribute values which begin with " { $snippet "@" } " are replaced with the corresponding " { $link "html.forms.values" } "."
+"HTML tags are rendered verbatim, except attribute values which begin with " { $snippet "@" } " are replaced with the corresponding " { $link "html.forms.values" } "."
 $nl
 "Chloe tags are defined in the " { $snippet "http://factorcode.org/chloe/1.0" } " namespace; by convention, it is bound with a prefix of " { $snippet "t" } ". The top-level tag must always be the " { $snippet "t:chloe" } " tag. A typical Chloe template looks like so:"
 { $code
@@ -292,7 +292,7 @@ ARTICLE: "html.templates.chloe.extend.components" "Extending Chloe with custom c
 } ;
 
 ARTICLE: "html.templates.chloe" "Chloe templates"
-"The " { $vocab-link "html.templates.chloe" } " vocabulary implements an XHTML templating engine. Unlike " { $vocab-link "html.templates.fhtml" } ", Chloe templates are always well-formed XML, and no Factor code can be embedded in them, enforcing proper separation of concerns. Chloe templates can be edited using standard XML editing tools; they are less flexible than FHTML, but often simpler as a result."
+"The " { $vocab-link "html.templates.chloe" } " vocabulary implements an HTML templating engine. Unlike " { $vocab-link "html.templates.fhtml" } ", Chloe templates are always well-formed XML, and no Factor code can be embedded in them, enforcing proper separation of concerns. Chloe templates can be edited using standard XML editing tools; they are less flexible than FHTML, but often simpler as a result."
 { $subsections
     <chloe>
     reset-cache

--- a/basis/html/templates/chloe/chloe-tests.factor
+++ b/basis/html/templates/chloe/chloe-tests.factor
@@ -212,3 +212,8 @@ TUPLE: person first-name last-name ;
         [ "test18" test-template call-template ] run-template
     ] with-variable
 ] unit-test
+
+
+{ "<style>&<>></style><script>&<>></script>" } [
+    [ "test19" test-template call-template ] run-template
+] unit-test

--- a/basis/html/templates/chloe/test/test19.xml
+++ b/basis/html/templates/chloe/test/test19.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<t:chloe xmlns:t="http://factorcode.org/chloe/1.0">
+  <style>&amp;&lt;&gt;></style><script>&amp;&lt;&gt;></script>
+</t:chloe>


### PR DESCRIPTION
HTML `style` and `script` elements are [raw text elements](https://html.spec.whatwg.org/multipage/syntax.html#elements-2), meaning their contents can't contain character references (like `&amp;` or `&gt;`), only raw text. Previously Chloe template compiler escaped characters `&`, `>` and `<` inside them, breaking inline scripts and stylesheets. The direction of Chloe development according to #2046 is to move away from generating XML representation and towards generating HTML representation, so I added special handling of the tags corresponding to raw text elements that prevents escaping their contents.

Notably this behavior was already correct in scripts and stylesheets rendered using the boilerplate Chloe tags `t:style`, `t:script`, `t:write-style` and `t:write-script`.

With this change `>` can be used literally in the raw text elements. To get `<` and `&` their escape codes `&lt;` and `&amp;` can be used, since a Chloe template is an XML file and these escapes will be correctly parsed in all contexts; my changes only affect HTML output.