### PR TITLE
build.sh, platform.hpp: support for DragonFlyBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -289,6 +289,7 @@ find_os() {
         *linux*) OS=linux ;;
         *Linux*) OS=linux ;;
         FreeBSD) OS=freebsd ;;
+        DragonFly) OS=freebsd ;;
         Haiku) OS=haiku ;;
     esac
 }
@@ -861,4 +862,3 @@ case "$1" in
     update-script) update_script ;;
     *) usage ;;
 esac
-

--- a/vm/platform.hpp
+++ b/vm/platform.hpp
@@ -29,16 +29,16 @@
     #endif
   #else
     #include "os-genunix.hpp"
-    #if defined(__FreeBSD__)
-	#define FACTOR_OS_STRING "freebsd"
-	#include "os-freebsd.hpp"
-        #if defined(FACTOR_X86)
-	    #include "os-freebsd-x86.32.hpp"
-        #elif defined(FACTOR_AMD64)
-	    #include "os-freebsd-x86.64.hpp"
-        #else
-            #error "Unsupported FreeBSD flavor"
-        #endif
+    #if defined(__FreeBSD__) || defined (__DragonFly__)
+      #define FACTOR_OS_STRING "freebsd"
+      #include "os-freebsd.hpp"
+      #if defined(FACTOR_X86)
+	      #include "os-freebsd-x86.32.hpp"
+      #elif defined(FACTOR_AMD64)
+	      #include "os-freebsd-x86.64.hpp"
+      #else
+        #error "Unsupported FreeBSD flavor"
+      #endif
     #elif defined(__linux__)
       #define FACTOR_OS_STRING "linux"
       #include "os-linux.hpp"


### PR DESCRIPTION
This fixes build errors on DragonFlyBSD because DragonFly doesn't call itself FreeBSD, even though that's its base.