### PR TITLE
help.vocabs: added other-classes section to vocab help

### DIFF
--- a/basis/help/vocabs/vocabs.factor
+++ b/basis/help/vocabs/vocabs.factor
@@ -138,6 +138,18 @@ C: <vocab-author> vocab-author
 : describe-intersection-classes ( classes -- )
     "Intersection classes" (describe-classes) ;
 
+: describe-other-classes ( classes -- )
+    [
+        "Other classes" $subheading
+        [
+            [ <$pretty-link> ]
+            [ "metaclass" word-prop <$pretty-link> ]
+            bi 2array
+        ] map
+        { { $strong "Class" } { $strong "Class type" } } prefix
+        $table
+    ] unless-empty ;
+
 : describe-classes ( classes -- )
     [ builtin-class? ] partition
     [ tuple-class? ] partition
@@ -145,7 +157,7 @@ C: <vocab-author> vocab-author
     [ predicate-class? ] partition
     [ mixin-class? ] partition
     [ union-class? ] partition
-    [ intersection-class? ] filter
+    [ intersection-class? ] partition
     {
         [ describe-builtin-classes ]
         [ describe-tuple-classes ]
@@ -154,6 +166,7 @@ C: <vocab-author> vocab-author
         [ describe-mixin-classes ]
         [ describe-union-classes ]
         [ describe-intersection-classes ]
+        [ describe-other-classes ]
     } spread ;
 
 : word-syntax ( word -- string/f )


### PR DESCRIPTION
Added a section in vocab help to list classes that are not part of `builtin`, `tuple`, `singleton`, etc.
This is what it looks like:
<img width="236" height="84" alt="Screenshot 2025-10-15 at 6 58 39 AM" src="https://github.com/user-attachments/assets/039bb734-373d-4f82-9274-3bcb51f161e2" />
