### PR TITLE
classes.enumeration: added 'see' support to enum member words

### DIFF
--- a/extra/classes/enumeration/enumeration.factor
+++ b/extra/classes/enumeration/enumeration.factor
@@ -139,6 +139,7 @@ M: enumeration-class see-class*
 
 M: enumeration-member-word see*
     [
+        dup seeing-word
         <colon \ ENUMERATION: pprint-word {
             [ "parent-enum" word-prop pprint-word ]
             [ "parent-enum" word-prop superclass-of dup fixnum eq? [ drop ] [ "<" text pprint-word ] if ]


### PR DESCRIPTION
Previously,
```factor
IN: scratchpad ENUMERATION: test a b ;
IN: scratchpad \ test.a see
```
would produce
```factor
IN: scratchpad 
CONSTANT: test.a 0 inline
```
which is not how `test.a` is defined.

now, it produces
```factor
USING: classes.enumeration ;
IN: scratchpad
ENUMERATION: test { a 0 } ;
```
which shows how `test.a` is defined, while still highlighting it.
If you ran `\ test.b see` instead, you now get
```factor
USING: classes.enumeration ;
IN: scratchpad
ENUMERATION: test { b 1 } ;
```