### PR TITLE
sequences: created (bounds-check?) generic word

### DIFF
--- a/basis/circular/circular.factor
+++ b/basis/circular/circular.factor
@@ -17,7 +17,7 @@ TUPLE: circular < wrapped-sequence { start integer } ;
 PRIVATE>
 
 M: circular virtual@ circular-wrap seq>> ; inline
-M: circular (bounds-check?) 2drop t ; inline
+M: circular bounds-check? 2drop t ; inline
 M: circular minimum seq>> minimum ; inline
 M: circular maximum seq>> maximum ; inline
 

--- a/basis/grouping/grouping.factor
+++ b/basis/grouping/grouping.factor
@@ -96,7 +96,7 @@ M: circular-slice hashcode* [ sequence-hashcode ] recursive-hashcode ;
 
 M: circular-slice length [ to>> ] [ from>> ] bi - ; inline
 
-M: circular-slice (bounds-check?) 2drop f ; inline
+M: circular-slice bounds-check? 2drop f ; inline
 
 M: circular-slice virtual@
     [ from>> + ] [ seq>> ] bi [ length rem ] keep ; inline

--- a/core/sequences/sequences-docs.factor
+++ b/core/sequences/sequences-docs.factor
@@ -246,21 +246,17 @@ HELP: push
 { $errors "Throws an error if " { $snippet "seq" } " is not resizable, or if the type of " { $snippet "elt" } " is not permitted in " { $snippet "seq" } "." }
 { $side-effects "seq" } ;
 
-HELP: (bounds-check?)
-{ $values { "n" object } { "seq" sequence } { "?" boolean } }
-{ $contract "Tests if the index is within the bounds of the sequence. This word may be implemented by sequence protocol members, but user code should use " { $link bounds-check? } }
-;
-
 HELP: bounds-check?
 { $values { "n" integer } { "seq" sequence } { "?" boolean } }
-{ $description "Tests if the index is within the bounds of the sequence." }
+{ $contract "Tests if the index is within the bounds of the sequence." }
 { $examples
     [=[
         USING: prettyprint sequences ;
         5 { 1 2 3 } bounds-check? .
         f
     ]=]
-} ;
+}
+{ $errors "Throws an " { $link integer-length-expected } " error if n is not an integer" } ;
 
 HELP: bounds-error
 { $values { "n" integer } { "seq" sequence } }
@@ -2011,7 +2007,7 @@ $nl
 "An optional generic word for creating sequences of the same class as a given sequence:"
 { $subsections like }
 "An optional generic word for testing if an index is part of a sequence:"
-{ $subsections (bounds-check?) }
+{ $subsections bounds-check? }
 "Optional generic words for optimization purposes:"
 { $subsections new-sequence new-resizable }
 { $see-also "sequences-unsafe" } ;

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -14,7 +14,7 @@ GENERIC: new-sequence ( len seq -- newseq ) flushable
 GENERIC: new-resizable ( len seq -- newseq ) flushable
 GENERIC: like ( seq exemplar -- newseq ) flushable
 GENERIC: clone-like ( seq exemplar -- newseq ) flushable
-GENERIC: (bounds-check?) ( n seq -- ? ) flushable
+GENERIC: bounds-check? ( n seq -- ? ) flushable
 
 : lengthd ( seq obj -- n obj ) [ length ] dip ; inline
 
@@ -62,13 +62,10 @@ M: sequence shorten [ length < ] 2check [ set-length ] [ 2drop ] if ; inline
 
 ERROR: bounds-error index seq ;
 
-M: sequence (bounds-check?)
-    dupd length < [ 0 >= ] [ drop f ] if ; inline
+ERROR: integer-length-expected obj ;
 
-GENERIC#: bounds-check? 1 ( n seq -- ? )
-
-M: integer bounds-check?
-    (bounds-check?) ; inline
+M: sequence bounds-check?
+    over integer? [ dupd length < [ 0 >= ] [ drop f ] if ] [ drop integer-length-expected ] if ; inline
 
 : bounds-check ( n seq -- n seq )
     [ bounds-check? ] 2check [ bounds-error ] unless ; inline
@@ -302,8 +299,6 @@ M: repetition nth-unsafe nip elt>> ; inline
 INSTANCE: repetition immutable-sequence
 
 <PRIVATE
-
-ERROR: integer-length-expected obj ;
 
 ! The check-length call forces partial dispatch
 : check-length ( n -- n )


### PR DESCRIPTION
The creation of `(bounds-check?)` fixes a minor problem with the implementation of certain virtual sequences (notably `circular`), and increases the flexibility of the sequence protocol.

Here's an example of where it could help:

`circular` has an infinite length, but it also still needs to provide an implementation for the `length` word. It does this by returning the length of the underlying sequence. 
This created a problem with the use of words like `subseq`, where users couldn't access indices outside of the underlying sequence. This happened because `check-slice` used `length` to check if an index was valid.
Now, `check-slice` uses `bounds-check?` (via the helper word `at-or-within-bounds?`), which itself calls `(bounds-check?)`
`circular` now overrides `(bounds-check?)` to always return true, so you can always create subseqs or slices of it with any length

(The reason `(bounds-check?)` and `bounds-check?` are separate is because the latter is implemented as a generic word that dispatches on the numeric input. It seems like the only implementation of this is `integer`, ensuring that the second input is always an integer. This should maybe be simplified, but theoretically, something other than `integer` could use this functionality, so it's still in for now)