### PR TITLE
vm: Fix GC safety bugs from caching pointers across allocations

### DIFF
--- a/vm/inline_cache.cpp
+++ b/vm/inline_cache.cpp
@@ -79,14 +79,11 @@ void inline_cache_jit::emit_inline_cache(fixnum index, cell generic_word_,
 
   // Generate machine code to check, in turn, if the class is one of the cached
   // entries.
-  std::span<const cell> entries(cache_entries.untagged()->data(),
-                                static_cast<size_t>(array_capacity(cache_entries.untagged())));
-  cell entry_offset = 0;
-  for (auto it = entries.begin(); it != entries.end(); it += 2) {
-    cell klass = *it;
-    cell method = *(it + 1);
-    emit_check_and_jump(ic_type, entry_offset, klass, method);
-    entry_offset += 2;
+  for (cell i = 0; i < array_capacity(cache_entries.untagged()); i += 2) {
+    cell klass = array_nth(cache_entries.untagged(), i);
+    cell method = array_nth(cache_entries.untagged(), i + 1);
+
+    emit_check_and_jump(ic_type, i, klass, method);
   }
 
   // If none of the above conditionals tested true, then execution "falls


### PR DESCRIPTION
This fixes three GC safety bugs where raw pointers to GC-managed memory are cached and then dereferenced after allocation points that can trigger GC and move objects in memory, causing use-after-free/invalid pointer bugs.

Bugs fixed:

1. vm/inline_cache.cpp (REGRESSION from 46aaad6):
   - Commit 46aaad6 changed from safe array_nth() pattern to std::span
   - std::span cached pointer to cache_entries->data()
   - emit_check_and_jump() calls emit_with_literal() which can GC
   - After GC, cached pointer is invalid
   - Fix: Revert to original safe pattern using array_nth() each iteration

2. vm/jit.cpp (PRE-EXISTING):
   - Cached relocation_entry* pointer before loop
   - append_bytes() can trigger grow_bytes() -> reallot_array() -> GC
   - Cached pointer becomes invalid after first allocation
   - Fix: Re-access through data_root each iteration

3. vm/code_heap.cpp (PRE-EXISTING):
   - Cached compiled_data pointer
   - add_code_block() allocates and can trigger GC
   - Cached pointer invalid when used
   - Fix: Extract all cell values before calling add_code_block()

Root cause: Factor's GC is moving/compacting. Any pointer obtained via .untagged() or ->data() is only valid until the next allocation point. Must always re-access through data_root to get current pointer after GC.