### PR TITLE
Enable OpenGL3 on Windows

### DIFF
--- a/basis/ui/backend/windows/windows.factor
+++ b/basis/ui/backend/windows/windows.factor
@@ -8,7 +8,7 @@ io.encodings.string io.encodings.utf16 io.encodings.utf8 kernel
 libc literals make math math.bitwise math.order math.parser namespaces opengl
 sequences sets specialized-arrays strings threads ui ui.backend
 ui.clipboards ui.event-loop ui.gadgets ui.gadgets.private
-ui.gadgets.worlds ui.gestures ui.pixel-formats ui.private ui.theme
+ui.gadgets.worlds ui.gestures ui.pixel-formats ui.private ui.render ui.theme
 ui.theme.switching windows.advapi32 windows.dwmapi
 windows.errors windows.gdi32 windows.kernel32 windows.messages
 windows.offscreen windows.ole32 windows.opengl32
@@ -764,6 +764,7 @@ M: windows-ui-backend set-title
 
 M: windows-ui-backend (with-ui)
     [
+        setup-gl3-hooks
         init-clipboard
         init-scale-factor
         init-win32-ui

--- a/basis/windows/uniscribe/uniscribe.factor
+++ b/basis/windows/uniscribe/uniscribe.factor
@@ -115,11 +115,15 @@ PRIVATE>
         if drop
     image RGBA >>component-order ;
 
+:: fill-x-channel ( image -- image' )
+   image bitmap>> uint32_t cast-array
+   [ 0xff000000 bitor ] map! drop image ;
+
 :: render-image ( dc ssa script-string -- image )
     script-string size>> :> size
     size dc [ ssa size script-string draw-script-string ] make-bitmap-image
     script-string font>> [ foreground>> ] [ background>> ] bi
-    >rgba alpha>> 1 number= [ drop ] [ color-to-alpha ] if ;
+    >rgba alpha>> 1 number= [ drop fill-x-channel ] [ color-to-alpha ] if ;
 
 : set-dc-font ( dc font -- )
     cache-font SelectObject win32-error=0/f ;


### PR DESCRIPTION
OpenGL interprets the spare channel in the BGRX bitmap from uniscribe as an alpha channel, which makes most text in the UI disappear. This commit fills it with 0xff to make it opaque if interpreted like that. A more principled fix might be to convince OpenGL to ignore the channel.