### PR TITLE
peg: repeat1-related parsers handle repeated ignores

### DIFF
--- a/basis/peg/parsers/parsers.factor
+++ b/basis/peg/parsers/parsers.factor
@@ -32,8 +32,8 @@ M: list-parser parser-quot
     '[
         input-slice V{ } clone <parse-result>
         _ parse-seq-element [
-            [ @ _ [ f ] if ] swap repeat-loop
-            _ [ dup ast>> length 2 < [ drop f ] when ] when
+            [ @ _ [ f ] if ] swap
+            _ [ repeat1-loop ] [ repeat0-loop ] if
         ] [ f ] if*
     ] ;
 

--- a/basis/peg/peg.factor
+++ b/basis/peg/peg.factor
@@ -416,28 +416,36 @@ M: choice-parser parser-quot
 
 TUPLE: repeat0-parser parser ;
 
-: repeat-loop ( quot: ( -- result/f ) result -- result )
+: repeat0-loop ( quot: ( -- result/f ) result -- result )
     over call [
         [ remaining>> >>remaining ] [ ast>> ] bi
-        over ast>> push repeat-loop
+        dup ignore = [ drop ] [ over ast>> push ] if
+        repeat0-loop
     ] [
         nip
     ] if* ; inline recursive
 
 M: repeat0-parser parser-quot
     parser>> execute-parser-quot '[
-        input-slice V{ } clone <parse-result> _ swap repeat-loop
+        input-slice V{ } clone <parse-result> _ swap
+        repeat0-loop
     ] ;
 
 TUPLE: repeat1-parser parser ;
 
-: repeat1-empty-check ( result -- result )
-    [ dup ast>> empty? [ drop f ] when ] [ f ] if* ;
+: repeat1-loop ( quot: ( -- result/f ) result -- result )
+    over call [
+        [ remaining>> >>remaining ] [ ast>> ] bi
+        dup ignore = [ drop ] [ over ast>> push ] if
+        repeat0-loop
+    ] [
+        2drop f
+    ] if* ; inline
 
 M: repeat1-parser parser-quot
     parser>> execute-parser-quot '[
-        input-slice V{ } clone <parse-result> _ swap repeat-loop
-        repeat1-empty-check
+        input-slice V{ } clone <parse-result> _ swap
+        repeat1-loop
     ] ;
 
 TUPLE: optional-parser parser ;


### PR DESCRIPTION
Current behavior of `repeat0`, `repeat1` and related parsers is to pass any `ignore` values generated by the encapsulated parsers in the resulting AST.

This pull request changes this behavior to be similar to the `seq` family of parsers which will exclude `ignore`s from their output.

Note that the behavior I implemented considers a `repeat1` parser which successfully matched its enclosing parser but got only `ignore`s a successful match nevertheless, creating a case where `repeat1` may produce an empty sequence AST. In my opinion if the content of `repeat1` matched the whole `repeat1` should be a success, no matter what the resulting AST is.