### PR TITLE
peg: optional* word for deciding between f and failed match

### DIFF
--- a/basis/peg/peg-docs.factor
+++ b/basis/peg/peg-docs.factor
@@ -95,7 +95,17 @@ HELP: optional
 }
 { $description
     "Returns a parser that parses 0 or 1 instances of the " { $snippet "parser" } ". The AST produced is "
-    { $link f } " if 0 instances are parsed, otherwise it is the AST produced by " { $snippet "parser" } "." } ;
+    { $link f } " if 0 instances are parsed, otherwise it is the AST produced by " { $snippet "parser" } "." }
+{ $see-also optional* } ;
+
+HELP: optional*
+{ $values
+  { "parser" parser }
+}
+{ $description
+    "Returns a parser that parses 0 or 1 instances of the " { $snippet "parser" } ". The AST produced is "
+    { $link f } " if 0 instances are parsed, otherwise it is a singleton array containing the AST produced by " { $snippet "parser" } " or an empty array if the AST produced was " { $link ignore } "." }
+{ $see-also optional } ;
 
 HELP: semantic
 { $values

--- a/basis/peg/peg-tests.factor
+++ b/basis/peg/peg-tests.factor
@@ -95,6 +95,26 @@ IN: peg.tests
     "cb" "a" token optional "b" token 2array seq parse
 ] must-fail
 
+{ V{ { "a" } "b" } } [
+    "ab" "a" token optional* "b" token 2array seq parse
+] unit-test
+
+{ V{ f "b" } } [
+    "b" "a" token optional* "b" token 2array seq parse
+] unit-test
+
+[
+    "cb" "a" token optional* "b" token 2array seq parse
+] must-fail
+
+{ V{ { f } "b" } } [
+    "ab" "a" token [ drop f ] action optional* "b" token 2array seq parse
+] unit-test
+
+{ V{ { } "b" } } [
+    "ab" "a" token [ drop ignore ] action optional* "b" token 2array seq parse
+] unit-test
+
 { V{ CHAR: a CHAR: b } } [
     "ab" "a" token ensure CHAR: a CHAR: z range dup 3array seq parse
 ] unit-test

--- a/basis/peg/peg.factor
+++ b/basis/peg/peg.factor
@@ -448,6 +448,15 @@ TUPLE: optional-parser parser ;
 M: optional-parser parser-quot
     parser>> execute-parser-quot '[ @ check-optional ] ;
 
+TUPLE: optional*-parser parser ;
+
+: check-optional* ( result -- result )
+    [ input-slice swap ast>> dup ignore = [ drop { } clone ]
+      [ 1array ] if ] [ input-slice f ] if* <parse-result> ;
+
+M: optional*-parser parser-quot
+    parser>> execute-parser-quot '[ @ check-optional* ] ;
+
 TUPLE: semantic-parser parser quot ;
 
 : check-semantic ( result quot -- result )
@@ -555,6 +564,9 @@ PRIVATE>
 
 : optional ( parser -- parser )
     optional-parser boa wrap-peg ;
+
+: optional* ( parser -- parser )
+    optional*-parser boa wrap-peg ;
 
 : semantic ( parser quot -- parser )
     semantic-parser boa wrap-peg ;


### PR DESCRIPTION
Currently there is no way to differentiate between the AST `f` and a failed match in the AST produced by `optional`. I present an alternative that allows to distinguish these two cases. Naming scheme follows `at*`. Several behaviors were considered:
1. Puting `value t` or `f f` in the parent AST.
2. Producing the AST `{ value }` or `f` (implemented by the PR).
3. Producing `{ value t }` or `{ f f }` so it can be destructured and treated similarly as `at*`.
4. Producing `{ value }` or `{ }` so it can be branched on with if-empty family.
5. Producing `value` wrapped in a special tuple or `f`.
6. Producing `value` or a special failure value.

Option 1 is impossible to implement in current PEG vocab implementation since it requires returning an AST of two elements.

Option 2 has been chosen because it retains the property of `optional` that a truthful value is returned on successful match allowing branching using usual conditional combinators, while also allowing a distinction for when the enclosed value has been `ignored` (an empty array is returned in such case).

Option 3 is the closest in behavior to `at*` but requires manual checking for `ignore` which can't be dropped from the output since a variable amount of elements here would cause problems.

Option 4 has the benefit of returning the same type of value every time, but requires manual checking for `ignore`.

Option 5 is very similar to option 2, but requires implementing a new type which only purpose will be to be destructured ASAP, and requires manual handling of `ignore`.

Option 6 doesn't always return a truthy value on success and never returns a falsy value on failure, which breaks similarity with `optional`. Otherwise it's a good solution.