### PR TITLE
fix: update tldr cache zip location

### DIFF
--- a/extra/tldr/tldr.factor
+++ b/extra/tldr/tldr.factor
@@ -22,7 +22,7 @@ tldr-platform [
 
 <PRIVATE
 
-CONSTANT: tldr-zip URL" https://tldr-pages.github.io/assets/tldr.zip"
+CONSTANT: tldr-zip URL" https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip"
 
 : download-tldr ( -- )
     "tldr" cache-file dup make-directory [


### PR DESCRIPTION
This PR updates the tldr cache location to use GitHub releases instead of the deprecated method of providing assets from the website repo.

See [tldr-pages/tldr@v2.2 (release)](https://github.com/tldr-pages/tldr/releases/tag/v2.2) and https://github.com/tldr-pages/tldr/issues/20832 for more information.