### PR TITLE
vm/slot_visitor.hpp: address compiler warning

### DIFF
--- a/vm/slot_visitor.hpp
+++ b/vm/slot_visitor.hpp
@@ -123,7 +123,7 @@ template <typename Fixup> struct slot_visitor {
   cell cards_scanned;
   cell decks_scanned;
 
-  slot_visitor<Fixup>(factor_vm* parent, Fixup fixup)
+  slot_visitor(factor_vm* parent, Fixup fixup)
   : parent(parent),
     fixup(fixup),
     cards_scanned(0),


### PR DESCRIPTION


We avoid the following warning:

```text
vm/slot_visitor.hpp:126:23: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  126 |   slot_visitor<Fixup>(factor_vm* parent, Fixup fixup)
      |                       ^~~~~~~~~
vm/slot_visitor.hpp:126:23: note: remove the '< >'
```
