### PR TITLE
combinators.syntax: changed definitions of ||[ and &&[ to improve usefulness and consistancy

### DIFF
--- a/extra/combinators/syntax/syntax-docs.factor
+++ b/extra/combinators/syntax/syntax-docs.factor
@@ -1,4 +1,4 @@
-USING: combinators.short-circut help.markup help.syntax combinators kernel generalizations ;
+USING: combinators.short-circuit help.markup help.syntax combinators kernel generalizations ;
 IN: combinators.syntax
 
 HELP: &[

--- a/extra/combinators/syntax/syntax-docs.factor
+++ b/extra/combinators/syntax/syntax-docs.factor
@@ -2,7 +2,7 @@ USING: combinators.short-circuit help.markup help.syntax combinators kernel gene
 IN: combinators.syntax
 
 HELP: &[
-    { $syntax "*[ A | B | C ]" }
+    { $syntax "&[ A | B | C ]" }
     { $description { "Applies quotations (separated by " { $link \ | } ") to the first value on the stack one by one, restoring the original value to the top of the stack each time"  }  }
     { $see-also \ cleave \ bi } ;
 

--- a/extra/combinators/syntax/syntax-docs.factor
+++ b/extra/combinators/syntax/syntax-docs.factor
@@ -2,12 +2,12 @@ USING: combinators.short-circut help.markup help.syntax combinators kernel gener
 IN: combinators.syntax
 
 HELP: &[
-    { $syntax "&[ A | B | C ]"  }
+    { $syntax "*[ A | B | C ]" }
     { $description { "Applies quotations (separated by " { $link \ | } ") to the first value on the stack one by one, restoring the original value to the top of the stack each time"  }  }
     { $see-also \ cleave \ bi } ;
 
 HELP: *[
-    { $syntax "*[ A | B | C ]"  }
+    { $syntax "*[ A | B | C ]" }
     { $description { "Applies quotations (separated by " { $link \ | } ") to successive values on the stack, applying the first quotation to the first value, the second to the second value, and so on" } }
     { $see-also \ spread \ bi* } ;
 

--- a/extra/combinators/syntax/syntax-docs.factor
+++ b/extra/combinators/syntax/syntax-docs.factor
@@ -1,13 +1,13 @@
-USING: help.markup help.syntax combinators kernel generalizations ;
+USING: combinators.short-circut help.markup help.syntax combinators kernel generalizations ;
 IN: combinators.syntax
 
 HELP: &[
-    { $syntax "&[ A | B | C ]"  } 
+    { $syntax "&[ A | B | C ]"  }
     { $description { "Applies quotations (separated by " { $link \ | } ") to the first value on the stack one by one, restoring the original value to the top of the stack each time"  }  }
     { $see-also \ cleave \ bi } ;
 
 HELP: *[
-    { $syntax "*[ A | B | C ]"  } 
+    { $syntax "*[ A | B | C ]"  }
     { $description { "Applies quotations (separated by " { $link \ | } ") to successive values on the stack, applying the first quotation to the first value, the second to the second value, and so on" } }
     { $see-also \ spread \ bi* } ;
 
@@ -30,6 +30,26 @@ HELP: n@[
     { $syntax "M N n@[ A ]" }
     { $description "Applies a quotation to the top N groups of size M on the stack" }
     { $see-also POSTPONE: @[ \ mnapply \ bi@ } ;
+
+HELP: &&[
+    { $syntax "&&[ A | B | C ]" }
+    { $description "Runs quotations (seperated by " { $link \ | } "), returning the result of the last quotation only if all previous quotations output true values. Otherwise, outputs " { $link POSTPONE: f }  "." }
+    { $see-also \ 0&& } ;
+
+HELP: ||[
+    { $syntax "||[ A | B | C ]" }
+    { $description "Runs quotations (seperated by " { $link \ | } "), returning the result of the first quotation to produce a true value, or " { $link POSTPONE: f } " if none of them do." }
+    { $see-also \ 0|| } ;
+
+HELP: n&&[
+    { $syntax "N n&&[ A | B | C ]" }
+    { $description "Applies quotations (seperated by " { $link \ | } "), to the first N elements on the stack, restoring the original values to the top of the stack each time. Returns the result of the last quotation, or " { $link POSTPONE: f } " if any previous quotation returns " { $link POSTPONE: f } "." }
+    { $see-also POSTPONE: &&[ \ n&& } ;
+
+HELP: n||[
+    { $syntax "N n||[ A | B | C ]" }
+    { $description "Applies quotations (seperated by " { $link \ | } "), to the first N elements on the stack, restoring the original values to the top of the stack each time. Returns the result of the first qquotation to return a true value, or " { $link POSTPONE: f } " if none of them do" }
+    { $see-also POSTPONE: ||[ \ n|| } ;
 
 HELP: |
 { $description "Delimiter in combinator syntax expressions." } ;

--- a/extra/combinators/syntax/syntax.factor
+++ b/extra/combinators/syntax/syntax.factor
@@ -81,6 +81,6 @@ ALIAS: napply[ n@[
 SYNTAX: n&&[ \ n&& parse-ncleave-like ;
 SYNTAX: n||[ \ n|| parse-ncleave-like ;
 
-SYNTAX: &&[ parse-quotation '[ dup [ drop @ ] when ] append! ;
+SYNTAX: &&[ \ 0&& parse-cleave-like ;
 
-SYNTAX: ||[ parse-quotation '[ dup [ drop @ ] unless ] append! ;
+SYNTAX: ||[ \ 0|| parse-cleave-like ;

--- a/extra/combinators/syntax/syntax.factor
+++ b/extra/combinators/syntax/syntax.factor
@@ -50,23 +50,23 @@ DEFER: | delimiter
 
 PRIVATE>
 
-SYNTAX: cleave[ \ cleave parse-cleave-like ;
 SYNTAX: &[ \ cleave parse-cleave-like ;
+ALIAS: cleave[ &[
 
-SYNTAX: spread[ \ spread parse-cleave-like ;
 SYNTAX: *[ \ spread parse-cleave-like ;
+ALIAS: spread[ &[
 
-SYNTAX: apply[ parse-apply ;
 SYNTAX: @[ parse-apply ;
+ALIAS: apply[ @[
 
-SYNTAX: ncleave[ \ ncleave parse-ncleave-like ;
 SYNTAX: n&[ \ ncleave parse-ncleave-like ;
+ALIAS: ncleave[ n&[
 
-SYNTAX: nspread[ \ nspread parse-ncleave-like ;
 SYNTAX: n*[ \ nspread parse-ncleave-like ;
+ALIAS: nspread[ n*[
 
-SYNTAX: napply[ parse-mnapply ;
 SYNTAX: n@[ parse-mnapply ;
+ALIAS: napply[ n@[
 
 SYNTAX: n&&[ \ n&& parse-ncleave-like ;
 SYNTAX: n||[ \ n|| parse-ncleave-like ;

--- a/extra/combinators/syntax/syntax.factor
+++ b/extra/combinators/syntax/syntax.factor
@@ -27,15 +27,25 @@ DEFER: | delimiter
 : parse-cleave-quotations ( -- quotations )
     100 <vector> [ (parse-cleave-like) ] loop ;
 
+! parses syntax of the form "quot1 | quot2 | etc. ]"
+! into something of the form "{ [ quot1 ] [ quot2 ] [ etc. ] } some-word"
 : parse-cleave-like ( acc word -- acc )
     parse-cleave-quotations swap [ suffix! ] bi@ ;
 
 ! couldn't think of a better name. napply, nspread, ncleave etc.
 ! are all macros that take in numbers as the top parameter on the
 ! stack, meaning that you have to do a bit of shuffling around ! before they work
+
+! takes the last item on the accumulator, the given word, and the result quot
+! of evaluating the parser quot and appends a quotation of the form
+! [ last-item given-word result-quot.. ] to the accumulator
 : parse-number-macro-input ( acc word parser-quot -- acc )
     [ unclip-last ] [ 1quotation ] [ call( -- quot ) ] tri* -rot 2curry append! ;
 
+
+! takes the last two items on the accumulator, the given word,
+! and the result quot of evaluating the parser quot and appends a quotation of the form
+! [ second-to-last-item last-item given-word result-quot.. ] to the accumulator
 : 2parse-number-macro-input ( acc word parser-quot -- acc )
     [ 2 cut* ] 2dip [ suffix! >quotation ] dip call( -- quot ) swap curry append! ;
 
@@ -54,7 +64,7 @@ SYNTAX: &[ \ cleave parse-cleave-like ;
 ALIAS: cleave[ &[
 
 SYNTAX: *[ \ spread parse-cleave-like ;
-ALIAS: spread[ &[
+ALIAS: spread[ *[
 
 SYNTAX: @[ parse-apply ;
 ALIAS: apply[ @[


### PR DESCRIPTION
I saw someone in the discord talking about how they can't figure out how the `||[` and `&&[` words worked, as they were undocumented. I also didn't know what they did, so I looked into the code and I found that they didn't really work like I expected them to

I expected them to be either syntactic sugar for `0||` and `0&&` or for `1 n||` and `1 n&&`. Instead, they were seemingly far less useful, just being syntactic sugar for `dup [ drop ... ] when` and `dup [ drop ... ] unless`. I'm pretty sure the first one could be simply represented `[ ... ] [ f ] if`, and the second one as `[ ... ] unless*`, both being so simple that they didn't need syntactic sugar.

Furthermore, the `0||` and `0&&` combinators could perhaps use some syntactic sugar, and would benefit from the `... | ... ]` style of the other combinator syntax words. On top of that, this would be more consistent, as the relationship between `&[` and `n&[` changes the amount of inputs, not the amount of quotations, so why should the relationship between `&&[` and `n&&[` be any different?

So that's what I did, alongside making some duplicate syntax words into aliases (perhaps we don't even need them), adding some comments to clarify slightly confusing code, and documenting the words with missing documentation