### PR TITLE
fix: fixed ui build on freebsd

### DIFF
--- a/basis/gdk3/ffi/platforms.txt
+++ b/basis/gdk3/ffi/platforms.txt
@@ -1,1 +1,1 @@
-linux
+unix

--- a/basis/gdk3/platforms.txt
+++ b/basis/gdk3/platforms.txt
@@ -1,1 +1,1 @@
-linux
+unix

--- a/basis/gtk3/ffi/platforms.txt
+++ b/basis/gtk3/ffi/platforms.txt
@@ -1,1 +1,1 @@
-linux
+unix

--- a/basis/gtk3/platforms.txt
+++ b/basis/gtk3/platforms.txt
@@ -1,1 +1,1 @@
-linux
+unix

--- a/basis/opengl/gl/gtk3/platforms.txt
+++ b/basis/opengl/gl/gtk3/platforms.txt
@@ -1,1 +1,1 @@
-linux
+unix

--- a/vm/Config.freebsd
+++ b/vm/Config.freebsd
@@ -1,7 +1,7 @@
 include vm/Config.unix
 PLAF_DLL_OBJS += $(BUILD_DIR)/os-genunix.o $(BUILD_DIR)/os-freebsd.o $(BUILD_DIR)/mvm-unix.o
 PLAF_MASTER_HEADERS += vm/os-genunix.hpp vm/os-freebsd.hpp
-LIBS := -L/usr/local/lib -lm $(X11_UI_LIBS) -pthread -lc -Wl,--export-dynamic -lthr -lpango-1.0 -lpangocairo-1.0 -lcairo -lglib-2.0 -lgobject-2.0 -lgtk-3.0 -lgdk-3.0 -lgdk_pixbuf-2.0 -latk-1.0 -lgio-2.0
+LIBS := -lm -pthread -lc -Wl,--export-dynamic -lthr
 
 FFI_TEST_CFLAGS := -fPIC
 CFLAGS += -fPIC


### PR DESCRIPTION
Removed gtk libs from the vm/Config.freebsd, which resulted in its removal as a hard dependency in every built executable. Fixed ui builds on freebsd by tweaking necessary platforms.txt files.