### PR TITLE
db.tester: skip PostgreSQL tests when no database is configured

### DIFF
--- a/basis/db/tester/tester.factor
+++ b/basis/db/tester/tester.factor
@@ -1,4 +1,5 @@
 ! Copyright (C) 2008 Slava Pestov, Doug Coleman.
+! Copyright (C) 2026 Zoltán Kéri <z@zolk3ri.name>
 ! See https://factorcode.org/license.txt for BSD license.
 USING: accessors assocs concurrency.combinators db db.pools
 db.postgresql db.queries db.sqlite db.tuples db.types
@@ -35,8 +36,10 @@ IN: db.tester
 
 : test-postgresql ( quot -- )
     '[
-        ! disable on windows-x86-32
-        os windows? cpu x86.32? and [
+        ! Skip on windows-x86-32 and when no postgresql-db has been
+        ! configured (\ postgresql-db set-global).
+        os windows? cpu x86.32? and
+        \ postgresql-db get-global not or [
             postgresql-template1-db [
                 postgresql-test-db-name ensure-database
             ] with-db


### PR DESCRIPTION
This PR adds a condition to skip PostgreSQL tests when no database is configured.

### Problem Description

Without a configured `postgresql-db`, `test-postgresql` calls
`postgresql-template1-db`, which clones the global (now `f`) and runs
`>>database` on it, throwing `Generic word database<< does not define a method
for the POSTPONE: f class`.

### Implementation Details

Extend the existing 32-bit-Windows skip guard in `test-postgresql` to also skip
when `postgresql-db` is unset. One guard covers `db.tuples`, `db.postgresql`,
and `db.postgresql.errors` since each wraps its PostgreSQL cases in
`test-postgresql`.

### Testing

Without `postgresql-db` set, the PostgreSQL cases are skipped, so `"db" test`,
`"db.tuples" test`, `"db.postgresql" test`, and `"db.postgresql.errors" test`
all pass. With it set (`\ postgresql-db set-global`), the new guard clause is
false and they run unchanged.