### PR TITLE
bencode: Sort dictionary keys when encoding

### DIFF
--- a/extra/bencode/bencode-tests.factor
+++ b/extra/bencode/bencode-tests.factor
@@ -11,6 +11,10 @@ USING: bencode linked-assocs tools.test ;
 
 { { "spam" 42 } } [ "l4:spami42ee" bencode> ] unit-test
 
+{ "d3:bar4:spam3:fooi42ee" } [
+    LH{ { "foo" 42 } { "bar" "spam" } } >bencode
+] unit-test
+
 { LH{ { "bar" "spam" } { "foo" 42 } } } [
     "d3:bar4:spam3:fooi42ee" bencode>
 ] unit-test

--- a/extra/bencode/bencode.factor
+++ b/extra/bencode/bencode.factor
@@ -1,6 +1,7 @@
 USING: arrays assocs byte-arrays combinators io
 io.encodings.binary io.streams.byte-array io.streams.string
-kernel linked-assocs math math.parser sequences sequences.extras strings ;
+kernel linked-assocs math math.parser sequences sequences.extras sorting
+strings ;
 IN: bencode
 
 GENERIC: >bencode ( obj -- bencode )
@@ -17,7 +18,7 @@ M: sequence >bencode
     [ >bencode ] map concat "l" "e" surround ;
 
 M: assoc >bencode
-    [ [ >bencode ] bi@ append ] { } assoc>map concat
+    sort-keys [ [ >bencode ] bi@ append ] { } assoc>map concat
     "d" "e" surround ;
 
 DEFER: read-bencode


### PR DESCRIPTION
Bencode dictionaries must encode keys in sorted raw-string order, but the association encoder currently follows the association's iteration order. This produces invalid output for order-preserving associations such as linked assocs when their insertion order differs from lexical order.

Sort keys before encoding entries and add a regression test whose insertion order differs from the required wire order.

Specification: [BEP 3 — Bencoding](https://www.bittorrent.org/beps/bep_0003.html#bencoding)
