### PR TITLE
ascii: Handle empty strings in capitalize

### DIFF
--- a/basis/ascii/ascii-tests.factor
+++ b/basis/ascii/ascii-tests.factor
@@ -17,5 +17,7 @@ USING: ascii kernel math sequences strings tools.test ;
 { "HELLO HOW ARE YOU?" } [ "hellO hOw arE YOU?" >upper ] unit-test
 { "i'm good thx bai" } [ "I'm Good THX bai" >lower ] unit-test
 
+{ "" } [ "" capitalize ] unit-test
+
 { "Hello How Are You?" } [ "hEllo how ARE yOU?" >title ] unit-test
 { { " " "Hello" " " " " " " "World" } } [ " Hello   World" >words [ >string ] map ] unit-test

--- a/basis/ascii/ascii.factor
+++ b/basis/ascii/ascii.factor
@@ -24,7 +24,8 @@ IN: ascii
         [ [ 1 ] when-zero cut-slice swap ]
         [ f 0 rot [ length ] keep <slice> ] if*
     ] produce nip ;
-: capitalize ( str -- str' ) >lower 0 over [ ch>upper ] change-nth ;
+: capitalize ( str -- str' )
+    >lower dup empty? [ 0 over [ ch>upper ] change-nth ] unless ;
 : >title ( str -- title ) >words [ capitalize ] map concat ;
 
 HINTS: >lower string ;


### PR DESCRIPTION
`capitalize` lowercases its input and then unconditionally changes the character at index zero, causing an out-of-bounds error for an empty string.

Skip the indexed update when the lowercased string is empty, and add a regression test covering that input.
