### PR TITLE
splitting: Preserve empty slices in split1-last-slice

### DIFF
--- a/core/splitting/splitting-tests.factor
+++ b/core/splitting/splitting-tests.factor
@@ -16,7 +16,14 @@ arrays ;
 { "hello world" "." } [ "hello world ." " " split1-last-slice [ >string ] bi@ ] unit-test
 { "hello-+world" "." } [ "hello-+world-+." "-+" split1-last-slice [ >string ] bi@ ] unit-test
 { "goodbye" f } [ "goodbye" " " split1-last-slice [ >string ] dip ] unit-test
-{ "" f } [ "great" "great" split1-last-slice [ >string ] dip ] unit-test
+{ "" "X" } [
+    "greatX" "great" split1-last-slice
+    [ dup [ >string ] when ] bi@
+] unit-test
+{ "" "" } [
+    "great" "great" split1-last-slice
+    [ dup [ >string ] when ] bi@
+] unit-test
 
 { "and end" t } [ "Beginning and end" "Beginning " ?head ] unit-test
 { "Beginning and end" f } [ "Beginning and end" "Beginning x" ?head ] unit-test

--- a/core/splitting/splitting.factor
+++ b/core/splitting/splitting.factor
@@ -61,8 +61,9 @@ PRIVATE>
     dup [ swap ] when ;
 
 : split1-last-slice ( seq subseq -- before-slice after-slice )
-    [ <reversed> ] bi@ split1-slice [ <reversed> ] bi@
-    [ f ] [ swap ] if-empty ;
+    [ <reversed> ] bi@ split1-slice
+    [ <reversed> ] dip
+    dup [ <reversed> swap ] when ;
 
 <PRIVATE
 


### PR DESCRIPTION
`split1-last-slice` used `if-empty` to detect failed matches, conflating a valid empty prefix slice with `f` when the selected match starts at index 0. Check for `f` directly so boundary matches return empty slices while missing matches still return `seq f`.

Adds regression coverage for matches at the start with and without a trailing suffix.
