### PR TITLE
sequences: Reject minimum on empty iota

### DIFF
--- a/core/sequences/sequences-tests.factor
+++ b/core/sequences/sequences-tests.factor
@@ -408,6 +408,7 @@ M: bogus-hashcode hashcode* 2drop 0 >bignum ;
 
 { 4 } [ 5 <iota> maximum ] unit-test
 { 0 } [ 5 <iota> minimum ] unit-test
+[ 0 <iota> minimum ] must-fail
 
 { 4 } [ 5 <iota> [ ] maximum-by ] unit-test
 { 0 } [ 5 <iota> [ ] minimum-by ] unit-test

--- a/core/sequences/sequences.factor
+++ b/core/sequences/sequences.factor
@@ -1139,7 +1139,8 @@ M: repetition sum [ elt>> ] [ length>> ] bi * ; inline
 
 GENERIC: minimum ( seq -- elt )
 M: sequence minimum [ ] [ min ] map-reduce ; inline
-M: iota minimum drop 0 ; inline
+M: iota minimum
+    dup empty? [ call-next-method ] [ drop 0 ] if ; inline
 M: reversed minimum seq>> minimum ; inline
 M: repetition minimum elt>> ; inline
 


### PR DESCRIPTION
`minimum` promises to throw for an empty sequence, but the constant-time `iota` specialization returned `0` even for `0 <iota>`.

Delegate the empty case to the general sequence method so it retains the documented error behavior, while preserving the constant-time result for nonempty iotas. Includes a regression test for the empty case.
