### PR TITLE
uuid: Set RFC variant bits

### DIFF
--- a/basis/uuid/uuid-tests.factor
+++ b/basis/uuid/uuid-tests.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2008 John Benediktsson
 ! See https://factorcode.org/license.txt for BSD license
 
-USING: kernel uuid tools.test ;
+USING: kernel math math.bitwise sequences tools.test uuid ;
 
 { t } [ NAMESPACE_DNS  [ uuid-parse uuid-unparse ] keep = ] unit-test
 { t } [ NAMESPACE_URL  [ uuid-parse uuid-unparse ] keep = ] unit-test
@@ -13,3 +13,7 @@ USING: kernel uuid tools.test ;
 
 { t } [ NAMESPACE_URL "ABCD" uuid5
         "0aa883d6-7953-57e7-a8f0-66db29ce5a91" = ] unit-test
+
+{ 0x80 } [ uuid1 uuid-parse 8 swap nth 0xc0 bitand ] unit-test
+{ 0x80 } [ uuid7 uuid-parse 8 swap nth 0xc0 bitand ] unit-test
+{ 0x80 } [ 0 0 0 uuid8 uuid-parse 8 swap nth 0xc0 bitand ] unit-test

--- a/basis/uuid/uuid.factor
+++ b/basis/uuid/uuid.factor
@@ -29,6 +29,10 @@ IN: uuid
         0xf000 64 shift bitnot bitand
     ] dip 76 shift bitor ;
 
+! RFC 9562 section 4.1 defines the RFC UUID variant as 0b10.
+! https://www.rfc-editor.org/rfc/rfc9562.html#section-4.1
+CONSTANT: rfc-variant 0b10
+
 : (uuid) ( a version b variant c -- n )
     {
         [ 48 bits 80 shift ]
@@ -59,7 +63,7 @@ PRIVATE>
 : uuid1 ( -- string )
     (timestamp)
     [ 32 bits 16 shift ] [ -32 shift 16 bits + 1 ] [ -48 shift ] tri
-    0b01 (clock) 48 shift (hardware) +
+    rfc-variant (clock) 48 shift (hardware) +
     (uuid) uuid>string ;
 
 : uuid3 ( namespace name -- string )
@@ -78,16 +82,16 @@ PRIVATE>
 
 : uuid6 ( -- string )
     (timestamp) [ -12 shift 6 ] [ 12 bits ] bi
-    0b10 (clock) 48 shift $[ 48 random-bits ] +
+    rfc-variant (clock) 48 shift $[ 48 random-bits ] +
     (uuid) uuid>string  ;
 
 : uuid7 ( -- string )
     now timestamp>millis 7
-    12 random-bits 0b11
+    12 random-bits rfc-variant
     62 random-bits (uuid) uuid>string ;
 
 : uuid8 ( a b c -- string )
-    [ 8 ] 2dip [ 0b01 ] dip (uuid) uuid>string ;
+    [ 8 ] 2dip [ rfc-variant ] dip (uuid) uuid>string ;
 
 : uuid-urn ( string -- url )
     "url:urn:" prepend ;


### PR DESCRIPTION
UUIDv1, UUIDv7, and UUIDv8 currently emit variant bits other than the RFC UUID variant, producing fourth groups outside the required `8`, `9`, `a`, or `b` range.

Use a shared private `0b10` variant constant and add regression tests that inspect the two most significant bits of octet 8. RFC 9562 §4.1 requires these bits to be set to 1 and 0: https://www.rfc-editor.org/rfc/rfc9562.html#section-4.1

The commits are ordered test-first, followed by the implementation fix.
