### PR TITLE
bit-arrays: Ignore padding bits when converting to integer

### DIFF
--- a/basis/bit-arrays/bit-arrays-tests.factor
+++ b/basis/bit-arrays/bit-arrays-tests.factor
@@ -71,6 +71,8 @@ sequences.private tools.test ;
 
 { 14 } [ ?{ f t t t } bit-array>integer ] unit-test
 { 0 } [ ?{ } bit-array>integer ] unit-test
+{ 1 } [ 1 <bit-array> dup set-bits bit-array>integer ] unit-test
+{ 3 } [ 2 B{ 0b111 } bit-array boa bit-array>integer ] unit-test
 { 0xffffffffffffffffffffffffffffffff } [ ?{
     t t t t t t t t   t t t t t t t t   t t t t t t t t  t t t t t t t t
     t t t t t t t t   t t t t t t t t   t t t t t t t t  t t t t t t t t

--- a/basis/bit-arrays/bit-arrays.factor
+++ b/basis/bit-arrays/bit-arrays.factor
@@ -101,7 +101,7 @@ SYNTAX: ?{ \ } [ >bit-array ] parse-literal ;
     [ dup log2 1 + [ nip ] [ bits>bytes >le ] 2bi bit-array boa ] if ;
 
 : bit-array>integer ( bit-array -- n )
-    underlying>> le> ;
+    [ underlying>> le> ] keep length bits ;
 
 INSTANCE: bit-array sequence
 


### PR DESCRIPTION
`bit-array>integer` currently decodes the entire backing byte array, allowing nonzero storage padding to change the logical value. This is observable after `set-bits` and for bit arrays populated through their raw storage.

Mask the decoded integer to the bit array's logical length, with regressions covering both cases.
