### PR TITLE
http.server.cgi: Set CGI content type from metadata

### DIFF
--- a/basis/http/server/cgi/cgi-tests.factor
+++ b/basis/http/server/cgi/cgi-tests.factor
@@ -1,0 +1,20 @@
+! Copyright (C) 2026 Rudi Grinberg.
+! See https://factorcode.org/license.txt for BSD license.
+
+USING: accessors assocs http http.server.cgi kernel namespaces
+tools.test urls ;
+IN: http.server.cgi.tests
+
+{ "text/plain" "4" } [
+    [
+        <request>
+            "POST" >>method
+            URL" http://localhost:8080/script.cgi" >>url
+            "text/plain" <post-data>
+                B{ 98 111 100 121 } >>data
+            >>data
+        dup url>> url set request set
+        "/script.cgi" cgi-variables
+        [ "CONTENT_TYPE" of ] [ "CONTENT_LENGTH" of ] bi
+    ] with-scope
+] unit-test

--- a/basis/http/server/cgi/cgi.factor
+++ b/basis/http/server/cgi/cgi.factor
@@ -34,9 +34,9 @@ IN: http.server.cgi
         request get "accept" header "HTTP_ACCEPT" ,,
 
         post-request? [
-            request get data>> data>>
-            [ "CONTENT_TYPE" ,, ]
-            [ length number>string "CONTENT_LENGTH" ,, ]
+            request get data>>
+            [ content-type>> "CONTENT_TYPE" ,, ]
+            [ data>> length number>string "CONTENT_LENGTH" ,, ]
             bi
         ] when
     ] H{ } make ;


### PR DESCRIPTION
CGI POST environments currently put the request body bytes in `CONTENT_TYPE`, because `cgi-variables` unwraps the `post-data` tuple before extracting both CGI values.

Keep the tuple long enough to read `content-type>>` for `CONTENT_TYPE` and use `data>>` only when calculating `CONTENT_LENGTH`. A regression test covers both values for a four-byte `text/plain` request.

The commits are ordered test-first, followed by the implementation fix.
