### PR TITLE
http.server.requests: Require decimal Content-Length

### DIFF
--- a/basis/http/server/requests/requests-tests.factor
+++ b/basis/http/server/requests/requests-tests.factor
@@ -11,6 +11,10 @@ IN: http.server.requests.tests
 : string>request ( str -- request )
     [ request-limit get limited-input read-request ] with-string-reader ;
 
+: content-length>request ( content-length -- request )
+    { { "foo" "bar" } } "localhost" <post-request> request>string
+    "7" rot replace string>request ;
+
 ! POST requests
 { "foo=bar" "7" } [
     "foo=bar" "localhost" <post-request> request>string string>request
@@ -107,13 +111,26 @@ hello
     [ content-length>> "i am not a number!" = ] bi and
 ] must-fail-with
 
-! Negative is it too.
-[
-    { { "foo" "bar" } } "localhost" <post-request> request>string
-    "7" "-1234" replace string>request
-] [
+! Content-Length permits decimal digits only.
+[ "0x7" content-length>request ] [
     [ invalid-content-length? ]
-    [ content-length>> -1234 = ] bi and
+    [ content-length>> "0x7" = ] bi and
+] must-fail-with
+
+[ "+7" content-length>request ] [
+    [ invalid-content-length? ]
+    [ content-length>> "+7" = ] bi and
+] must-fail-with
+
+[ "7.0" content-length>request ] [
+    [ invalid-content-length? ]
+    [ content-length>> "7.0" = ] bi and
+] must-fail-with
+
+! Negative is it too.
+[ "-1234" content-length>request ] [
+    [ invalid-content-length? ]
+    [ content-length>> "-1234" = ] bi and
 ] must-fail-with
 
 ! And too big

--- a/basis/http/server/requests/requests.factor
+++ b/basis/http/server/requests/requests.factor
@@ -1,4 +1,4 @@
-USING: accessors combinators continuations http http.parsers io
+USING: accessors ascii combinators continuations http http.parsers io
 io.crlf io.encodings io.encodings.binary io.streams.limited
 kernel math.order math.parser namespaces sequences splitting
 urls urls.encoding ;
@@ -48,7 +48,7 @@ upload-limit [ 200,000,000 ] initialize
 
 : parse-content-length-safe ( request -- content-length )
     "content-length" header [
-        [ string>number ]
+        [ dup [ digit? ] all? [ string>number ] [ drop f ] if ]
         [
             dup 0 upload-limit get between? [
                 invalid-content-length


### PR DESCRIPTION
The HTTP server currently passes `Content-Length` directly to Factor's general numeric parser, so values such as `0x7`, `+7`, and `7.0` can be accepted even though the HTTP field grammar permits decimal digits only.

Require every character to be an ASCII digit before parsing the value. Existing nonnegative and upload-limit validation remains unchanged. Regression tests cover the accepted non-decimal forms.