### PR TITLE
math.statistics: Apply ddof to covariance in corr-ddof

### DIFF
--- a/basis/math/statistics/statistics-tests.factor
+++ b/basis/math/statistics/statistics-tests.factor
@@ -137,9 +137,9 @@ IN: math.statistics
 { 0 } [ { 1 } { 1 } sample-cov ] unit-test
 { 2/3 } [ { 1 2 3 } { 4 5 6 } population-cov ] unit-test
 
-{ 0.75 } [ { 1 2 3 4 } dup sample-corr ] unit-test
+{ 1.0 } [ { 1 2 3 4 } dup sample-corr ] unit-test
 { 1.0 } [ { 1 2 3 4 } dup population-corr ] unit-test
-{ -0.75 } [ { 1 2 3 4 } { -4 -5 -6 -7 } sample-corr ] unit-test
+{ -1.0 } [ { 1 2 3 4 } { -4 -5 -6 -7 } sample-corr ] unit-test
 
 { { 1 2 4 7 } } [ { 1 1 2 3 } cum-sum ] unit-test
 { { 1 1 2 6 } } [ { 1 1 2 3 } cum-product ] unit-test

--- a/basis/math/statistics/statistics.factor
+++ b/basis/math/statistics/statistics.factor
@@ -345,7 +345,7 @@ PRIVATE>
 : sample-cov ( x-seq y-seq -- cov ) 1 cov-ddof ; inline
 
 : corr-ddof ( x-seq y-seq n -- corr )
-    [ [ population-cov ] ] dip
+    [ '[ _ cov-ddof ] ] keep
     '[ [ _ var-ddof ] bi@ * sqrt ] 2bi / ;
 
 : population-corr ( x-seq y-seq -- corr ) 0 corr-ddof ; inline


### PR DESCRIPTION
`corr-ddof` always used population covariance while applying the requested degrees-of-freedom adjustment to both variances. This caused `sample-corr` to scale correlation coefficients by `(n - 1) / n`.

Apply the same `ddof` to covariance so the scaling remains consistent, and correct the existing perfect-correlation expectations to `1.0` and `-1.0`.
