### PR TITLE
tnetstrings: Reject invalid numbers

### DIFF
--- a/extra/tnetstrings/tnetstrings-tests.factor
+++ b/extra/tnetstrings/tnetstrings-tests.factor
@@ -24,3 +24,5 @@ USING: kernel tnetstrings sequences tools.test ;
         first2 [ tnetstring> = ] [ swap >tnetstring = ] 2bi and
     ] all?
 ] unit-test
+
+[ "1:x#" tnetstring> ] must-fail

--- a/extra/tnetstrings/tnetstrings.factor
+++ b/extra/tnetstrings/tnetstrings.factor
@@ -41,9 +41,12 @@ DEFER: parse-tnetstring
 : parse-null ( data -- f )
     [ f ] [ drop "Payload must be 0 length" throw ] if-empty ;
 
+: parse-number ( data -- number )
+    string>number [ "Invalid number" throw ] unless* ;
+
 : parse-tnetstring ( data -- remain value )
     parse-payload {
-        { CHAR: # [ string>number ] }
+        { CHAR: # [ parse-number ] }
         { CHAR: \" [ ] }
         { CHAR: } [ parse-dict ] }
         { CHAR: ] [ parse-list ] }


### PR DESCRIPTION
Malformed numeric typed-netstring payloads currently pass through `string>number` and decode as `f`, making invalid input indistinguishable from false or null.

Add a regression test and reject failed numeric conversions while preserving the existing accepted numeric syntax.
