### PR TITLE
command-line.parser: Handle zero-argument options

### DIFF
--- a/basis/command-line/parser/parser-tests.factor
+++ b/basis/command-line/parser/parser-tests.factor
@@ -41,6 +41,11 @@ TUPLE: foo ;
     } [ (parse-options) ] with map
 ] unit-test
 
+{ H{ { "flag" t } } } [
+    { T{ option { name "--flag" } { #args 0 } { const t } } }
+    { "--flag" } (parse-options)
+] unit-test
+
 { H{ { "username" "test" } } } [
     { T{ option { name "--username" } } }
     { "--user" "test" } (parse-options)

--- a/basis/command-line/parser/parser.factor
+++ b/basis/command-line/parser/parser.factor
@@ -150,6 +150,7 @@ M: class argvalid? instance? ;
 
 :: option-value ( args option -- args' value )
     args option option-#args {
+        { 0 [ option const>> ] }
         { "+" [
             [ option expected-arguments ]
             [ f swap [ option option-convert ] map ]


### PR DESCRIPTION
Explicitly setting an option's `#args` slot to zero currently enters the fixed-argument branch because numeric zero is truthy in Factor. Parsing the option then fails with `expected-arguments` instead of returning its constant value.

Handle zero explicitly in `option-value`: consume no command-line arguments and return the option's `const` value. A regression test covers a zero-argument boolean flag.