### PR TITLE
json: Reject unknown escapes

### DIFF
--- a/basis/json/json-tests.factor
+++ b/basis/json/json-tests.factor
@@ -39,6 +39,7 @@ IN: json.tests
 ! unicode is allowed in json
 { "ß∂¬ƒ˚∆" } [ "  \"ß∂¬ƒ˚∆\""  json> ] unit-test
 ${ { 8 9 10 12 13 34 47 92 } >string } [ " \"\\b\\t\\n\\f\\r\\\"\\/\\\\\" " json> ] unit-test
+[ "\"\\q\"" json> ] [ json-error? ] must-fail-with
 ${ { 0xabcd } >string } [ " \"\\uaBCd\" " json> ] unit-test
 { "𝄞" } [ "\"\\ud834\\udd1e\"" json> ] unit-test
 

--- a/basis/json/json.factor
+++ b/basis/json/json.factor
@@ -80,7 +80,7 @@ DEFER: (read-json-string)
         { CHAR: r [ CHAR: \r ] }
         { CHAR: t [ CHAR: \t ] }
         { CHAR: u [ over read-json-escape-unicode ] }
-        [ ]
+        [ drop f ]
     } case [ suffix! (read-json-string) ] [ json-error ] if* ;
 
 : (read-json-string) ( stream accum -- accum )


### PR DESCRIPTION
The JSON reader currently accepts unknown backslash escapes such as `\q` and silently removes the backslash. JSON defines a closed set of valid string escapes, so unknown escapes must be rejected.

Return `f` from the escape dispatch's default branch so the existing `if*` failure path throws `json-error`. A regression test covers an unknown escape.
