### PR TITLE
calendar: Fix start of quarter

### DIFF
--- a/basis/calendar/calendar-tests.factor
+++ b/basis/calendar/calendar-tests.factor
@@ -211,6 +211,11 @@ IN: calendar
     12 [1..b] [ 2020 swap 1 <date> quarter ] map
 ] unit-test
 
+{ t } [
+    2024 2 15 12 34 56 instant <timestamp> start-of-quarter
+    2024 1 1 <date-gmt> =
+] unit-test
+
 { 0 }
 [ now-gmt gmt-offset>> duration>seconds ] unit-test
 

--- a/basis/calendar/calendar.factor
+++ b/basis/calendar/calendar.factor
@@ -544,7 +544,7 @@ ALIAS: start-of-day midnight
     [ end-of-day ] [ days-in-month ] bi >>day ;
 
 : start-of-quarter ( timestamp -- timestamp' )
-    [ start-of-day ] [ quarter 1 - 3 * ] bi >>month ; inline
+    [ start-of-month ] [ quarter 1 - 3 * 1 + ] bi >>month ; inline
 
 : end-of-quarter ( timestamp -- timestamp' )
     dup quarter 1 - 3 * 3 + >>month end-of-month ; inline


### PR DESCRIPTION
`start-of-quarter` currently computes quarter start months as 0, 3, 6, and 9, and resets only the time of day. For example, February 15 becomes month zero on day 15 instead of January 1.

Use `start-of-month` to reset the day as well as the time, and add one to the zero-based quarter-month calculation to obtain months 1, 4, 7, and 10. A regression test covers both errors with a non-midnight timestamp.

The commits are ordered test-first, followed by the implementation fix.
