### PR TITLE
math.statistics: Sum absolute errors

### DIFF
--- a/basis/math/statistics/statistics-tests.factor
+++ b/basis/math/statistics/statistics-tests.factor
@@ -100,6 +100,7 @@ IN: math.statistics
 { 0.0 } [ { 1 } sample-ste ] unit-test
 
 { 2 } [ { 1 3 5 7 } mean-dev ] unit-test
+{ 2 } [ { 1 3 } sum-of-absolute-errors ] unit-test
 { 4/5 } [ { 1 3 3 3 5 } median-dev ] unit-test
 
 {

--- a/basis/math/statistics/statistics.factor
+++ b/basis/math/statistics/statistics.factor
@@ -61,7 +61,7 @@ M: ranges:range sum-of-quads
     [ mean ] keep [ - sq ] with map-sum ; inline
 
 : sum-of-absolute-errors ( seq -- x )
-    [ mean ] keep [ - ] with map-sum ; inline
+    [ mean ] keep [ - abs ] with map-sum ; inline
 
 : quadratic-mean ( seq -- x ) ! root-mean-square
     [ sum-of-squares ] [ length ] bi / sqrt ; inline


### PR DESCRIPTION
`sum-of-absolute-errors` currently sums signed deviations from the mean, causing positive and negative errors to cancel. For `{ 1 3 }`, it returns zero instead of two.

Take the absolute value of each deviation before `map-sum`. A regression test covers the cancellation case.
