### PR TITLE
math.matrices: Use squared magnitudes in matrix L2 norm

### DIFF
--- a/basis/math/matrices/matrices-docs.factor
+++ b/basis/math/matrices/matrices-docs.factor
@@ -984,7 +984,7 @@ $nl "This is the matrix norm when " { $snippet "p=1" } ", and is the overall max
 HELP: matrix-l2-norm
 { $values { "m" matrix } { "n" number } }
 { $description "Find the norm (size) of a matrix in 𝑙₂ (" { $snippet "L^2" } ") vector space, usually written ∥･∥₂."
-$nl "This is the matrix norm when " { $snippet "p=2" } ", and is the square root of the sums of the squares of all the elements of the matrix." }
+$nl "This is the matrix norm when " { $snippet "p=2" } ", and is the square root of the sum of the squared magnitudes of all the elements of the matrix." }
 { $notelist
     { "This norm is sometimes called the Hilbert-Schmidt norm." }
     { "User code should call the generic " { $link p-norm } " instead." }

--- a/basis/math/matrices/matrices-tests.factor
+++ b/basis/math/matrices/matrices-tests.factor
@@ -327,6 +327,9 @@ PRIVATE>
 { 2.0 }
 [ { { 1 1 } { 1 1 } } matrix-l2-norm ] unit-test
 
+{ 1.0 }
+[ { { C{ 0 1 } } } matrix-l2-norm ] unit-test
+
 { 10e-8 }
 [
   5.4772255

--- a/basis/math/matrices/matrices.factor
+++ b/basis/math/matrices/matrices.factor
@@ -269,7 +269,7 @@ DEFER: matrix-set-nths
 
 : matrix-l2-norm ( m -- n )
     dup zero-matrix? [ drop 0 ] [
-        [ [ sq ] map-sum ] map-sum sqrt
+        [ [ absq ] map-sum ] map-sum sqrt
     ] if ; inline foldable
 
 ! XXX: M: zero-matrix l1-norm drop 0 ; inline


### PR DESCRIPTION
`matrix-l2-norm` currently squares complex entries directly, which can make the resulting norm complex. Use squared magnitudes so the Frobenius norm remains a nonnegative real value, and clarify the documentation accordingly.
