### PR TITLE
bencode: Reject trailing data

### DIFF
--- a/extra/bencode/bencode-docs.factor
+++ b/extra/bencode/bencode-docs.factor
@@ -7,4 +7,4 @@ HELP: >bencode
 
 HELP: bencode>
 { $values { "bencode" string } { "obj" object } }
-{ $description "Decodes an object using the bencode algorithm." } ;
+{ $description "Decodes exactly one object using the bencode algorithm. Throws an error if the input contains trailing data." } ;

--- a/extra/bencode/bencode-tests.factor
+++ b/extra/bencode/bencode-tests.factor
@@ -1,4 +1,4 @@
-USING: bencode linked-assocs tools.test ;
+USING: bencode byte-arrays linked-assocs tools.test ;
 
 { "i42e" } [ 42 >bencode ] unit-test
 { "i0e" } [ 0 >bencode ] unit-test
@@ -18,3 +18,7 @@ USING: bencode linked-assocs tools.test ;
 { LH{ { "bar" "spam" } { "foo" 42 } } } [
     "d3:bar4:spam3:fooi42ee" bencode>
 ] unit-test
+
+[ "i42ei43e" bencode> ] must-fail
+[ "i42eJUNK" bencode> ] must-fail
+[ "i42eJUNK" >byte-array bencode> ] must-fail

--- a/extra/bencode/bencode.factor
+++ b/extra/bencode/bencode.factor
@@ -51,10 +51,17 @@ PRIVATE>
         [ read-string ]
     } case ;
 
+<PRIVATE
+
+: read-bencode-input ( -- obj )
+    read-bencode read1 f assert= ;
+
+PRIVATE>
+
 GENERIC: bencode> ( bencode -- obj )
 
 M: byte-array bencode>
-    binary [ read-bencode ] with-byte-reader ;
+    binary [ read-bencode-input ] with-byte-reader ;
 
 M: string bencode>
-    [ read-bencode ] with-string-reader ;
+    [ read-bencode-input ] with-string-reader ;


### PR DESCRIPTION
`bencode>` currently decodes the first bencoded object and silently drops any remaining input, accepting values such as `i42ei43e` and `i42eJUNK` as `42`.

Make the one-shot string and byte-array decoders verify EOF after `read-bencode`, while preserving `read-bencode` for stream-oriented parsing. Add regression coverage for concatenated objects and malformed suffixes, and document the stricter behavior.
