### PR TITLE
ini-file: Escape vertical tabs correctly

### DIFF
--- a/basis/ini-file/ini-file-tests.factor
+++ b/basis/ini-file/ini-file-tests.factor
@@ -5,6 +5,13 @@ USING: ini-file linked-assocs tools.test ;
 
 { LH{ } } [ "" string>ini ] unit-test
 
+{ "backspace=a\\bb\nvertical-tab=a\\vb\n" } [
+    LH{
+        { "backspace" "a\bb" }
+        { "vertical-tab" "a\vb" }
+    } ini>string
+] unit-test
+
 { LH{ { "section" LH{ } } } } [ "[section]" string>ini ] unit-test
 
 { "[\"test \\\"section with quotes\\\"\"]\n\n" } [

--- a/basis/ini-file/ini-file.factor
+++ b/basis/ini-file/ini-file.factor
@@ -59,7 +59,7 @@ IN: ini-file
                 { CHAR: \n   "\\n"  }
                 { CHAR: \r   "\\r"  }
                 { CHAR: \t   "\\t"  }
-                { CHAR: \b   "\\v"  }
+                { CHAR: \v   "\\v"  }
                 { CHAR: '    "\\'"  }
                 { CHAR: \"   "\\\"" }
                 { CHAR: \\   "\\\\" }


### PR DESCRIPTION
Correct the INI escape table's vertical-tab entry and add regression coverage for backspace and vertical-tab serialization.
