### PR TITLE
bson: Reject trailing data

### DIFF
--- a/extra/bson/bson-tests.factor
+++ b/extra/bson/bson-tests.factor
@@ -1,4 +1,4 @@
-USING: bson bson.constants calendar linked-assocs math
+USING: bson bson.constants calendar kernel linked-assocs math sequences
 tools.test ;
 
 { LH{ { "a" "a string" } } } [ LH{ { "a" "a string" } } >bson bson> ] unit-test
@@ -45,3 +45,10 @@ tools.test ;
           { "quot" [ 1 2 + ] }
      } >bson bson>
 ] unit-test
+
+{ { LH{ { "a" 1 } } LH{ { "a" 1 } } } } [
+    LH{ { "a" 1 } } >bson dup append bson-sequence>
+] unit-test
+
+[ LH{ { "a" 1 } } >bson dup append bson> ] must-fail
+[ LH{ { "a" 1 } } >bson 0 suffix bson> ] must-fail

--- a/extra/bson/bson.factor
+++ b/extra/bson/bson.factor
@@ -116,8 +116,15 @@ PRIVATE>
         state [ bson-object-data-read ] with-variable
     ] 1guard ;
 
+<PRIVATE
+
+: read-bson-input ( -- assoc )
+    LH{ } read-bson-assoc read1 f assert= ;
+
+PRIVATE>
+
 : bson> ( bytes -- assoc )
-    binary [ LH{ } read-bson-assoc ] with-byte-reader ;
+    binary [ read-bson-input ] with-byte-reader ;
 
 : read-bson-sequence ( exemplar -- seq )
     '[ _ read-bson-assoc ] loop>array ;


### PR DESCRIPTION
`bson>` silently ignored bytes after the first document. Require EOF after decoding one document while retaining `bson-sequence>` for concatenated documents.
