### PR TITLE
bson: Reject invalid boolean bytes

### DIFF
--- a/extra/bson/bson-tests.factor
+++ b/extra/bson/bson-tests.factor
@@ -1,7 +1,13 @@
-USING: bson bson.constants calendar kernel linked-assocs math sequences
-tools.test ;
+USING: bson bson.constants calendar hex-strings kernel
+linked-assocs math sequences tools.test ;
 
 { LH{ { "a" "a string" } } } [ LH{ { "a" "a string" } } >bson bson> ] unit-test
+
+{ LH{ { "false" f } { "true" t } } } [
+    LH{ { "false" f } { "true" t } } >bson bson>
+] unit-test
+
+[ "090000000878000200" hex-string>bytes bson> ] must-fail
 
 { LH{ { "a" "a string" } { "b" LH{ { "a" "アップルからの最新のニュースや情報を読む" } } } } }
 [ LH{ { "a" "a string" } { "b" LH{ { "a" "アップルからの最新のニュースや情報を読む" } } } } >bson bson> ] unit-test

--- a/extra/bson/bson.factor
+++ b/extra/bson/bson.factor
@@ -15,6 +15,8 @@ DEFER: read-bson-assoc
 
 ERROR: unknown-bson-type type msg ;
 
+ERROR: invalid-bson-boolean value ;
+
 <PRIVATE
 
 SYMBOL: state
@@ -35,6 +37,13 @@ DEFER: read-elements
 
 : read-byte ( -- byte )
     read-byte-raw first ; inline
+
+: read-boolean ( -- ? )
+    read-byte {
+        { 0 [ f ] }
+        { 1 [ t ] }
+        [ invalid-bson-boolean ]
+    } case ; inline
 
 : read-cstring ( -- string )
     input-stream get utf8 <decoder>
@@ -87,7 +96,7 @@ TYPED: element-data-read ( type: integer -- object )
         { T_Object      [ [ bson-object-data-read drop ] object-result check-object ] }
         { T_Array       [ [ bson-object-data-read drop ] object-result values ] }
         { T_Double      [ read-double ] }
-        { T_Boolean     [ read-byte 1 = ] }
+        { T_Boolean     [ read-boolean ] }
         { T_Date        [ read-longlong millis>timestamp ] }
         { T_Regexp      [ bson-regexp-read ] }
         { T_Timestamp   [ read-timestamp ] }


### PR DESCRIPTION
Reject BSON boolean bytes other than 0 and 1, with regression coverage.
