### PR TITLE
bencode: Reject truncated strings

### DIFF
--- a/extra/bencode/bencode-tests.factor
+++ b/extra/bencode/bencode-tests.factor
@@ -1,4 +1,5 @@
-USING: bencode byte-arrays linked-assocs tools.test ;
+USING: bencode byte-arrays io.streams.throwing linked-assocs
+tools.test ;
 
 { "i42e" } [ 42 >bencode ] unit-test
 { "i0e" } [ 0 >bencode ] unit-test
@@ -22,3 +23,8 @@ USING: bencode byte-arrays linked-assocs tools.test ;
 [ "i42ei43e" bencode> ] must-fail
 [ "i42eJUNK" bencode> ] must-fail
 [ "i42eJUNK" >byte-array bencode> ] must-fail
+
+{ "" } [ "0:" bencode> ] unit-test
+
+[ "3:ab" bencode> ] [ stream-exhausted? ] must-fail-with
+[ "3:ab" >byte-array bencode> ] [ stream-exhausted? ] must-fail-with

--- a/extra/bencode/bencode.factor
+++ b/extra/bencode/bencode.factor
@@ -1,6 +1,7 @@
 USING: arrays assocs byte-arrays combinators io
 io.encodings.binary io.streams.byte-array io.streams.string
-kernel linked-assocs math math.parser sequences sequences.extras sorting
+io.streams.throwing kernel linked-assocs math math.parser sequences
+sequences.extras sorting
 strings ;
 IN: bencode
 
@@ -38,7 +39,7 @@ DEFER: read-bencode
 
 : read-string ( prefix -- obj )
     ":" read-until CHAR: : assert= swap prefix
-    string>number read "" like ;
+    string>number [ read ] throw-on-eof "" like ;
 
 PRIVATE>
 


### PR DESCRIPTION
`bencode>` accepted strings shorter than their declared length. Make payload reads throw `stream-exhausted` on premature EOF for string and byte-array inputs.
