### PR TITLE
hex-strings: Reject invalid digits

### DIFF
--- a/basis/hex-strings/hex-strings-docs.factor
+++ b/basis/hex-strings/hex-strings-docs.factor
@@ -37,6 +37,7 @@ HELP: bytes>hex-string
 HELP: hex-string>bytes
 { $values { "hex-string" sequence } { "bytes" byte-array } }
 { $description "Converts a sequence of hex numbers in the range [00,ff] to a sequence of bytes (integers in the range [0,255])." }
+{ $errors "Throws an error if the input has odd length or contains a non-hexadecimal character." }
 { $examples
     { $example "USING: hex-strings prettyprint ;" "\"cafebabe\" hex-string>bytes ." "B{ 202 254 186 190 }" }
 } ;

--- a/basis/hex-strings/hex-strings-tests.factor
+++ b/basis/hex-strings/hex-strings-tests.factor
@@ -6,6 +6,8 @@ IN: hex-strings.tests
 { "deadbeef" } [ B{ 222 173 190 239 } bytes>hex-string ] unit-test
 { B{ 222 173 190 239 } } [ "deADbeEF" hex-string>bytes ] unit-test
 [ "0" hex-string>bytes ] [ invalid-hex-string-length? ] must-fail-with
+[ "gg" hex-string>bytes ] must-fail
+[ "!!" hex-string>bytes ] must-fail
 
 { f } [ "asdf" hex-string? ] unit-test
 { t } [ "adfAE12309812861cdef" hex-string? ] unit-test

--- a/basis/hex-strings/hex-strings.factor
+++ b/basis/hex-strings/hex-strings.factor
@@ -22,9 +22,12 @@ IN: hex-strings
 : sha512-string? ( str -- ? ) { [ length 128 = ] [ hex-string? ] } 1&& ;
 
 ERROR: invalid-hex-string-length n ;
+ERROR: invalid-hex-string string ;
 
 : hex-string>bytes ( hex-string -- bytes )
-    dup length dup even? [ invalid-hex-string-length ] unless 2/ <byte-array> [
+    dup length dup even? [ invalid-hex-string-length ] unless
+    over hex-string? [ drop invalid-hex-string ] unless
+    2/ <byte-array> [
         [
             [ digit> ] 2dip over even? [
                 [ 16 * ] [ 2/ ] [ set-nth-unsafe ] tri*


### PR DESCRIPTION
Reject non-hexadecimal characters before decoding and add regression coverage.
