### PR TITLE
shuffle: move $shuffle help out of shuffle.factor

### DIFF
--- a/extra/shuffle/shuffle-docs.factor
+++ b/extra/shuffle/shuffle-docs.factor
@@ -1,5 +1,7 @@
-USING: help.markup help.syntax math ;
+USING: help help.markup help.syntax kernel math ;
 IN: shuffle
+
+M: shuffle-word word-help* drop { $shuffle } ;
 
 HELP: nreverse
 { $values { "n" integer } }

--- a/extra/shuffle/shuffle.factor
+++ b/extra/shuffle/shuffle.factor
@@ -2,10 +2,10 @@
 ! See https://factorcode.org/license.txt for BSD license.
 
 USING: accessors assocs combinators combinators.short-circuit
-definitions effects effects.parser generalizations help
-help.markup kernel math parser ranges sequences
-sequences.generalizations stack-checker.backend
-stack-checker.known-words stack-checker.values words ;
+definitions effects effects.parser generalizations kernel math
+parser ranges sequences sequences.generalizations
+stack-checker.backend stack-checker.known-words
+stack-checker.values words ;
 
 IN: shuffle
 
@@ -26,7 +26,6 @@ SYNTAX: SHUFFLE:
     scan-new-word scan-effect {
         [ [ '[ _ shuffle-effect ] ] keep define-declared ]
         [ "shuffle" set-word-prop ]
-        [ drop { $shuffle } swap set-word-help ]
     } 2cleave ;
 
 PREDICATE: shuffle-word < word


### PR DESCRIPTION
By using word-help* in shuffle-docs.factor, we remove shuffle.factor's dependency on the help system.